### PR TITLE
Prepare CELT decoder scaffolding

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/pion/opus/internal/bitdepth"
+	"github.com/pion/opus/internal/celt"
 	silkresample "github.com/pion/opus/internal/resample/silk"
 	"github.com/pion/opus/internal/silk"
 )
@@ -16,12 +17,17 @@ const (
 	maxOpusFrameSize                = 1275
 	maxOpusPacketDurationNanosecond = 120000000
 	maxSilkFrameSampleCount         = 320
+	maxCeltFrameSampleCount         = 960
+	celtSampleRate                  = 48000
 )
 
 // Decoder decodes the Opus bitstream into PCM.
 type Decoder struct {
 	silkDecoder            silk.Decoder
 	silkBuffer             []float32
+	celtDecoder            celt.Decoder
+	celtBuffer             []float32
+	previousMode           configurationMode
 	resampleBuffer         []float32
 	resampleChannelIn      [2][]float32
 	resampleChannelOut     [2][]float32
@@ -45,6 +51,7 @@ func NewDecoderWithOutput(sampleRate, channels int) (Decoder, error) {
 	decoder := Decoder{
 		silkDecoder: silk.NewDecoder(),
 		silkBuffer:  make([]float32, maxSilkFrameSampleCount),
+		celtDecoder: celt.NewDecoder(),
 	}
 	if err := decoder.Init(sampleRate, channels); err != nil {
 		return Decoder{}, err
@@ -143,6 +150,26 @@ func (d *Decoder) resampleSilkChannel(
 	return nil
 }
 
+func (d *Decoder) resetModeState(mode configurationMode) {
+	if d.previousMode == mode {
+		return
+	}
+
+	switch mode {
+	case configurationModeSilkOnly:
+		d.silkDecoder = silk.NewDecoder()
+	case configurationModeCELTOnly:
+		d.celtDecoder.Reset()
+		clear(d.celtBuffer)
+	case configurationModeHybrid:
+		d.silkDecoder = silk.NewDecoder()
+		d.celtDecoder.Reset()
+		clear(d.celtBuffer)
+	}
+
+	d.previousMode = mode
+}
+
 func (c Configuration) silkFrameSampleCount() int {
 	if c.mode() != configurationModeSilkOnly {
 		return 0
@@ -160,6 +187,28 @@ func (c Configuration) silkFrameSampleCount() int {
 	}
 
 	return 0
+}
+
+func (c Configuration) celtFrameSampleCount() int {
+	if c.mode() != configurationModeCELTOnly {
+		return 0
+	}
+	if c.frameDuration() == frameDuration20ms {
+		return maxCeltFrameSampleCount
+	}
+
+	return int(int64(c.frameDuration().nanoseconds()) * int64(celtSampleRate) / 1000000000)
+}
+
+func (c Configuration) decodedSampleRate() int {
+	switch c.mode() {
+	case configurationModeSilkOnly:
+		return c.bandwidth().SampleRate()
+	case configurationModeCELTOnly:
+		return celtSampleRate
+	default:
+		return 0
+	}
 }
 
 func parseFrameLength(in []byte) (frameLength int, bytesRead int, err error) {
@@ -389,10 +438,30 @@ func (d *Decoder) decode(in []byte, out []float32) (bandwidth Bandwidth, isStere
 		return 0, false, 0, err
 	}
 
-	if cfg.mode() != configurationModeSilkOnly {
+	switch cfg.mode() {
+	case configurationModeSilkOnly:
+		d.resetModeState(configurationModeSilkOnly)
+
+		return d.decodeSilkFrames(cfg, tocHeader, encodedFrames, out)
+	case configurationModeCELTOnly:
+		d.resetModeState(configurationModeCELTOnly)
+
+		return 0, false, 0, fmt.Errorf("%w: %d", errUnsupportedConfigurationMode, cfg.mode())
+	case configurationModeHybrid:
+		d.resetModeState(configurationModeHybrid)
+
+		return 0, false, 0, fmt.Errorf("%w: %d", errUnsupportedConfigurationMode, cfg.mode())
+	default:
 		return 0, false, 0, fmt.Errorf("%w: %d", errUnsupportedConfigurationMode, cfg.mode())
 	}
+}
 
+func (d *Decoder) decodeSilkFrames(
+	cfg Configuration,
+	tocHeader tableOfContentsHeader,
+	encodedFrames [][]byte,
+	out []float32,
+) (bandwidth Bandwidth, isStereo bool, sampleCount int, err error) {
 	frameSampleCount := cfg.silkFrameSampleCount()
 	if tocHeader.isStereo() {
 		frameSampleCount *= 2

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -173,3 +173,45 @@ func TestSilkFrameSampleCount(t *testing.T) {
 	assert.Equal(t, 0, Configuration(12).silkFrameSampleCount())
 	assert.Equal(t, 0, Configuration(16).silkFrameSampleCount())
 }
+
+func TestCeltFrameSampleCount(t *testing.T) {
+	assert.Equal(t, 120, Configuration(16).celtFrameSampleCount())
+	assert.Equal(t, 240, Configuration(17).celtFrameSampleCount())
+	assert.Equal(t, 480, Configuration(18).celtFrameSampleCount())
+	assert.Equal(t, 960, Configuration(19).celtFrameSampleCount())
+	assert.Equal(t, 960, Configuration(31).celtFrameSampleCount())
+	assert.Equal(t, 0, Configuration(0).celtFrameSampleCount())
+	assert.Equal(t, 0, Configuration(12).celtFrameSampleCount())
+}
+
+func TestDecodedSampleRate(t *testing.T) {
+	assert.Equal(t, 8000, Configuration(0).decodedSampleRate())
+	assert.Equal(t, 16000, Configuration(8).decodedSampleRate())
+	assert.Equal(t, celtSampleRate, Configuration(16).decodedSampleRate())
+	assert.Equal(t, celtSampleRate, Configuration(31).decodedSampleRate())
+	assert.Equal(t, 0, Configuration(12).decodedSampleRate())
+}
+
+func TestDecodeCeltOnlyStillUnsupported(t *testing.T) {
+	decoder := NewDecoder()
+
+	bandwidth, isStereo, sampleCount, err := decoder.decode([]byte{byte(16<<3) | byte(frameCodeOneFrame)}, nil)
+
+	assert.ErrorIs(t, err, errUnsupportedConfigurationMode)
+	assert.Zero(t, bandwidth)
+	assert.False(t, isStereo)
+	assert.Zero(t, sampleCount)
+	assert.Equal(t, configurationModeCELTOnly, decoder.previousMode)
+}
+
+func TestDecodeHybridStillUnsupported(t *testing.T) {
+	decoder := NewDecoder()
+
+	bandwidth, isStereo, sampleCount, err := decoder.decode([]byte{byte(12<<3) | byte(frameCodeOneFrame)}, nil)
+
+	assert.ErrorIs(t, err, errUnsupportedConfigurationMode)
+	assert.Zero(t, bandwidth)
+	assert.False(t, isStereo)
+	assert.Zero(t, sampleCount)
+	assert.Equal(t, configurationModeHybrid, decoder.previousMode)
+}

--- a/internal/celt/celt.go
+++ b/internal/celt/celt.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package celt implements the MDCT layer of the Opus decoder.
+package celt
+
+const (
+	// RFC 6716 Section 4.3 defines the normal Opus CELT layer around a
+	// 48 kHz mode with 21 energy bands and 2.5 ms band-edge units.
+	sampleRate            = 48000
+	shortBlockSampleCount = 120
+	maxLM                 = 3
+	maxBands              = 21
+	hybridStartBand       = 17
+)

--- a/internal/celt/decoder.go
+++ b/internal/celt/decoder.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import "github.com/pion/opus/internal/rangecoding"
+
+// Decoder maintains state for the RFC 6716 Section 4.3 CELT layer.
+type Decoder struct {
+	mode         *Mode
+	rangeDecoder rangecoding.Decoder
+	previousLogE [2][maxBands]float32
+	overlap      [2][]float32
+}
+
+// NewDecoder creates a CELT decoder with the static Opus 48 kHz mode.
+func NewDecoder() Decoder {
+	decoder := Decoder{mode: DefaultMode()}
+	decoder.Reset()
+
+	return decoder
+}
+
+// Reset clears frame-to-frame CELT decode state.
+func (d *Decoder) Reset() {
+	d.mode = DefaultMode()
+	d.rangeDecoder = rangecoding.Decoder{}
+	clear(d.previousLogE[0][:])
+	clear(d.previousLogE[1][:])
+
+	for channelIndex := range d.overlap {
+		if cap(d.overlap[channelIndex]) < shortBlockSampleCount {
+			d.overlap[channelIndex] = make([]float32, shortBlockSampleCount)
+		}
+		clear(d.overlap[channelIndex])
+	}
+}
+
+// Mode returns the static CELT mode used by this decoder.
+func (d *Decoder) Mode() *Mode {
+	if d.mode == nil {
+		d.mode = DefaultMode()
+	}
+
+	return d.mode
+}

--- a/internal/celt/errors.go
+++ b/internal/celt/errors.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import "errors"
+
+var (
+	errInvalidFrameSize  = errors.New("invalid CELT frame size")
+	errInvalidLM         = errors.New("invalid CELT size shift")
+	errInvalidBand       = errors.New("invalid CELT band")
+	errInvalidSampleRate = errors.New("invalid CELT sample rate")
+)

--- a/internal/celt/mode.go
+++ b/internal/celt/mode.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+// Mode describes the static 48 kHz CELT mode from RFC 6716 Section 4.3.
+type Mode struct {
+	sampleRate            int
+	shortBlockSampleCount int
+	maxLM                 int
+	bandEdges             []int16
+}
+
+var defaultMode = Mode{ //nolint:gochecknoglobals
+	sampleRate:            sampleRate,
+	shortBlockSampleCount: shortBlockSampleCount,
+	maxLM:                 maxLM,
+	bandEdges:             bandEdges[:],
+}
+
+// DefaultMode returns the static 48 kHz CELT mode used by Opus.
+func DefaultMode() *Mode {
+	return &defaultMode
+}
+
+// SampleRate returns the CELT synthesis sample rate.
+func (m *Mode) SampleRate() int {
+	return m.sampleRate
+}
+
+// BandCount returns the number of CELT energy bands.
+func (m *Mode) BandCount() int {
+	return len(m.bandEdges) - 1
+}
+
+// MaxLM returns the maximum CELT frame-size shift.
+func (m *Mode) MaxLM() int {
+	return m.maxLM
+}
+
+// ShortBlockSampleCount returns the CELT 2.5 ms block size at 48 kHz.
+func (m *Mode) ShortBlockSampleCount() int {
+	return m.shortBlockSampleCount
+}
+
+// FrameSampleCount returns the sample count per channel for a CELT LM.
+// RFC 6716 Section 4.3.3 defines LM as log2(frame_size/120).
+func (m *Mode) FrameSampleCount(lm int) (int, error) {
+	if lm < 0 || lm > m.maxLM {
+		return 0, errInvalidLM
+	}
+
+	return m.shortBlockSampleCount << lm, nil
+}
+
+// LMForFrameSampleCount maps a sample count per channel to a CELT LM.
+func (m *Mode) LMForFrameSampleCount(frameSampleCount int) (int, error) {
+	for lm := 0; lm <= m.maxLM; lm++ {
+		if frameSampleCount == m.shortBlockSampleCount<<lm {
+			return lm, nil
+		}
+	}
+
+	return 0, errInvalidFrameSize
+}
+
+// BandEdges returns the RFC 6716 Table 55 MDCT bin edges scaled for a CELT LM.
+func (m *Mode) BandEdges(lm int) ([]int, error) {
+	if lm < 0 || lm > m.maxLM {
+		return nil, errInvalidLM
+	}
+
+	edges := make([]int, len(m.bandEdges))
+	for i, edge := range m.bandEdges {
+		edges[i] = int(edge) << lm
+	}
+
+	return edges, nil
+}
+
+// BandWidth returns the number of MDCT bins in one energy band for a CELT LM.
+func (m *Mode) BandWidth(band, lm int) (int, error) {
+	if band < 0 || band >= m.BandCount() {
+		return 0, errInvalidBand
+	}
+
+	edges, err := m.BandEdges(lm)
+	if err != nil {
+		return 0, err
+	}
+
+	return edges[band+1] - edges[band], nil
+}
+
+// BandRangeForSampleRate returns the coded CELT band range for an Opus bandwidth sample rate.
+// The end bands come from the RFC 6716 Section 4.3/Table 55 band stop frequencies.
+func (m *Mode) BandRangeForSampleRate(sampleRate int) (startBand, endBand int, err error) {
+	switch sampleRate {
+	case 8000:
+		return 0, 13, nil
+	case 16000:
+		return 0, 17, nil
+	case 24000:
+		return 0, 19, nil
+	case 48000:
+		return 0, m.BandCount(), nil
+	default:
+		return 0, 0, errInvalidSampleRate
+	}
+}
+
+// HybridBandRange returns the CELT band range used by hybrid modes.
+// RFC 6716 Section 4.3 leaves bands below band 17 to SILK in hybrid modes.
+func (m *Mode) HybridBandRange(sampleRate int) (startBand, endBand int, err error) {
+	_, endBand, err = m.BandRangeForSampleRate(sampleRate)
+	if err != nil {
+		return 0, 0, err
+	}
+	if endBand <= hybridStartBand {
+		return 0, 0, errInvalidSampleRate
+	}
+
+	return hybridStartBand, endBand, nil
+}

--- a/internal/celt/mode_test.go
+++ b/internal/celt/mode_test.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultMode(t *testing.T) {
+	mode := DefaultMode()
+
+	assert.Equal(t, sampleRate, mode.SampleRate())
+	assert.Equal(t, shortBlockSampleCount, mode.ShortBlockSampleCount())
+	assert.Equal(t, maxLM, mode.MaxLM())
+	assert.Equal(t, maxBands, mode.BandCount())
+}
+
+func TestFrameSampleCount(t *testing.T) {
+	mode := DefaultMode()
+
+	for _, test := range []struct {
+		name       string
+		lm         int
+		sampleSize int
+	}{
+		{name: "2.5ms", lm: 0, sampleSize: 120},
+		{name: "5ms", lm: 1, sampleSize: 240},
+		{name: "10ms", lm: 2, sampleSize: 480},
+		{name: "20ms", lm: 3, sampleSize: 960},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := mode.FrameSampleCount(test.lm)
+			require.NoError(t, err)
+			assert.Equal(t, test.sampleSize, got)
+
+			lm, err := mode.LMForFrameSampleCount(test.sampleSize)
+			require.NoError(t, err)
+			assert.Equal(t, test.lm, lm)
+		})
+	}
+
+	_, err := mode.FrameSampleCount(4)
+	assert.ErrorIs(t, err, errInvalidLM)
+	_, err = mode.LMForFrameSampleCount(720)
+	assert.ErrorIs(t, err, errInvalidFrameSize)
+}
+
+func TestBandEdges(t *testing.T) {
+	mode := DefaultMode()
+
+	edges, err := mode.BandEdges(0)
+	require.NoError(t, err)
+	assert.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28, 32, 40, 48, 60, 78, 100}, edges)
+
+	edges, err = mode.BandEdges(3)
+	require.NoError(t, err)
+	assert.Equal(t, 0, edges[0])
+	assert.Equal(t, 800, edges[len(edges)-1])
+
+	width, err := mode.BandWidth(20, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 176, width)
+}
+
+func TestBandRangeForSampleRate(t *testing.T) {
+	mode := DefaultMode()
+
+	for _, test := range []struct {
+		name       string
+		sampleRate int
+		endBand    int
+	}{
+		{name: "narrowband", sampleRate: 8000, endBand: 13},
+		{name: "wideband", sampleRate: 16000, endBand: 17},
+		{name: "superwideband", sampleRate: 24000, endBand: 19},
+		{name: "fullband", sampleRate: 48000, endBand: 21},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			startBand, endBand, err := mode.BandRangeForSampleRate(test.sampleRate)
+			require.NoError(t, err)
+			assert.Equal(t, 0, startBand)
+			assert.Equal(t, test.endBand, endBand)
+		})
+	}
+
+	_, _, err := mode.BandRangeForSampleRate(12000)
+	assert.ErrorIs(t, err, errInvalidSampleRate)
+}
+
+func TestHybridBandRange(t *testing.T) {
+	startBand, endBand, err := DefaultMode().HybridBandRange(48000)
+	require.NoError(t, err)
+
+	assert.Equal(t, hybridStartBand, startBand)
+	assert.Equal(t, maxBands, endBand)
+
+	_, _, err = DefaultMode().HybridBandRange(16000)
+	assert.ErrorIs(t, err, errInvalidSampleRate)
+}
+
+func TestStaticTables(t *testing.T) {
+	assert.Len(t, bandEdges, maxBands+1)
+	assert.Equal(t, int16(0), bandEdges[0])
+	assert.Equal(t, int16(100), bandEdges[len(bandEdges)-1])
+
+	assert.Len(t, bandAllocation, maxBands)
+	assert.Equal(t, uint8(90), bandAllocation[1][0])
+	assert.Equal(t, uint8(188), bandAllocation[20][10])
+
+	assert.Equal(t, []uint{32768, 32767, 32768}, icdfSilence)
+	assert.Equal(t, []uint{32, 7, 9, 30, 32}, icdfSpread)
+}
+
+func TestDecoderReset(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.previousLogE[0][0] = 1
+	decoder.overlap[0][0] = 1
+
+	decoder.Reset()
+
+	assert.Zero(t, decoder.previousLogE[0][0])
+	assert.Zero(t, decoder.overlap[0][0])
+	assert.Equal(t, sampleRate, decoder.Mode().SampleRate())
+}

--- a/internal/celt/tables.go
+++ b/internal/celt/tables.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+// bandEdges are the 2.5 ms CELT band edges from RFC 6716 Table 55.
+var bandEdges = [...]int16{ //nolint:gochecknoglobals
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28, 32, 40, 48, 60, 78, 100,
+}
+
+// bandAllocation is the static CELT allocation table from RFC 6716 Table 57.
+// Rows are energy bands, columns are allocation vectors 0 through 10.
+var bandAllocation = [maxBands][11]uint8{ //nolint:gochecknoglobals
+	{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	{90, 80, 75, 69, 63, 56, 49, 40, 34, 29, 20},
+	{110, 100, 90, 84, 78, 71, 65, 58, 51, 45, 39},
+	{118, 110, 103, 93, 86, 80, 75, 71, 65, 60, 54},
+	{126, 119, 112, 104, 95, 89, 83, 80, 76, 70, 65},
+	{134, 128, 120, 114, 103, 97, 91, 88, 83, 77, 72},
+	{144, 137, 129, 124, 113, 107, 101, 97, 92, 86, 83},
+	{152, 145, 137, 132, 123, 117, 111, 107, 102, 96, 93},
+	{162, 154, 147, 142, 133, 127, 121, 117, 112, 106, 103},
+	{172, 164, 157, 152, 143, 137, 131, 127, 122, 116, 113},
+	{200, 200, 198, 194, 183, 177, 171, 167, 162, 156, 153},
+	{200, 200, 200, 200, 198, 194, 188, 183, 179, 173, 168},
+	{200, 200, 200, 200, 200, 200, 199, 194, 190, 185, 180},
+	{200, 200, 200, 200, 200, 200, 200, 200, 199, 194, 190},
+	{200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200},
+	{200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200},
+	{200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200},
+	{200, 200, 200, 200, 200, 200, 200, 200, 198, 193, 188},
+	{200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200},
+	{200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200},
+	{200, 200, 200, 200, 200, 200, 200, 200, 198, 193, 188},
+}
+
+// These ICDFs mirror the CELT symbol PDFs from RFC 6716 Table 56 and the
+// decoder subsections it references, including Section 4.3.3/Table 58.
+// nolint:gochecknoglobals,unused
+var (
+	icdfSilence        = []uint{32768, 32767, 32768}
+	icdfPostFilter     = []uint{2, 1, 2}
+	icdfTransient      = []uint{8, 7, 8}
+	icdfTapset         = []uint{4, 2, 3, 4}
+	icdfTFChange       = []uint{4, 3, 4}
+	icdfTFChangeLong   = []uint{16, 15, 16}
+	icdfSpread         = []uint{32, 7, 9, 30, 32}
+	icdfAllocationTrim = []uint{128, 2, 4, 9, 19, 41, 87, 109, 119, 124, 126, 128}
+)

--- a/internal/rangecoding/decoder.go
+++ b/internal/rangecoding/decoder.go
@@ -3,6 +3,8 @@
 
 package rangecoding
 
+import "math/bits"
+
 // Decoder implements rfc6716#section-4.1
 // Opus uses an entropy coder based on range coding [RANGE-CODING]
 // [MARTIN79], which is itself a rediscovery of the FIFO arithmetic code
@@ -69,8 +71,10 @@ package rangecoding
 // the current range.  Both val and rng are 32-bit unsigned integer
 // values.
 type Decoder struct {
-	data     []byte
-	bitsRead uint
+	data        []byte
+	bitsRead    uint
+	rawBitsRead uint
+	nbitsTotal  uint
 
 	rangeSize              uint32 // rng in RFC 6716
 	highAndCodedDifference uint32 // val in RFC 6716
@@ -92,6 +96,8 @@ type Decoder struct {
 func (r *Decoder) Init(data []byte) {
 	r.data = data
 	r.bitsRead = 0
+	r.rawBitsRead = 0
+	r.nbitsTotal = 9
 
 	r.rangeSize = 128
 	r.highAndCodedDifference = 127 - r.getBits(7)
@@ -178,6 +184,33 @@ func (r *Decoder) getBits(n int) uint32 {
 	return bits
 }
 
+func (r *Decoder) getRawBit() uint32 {
+	index := r.rawBitsRead / 8
+	offset := r.rawBitsRead % 8
+	r.rawBitsRead++
+	r.nbitsTotal++
+	if index >= uint(len(r.data)) {
+		return 0
+	}
+
+	byteIndex := len(r.data) - 1 - int(index) //nolint:gosec // G115: index is bounded by len(r.data) above.
+
+	return uint32((r.data[byteIndex] >> offset) & 1)
+}
+
+func (r *Decoder) getRawBits(n uint) uint32 {
+	var bits uint32
+
+	for i := uint(0); i < n && i < 32; i++ {
+		bits |= r.getRawBit() << i
+	}
+	for i := uint(32); i < n; i++ {
+		_ = r.getRawBit()
+	}
+
+	return bits
+}
+
 // minRangeSize is the minimum allowed size for rng.
 // It's equal to math.Pow(2, 23).
 const minRangeSize = 1 << 23
@@ -200,6 +233,7 @@ const minRangeSize = 1 << 23
 func (r *Decoder) normalize() {
 	for r.rangeSize <= minRangeSize {
 		r.rangeSize <<= 8
+		r.nbitsTotal += 8
 		r.highAndCodedDifference = ((r.highAndCodedDifference << 8) + (255 - r.getBits(8))) & 0x7FFFFFFF
 	}
 }
@@ -219,8 +253,70 @@ func (r *Decoder) update(scale, low, high, total uint32) {
 func (r *Decoder) SetInternalValues(data []byte, bitsRead uint, rangeSize uint32, highAndCodedDifference uint32) {
 	r.data = data
 	r.bitsRead = bitsRead
+	r.rawBitsRead = 0
+	r.nbitsTotal = bitsRead
 	r.rangeSize = rangeSize
 	r.highAndCodedDifference = highAndCodedDifference
+}
+
+// DecodeRawBits decodes raw bits packed from the end of the frame.
+// RFC 6716 Section 4.1.4 defines this LSB-first tail packing for CELT.
+func (r *Decoder) DecodeRawBits(n uint) uint32 {
+	return r.getRawBits(n)
+}
+
+// Tell returns a conservative upper bound, in whole bits, of how many bits
+// have been consumed from the current frame, per RFC 6716 Section 4.1.6.1.
+func (r *Decoder) Tell() uint {
+	lg := uint(bits.Len32(r.rangeSize)) //nolint:gosec // G115: bits.Len32 returns 0..32.
+	if lg == 0 {
+		return r.nbitsTotal
+	}
+	if r.nbitsTotal <= lg {
+		return 0
+	}
+
+	return r.nbitsTotal - lg
+}
+
+// TellFrac returns a conservative upper bound in 1/8 bit units.
+// This follows the ec_tell_frac() construction in RFC 6716 Section 4.1.6.2.
+func (r *Decoder) TellFrac() uint {
+	lg := uint(bits.Len32(r.rangeSize)) //nolint:gosec // G115: bits.Len32 returns 0..32.
+	if lg == 0 {
+		return r.nbitsTotal * 8
+	}
+	if lg < 24 {
+		return r.Tell() * 8
+	}
+
+	rQ15 := uint64(r.rangeSize >> (lg - 16))
+	for range 3 {
+		rQ15 = (rQ15 * rQ15) >> 15
+		bit := rQ15 >> 16
+		lg = 2*lg + uint(bit)
+		if bit != 0 {
+			rQ15 >>= 1
+		}
+	}
+
+	total := r.nbitsTotal * 8
+	if total <= lg {
+		return 0
+	}
+
+	return total - lg
+}
+
+// RemainingBits reports a conservative estimate of the unread payload bits.
+// RFC 6716 Section 4.1.4 allows range and raw-bit cursor overlap.
+func (r *Decoder) RemainingBits() int {
+	return len(r.data)*8 - int(r.bitsRead) - int(r.rawBitsRead) //nolint:gosec // G115: decode cursors are frame-sized.
+}
+
+// FinalRange exposes the current range coder range state for tests.
+func (r *Decoder) FinalRange() uint32 {
+	return r.rangeSize
 }
 
 func localMin(a, b uint) uint {

--- a/internal/rangecoding/decoder_test.go
+++ b/internal/rangecoding/decoder_test.go
@@ -200,3 +200,79 @@ func TestDecoderInitEmptyInput(t *testing.T) {
 		decoder.Init(nil)
 	})
 }
+
+func TestDecodeRawBits(t *testing.T) {
+	t.Run("reads bits from the end of the frame in LSB-first order", func(t *testing.T) {
+		decoder := &Decoder{data: []byte{0xB2}}
+
+		assert.Equal(t, uint32(0xB2), decoder.DecodeRawBits(8))
+		assert.Equal(t, uint(8), decoder.rawBitsRead)
+		assert.Equal(t, 0, decoder.RemainingBits())
+	})
+
+	t.Run("returns zero for n==0", func(t *testing.T) {
+		decoder := &Decoder{data: []byte{0xFF}}
+
+		assert.Zero(t, decoder.DecodeRawBits(0))
+		assert.Zero(t, decoder.rawBitsRead)
+	})
+
+	t.Run("pads missing raw bits with zeros", func(t *testing.T) {
+		decoder := &Decoder{data: []byte{0x01}}
+
+		assert.Equal(t, uint32(0x01), decoder.DecodeRawBits(12))
+		assert.Equal(t, uint(12), decoder.rawBitsRead)
+		assert.Equal(t, -4, decoder.RemainingBits())
+	})
+}
+
+func TestTell(t *testing.T) {
+	decoder := &Decoder{}
+	decoder.Init(make([]byte, 8))
+
+	assert.Equal(t, uint(1), decoder.Tell())
+	assert.Equal(t, uint(8), decoder.TellFrac())
+
+	decoder.DecodeRawBits(8)
+
+	assert.Equal(t, uint(9), decoder.Tell())
+	assert.Equal(t, uint(72), decoder.TellFrac())
+}
+
+func TestTellFracDoesNotUnderflow(t *testing.T) {
+	decoder := &Decoder{rangeSize: 1 << 31}
+
+	assert.Zero(t, decoder.TellFrac())
+}
+
+func TestSetInternalValuesResetsBitAccounting(t *testing.T) {
+	decoder := &Decoder{
+		rawBitsRead: 7,
+		nbitsTotal:  99,
+	}
+
+	decoder.SetInternalValues([]byte{0x00, 0x00}, 12, 1<<31, 0)
+
+	assert.Equal(t, uint(12), decoder.bitsRead)
+	assert.Zero(t, decoder.rawBitsRead)
+	assert.Equal(t, uint(12), decoder.nbitsTotal)
+	assert.Equal(t, 4, decoder.RemainingBits())
+}
+
+func TestRemainingBitsAndFinalRange(t *testing.T) {
+	t.Run("reports remaining bits conservatively", func(t *testing.T) {
+		decoder := &Decoder{
+			data:        []byte{0x00, 0x00},
+			bitsRead:    10,
+			rawBitsRead: 7,
+		}
+
+		assert.Equal(t, -1, decoder.RemainingBits())
+	})
+
+	t.Run("exposes the current final range", func(t *testing.T) {
+		decoder := &Decoder{rangeSize: 12345}
+
+		assert.Equal(t, uint32(12345), decoder.FinalRange())
+	})
+}


### PR DESCRIPTION
## Summary

- Add CELT decoder scaffolding with the static RFC 6716 48 kHz mode, band tables, allocation/ICDF table placeholders, and resettable decoder state.
- Extend range decoder support for CELT raw tail bits, bit accounting, final range inspection, and RFC-referenced helper comments.
- Wire CELT-only and hybrid mode state reset paths while keeping those modes explicitly unsupported until the full CELT decode path lands.
- Rebase the branch onto the current valid base branch, `main`, after GitHub rejected `master` as an invalid PR base.

## Validation

- `env GOCACHE=/tmp/opus-go-build GOLANGCI_LINT_CACHE=/tmp/opus-golangci-lint-cache golangci-lint run ./...`
- `env GOCACHE=/tmp/opus-go-build go test -count=1 -coverprofile=/tmp/opus-coverage.out ./...`
- `env GOCACHE=/tmp/opus-go-build go tool cover -func=/tmp/opus-coverage.out` reported total statement coverage `81.4%`.