### PR TITLE
Decode CELT frame side information

### DIFF
--- a/internal/celt/errors.go
+++ b/internal/celt/errors.go
@@ -6,8 +6,10 @@ package celt
 import "errors"
 
 var (
-	errInvalidFrameSize  = errors.New("invalid CELT frame size")
-	errInvalidLM         = errors.New("invalid CELT size shift")
-	errInvalidBand       = errors.New("invalid CELT band")
-	errInvalidSampleRate = errors.New("invalid CELT sample rate")
+	errInvalidFrameSize    = errors.New("invalid CELT frame size")
+	errInvalidLM           = errors.New("invalid CELT size shift")
+	errInvalidBand         = errors.New("invalid CELT band")
+	errInvalidSampleRate   = errors.New("invalid CELT sample rate")
+	errInvalidChannelCount = errors.New("invalid CELT channel count")
+	errRangeCoderSymbol    = errors.New("invalid CELT range coder symbol")
 )

--- a/internal/celt/frame.go
+++ b/internal/celt/frame.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import "fmt"
+
+const (
+	postFilterPitchBase = 16
+	postFilterGainStep  = 0.09375
+)
+
+type frameConfig struct {
+	frameSampleCount int
+	startBand        int
+	endBand          int
+	channelCount     int
+}
+
+type frameSideInfo struct {
+	lm              int
+	totalBits       uint
+	startBand       int
+	endBand         int
+	channelCount    int
+	silence         bool
+	postFilter      postFilter
+	transient       bool
+	shortBlockCount int
+	intraEnergy     bool
+}
+
+type postFilter struct {
+	enabled bool
+	octave  int
+	period  int
+	gain    float32
+	tapset  int
+}
+
+// decodeFrameSideInfo consumes the initial CELT symbols through the intra-energy
+// flag in the order specified by RFC 6716 Table 56. Coarse energy decoding,
+// TF changes, allocation, and PVQ residual decoding are intentionally left to
+// the following CELT slices.
+func (d *Decoder) decodeFrameSideInfo(data []byte, cfg frameConfig) (frameSideInfo, error) {
+	info, err := d.validateFrameConfig(cfg)
+	if err != nil {
+		return frameSideInfo{}, err
+	}
+
+	info.totalBits = uint(len(data) * 8)
+	d.rangeDecoder.Init(data)
+
+	d.decodeSilenceFlag(&info)
+	if info.silence {
+		return info, nil
+	}
+
+	if err = d.decodePostFilter(&info); err != nil {
+		return frameSideInfo{}, err
+	}
+	d.decodeTransientFlag(&info)
+	d.decodeIntraEnergyFlag(&info)
+
+	return info, nil
+}
+
+func (d *Decoder) validateFrameConfig(cfg frameConfig) (frameSideInfo, error) {
+	// RFC 6716 Section 4.3.3 defines LM as log2(frame_size/120).
+	lm, err := d.Mode().LMForFrameSampleCount(cfg.frameSampleCount)
+	if err != nil {
+		return frameSideInfo{}, err
+	}
+	if cfg.startBand < 0 || cfg.startBand >= d.Mode().BandCount() {
+		return frameSideInfo{}, errInvalidBand
+	}
+	if cfg.endBand <= cfg.startBand || cfg.endBand > d.Mode().BandCount() {
+		return frameSideInfo{}, errInvalidBand
+	}
+	if cfg.channelCount != 1 && cfg.channelCount != 2 {
+		return frameSideInfo{}, errInvalidChannelCount
+	}
+
+	return frameSideInfo{
+		lm:           lm,
+		startBand:    cfg.startBand,
+		endBand:      cfg.endBand,
+		channelCount: cfg.channelCount,
+	}, nil
+}
+
+func (d *Decoder) decodeSilenceFlag(info *frameSideInfo) {
+	tell := d.rangeDecoder.Tell()
+	switch {
+	case tell >= info.totalBits:
+		info.silence = true
+	case tell == 1:
+		// RFC 6716 Table 56 starts CELT frames with a {32767,1}/32768 silence flag.
+		info.silence = d.rangeDecoder.DecodeSymbolLogP(15) == 1
+	}
+}
+
+// decodePostFilter decodes the optional pitch post-filter header fields listed
+// in RFC 6716 Table 56: enable flag, octave, raw period suffix, raw gain, and tapset.
+func (d *Decoder) decodePostFilter(info *frameSideInfo) error {
+	// The reference decoder only reads the pitch post-filter when CELT start==0
+	// and there are at least 16 conservative whole bits left in the frame.
+	if info.startBand != 0 || d.rangeDecoder.Tell()+16 > info.totalBits {
+		return nil
+	}
+	if d.rangeDecoder.DecodeSymbolLogP(1) == 0 {
+		return nil
+	}
+
+	octave, ok := d.rangeDecoder.DecodeUniform(6)
+	if !ok {
+		return fmt.Errorf("%w: post-filter octave", errRangeCoderSymbol)
+	}
+	// RFC 6716 Table 56 stores the post-filter period/gain as raw tail bits,
+	// not as range-coded symbols.
+	rawPeriod := d.rangeDecoder.DecodeRawBits(4 + uint(octave))
+	rawGain := d.rangeDecoder.DecodeRawBits(3)
+
+	info.postFilter = postFilter{
+		enabled: true,
+		octave:  int(octave),
+		period:  (postFilterPitchBase << octave) + int(rawPeriod) - 1,
+		gain:    postFilterGainStep * float32(rawGain+1),
+	}
+
+	if d.rangeDecoder.Tell()+2 <= info.totalBits {
+		info.postFilter.tapset = int(d.rangeDecoder.DecodeSymbolWithICDF(icdfTapset))
+	}
+
+	return nil
+}
+
+// decodeTransientFlag decodes the RFC 6716 Section 4.3.1 global transient flag.
+// 2.5 ms CELT frames cannot be split further, so they do not code this symbol.
+func (d *Decoder) decodeTransientFlag(info *frameSideInfo) {
+	if info.lm == 0 || d.rangeDecoder.Tell()+3 > info.totalBits {
+		return
+	}
+
+	info.transient = d.rangeDecoder.DecodeSymbolLogP(3) == 1
+	if info.transient {
+		info.shortBlockCount = 1 << info.lm
+	}
+}
+
+// decodeIntraEnergyFlag decodes the RFC 6716 Section 4.3.2.1 flag that selects
+// intra-frame coarse-energy prediction. The coarse energy itself is decoded later.
+func (d *Decoder) decodeIntraEnergyFlag(info *frameSideInfo) {
+	if d.rangeDecoder.Tell()+3 > info.totalBits {
+		return
+	}
+
+	info.intraEnergy = d.rangeDecoder.DecodeSymbolLogP(3) == 1
+}

--- a/internal/celt/frame_test.go
+++ b/internal/celt/frame_test.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"testing"
+
+	"github.com/pion/opus/internal/rangecoding"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeFrameSideInfoValidatesConfig(t *testing.T) {
+	decoder := NewDecoder()
+	validConfig := frameConfig{
+		frameSampleCount: shortBlockSampleCount,
+		startBand:        0,
+		endBand:          maxBands,
+		channelCount:     1,
+	}
+
+	cfg := validConfig
+	cfg.frameSampleCount = 720
+	_, err := decoder.decodeFrameSideInfo(nil, cfg)
+	assert.ErrorIs(t, err, errInvalidFrameSize)
+
+	cfg = validConfig
+	cfg.startBand = -1
+	_, err = decoder.decodeFrameSideInfo(nil, cfg)
+	assert.ErrorIs(t, err, errInvalidBand)
+
+	cfg = validConfig
+	cfg.endBand = maxBands + 1
+	_, err = decoder.decodeFrameSideInfo(nil, cfg)
+	assert.ErrorIs(t, err, errInvalidBand)
+
+	cfg = validConfig
+	cfg.channelCount = 3
+	_, err = decoder.decodeFrameSideInfo(nil, cfg)
+	assert.ErrorIs(t, err, errInvalidChannelCount)
+}
+
+func TestDecodeFrameSideInfoSilence(t *testing.T) {
+	decoder := NewDecoder()
+
+	info, err := decoder.decodeFrameSideInfo(nil, frameConfig{
+		frameSampleCount: shortBlockSampleCount,
+		startBand:        0,
+		endBand:          maxBands,
+		channelCount:     1,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, info.silence)
+	assert.Equal(t, 0, info.lm)
+	assert.False(t, info.postFilter.enabled)
+	assert.False(t, info.transient)
+	assert.False(t, info.intraEnergy)
+}
+
+func TestDecodeFrameSideInfoAllDefaultFlags(t *testing.T) {
+	decoder := NewDecoder()
+
+	info, err := decoder.decodeFrameSideInfo(make([]byte, 8), frameConfig{
+		frameSampleCount: shortBlockSampleCount << 1,
+		startBand:        0,
+		endBand:          maxBands,
+		channelCount:     2,
+	})
+
+	require.NoError(t, err)
+	assert.False(t, info.silence)
+	assert.Equal(t, 1, info.lm)
+	assert.Equal(t, 2, info.channelCount)
+	assert.False(t, info.postFilter.enabled)
+	assert.False(t, info.transient)
+	assert.Zero(t, info.shortBlockCount)
+	assert.False(t, info.intraEnergy)
+}
+
+func TestDecodePostFilter(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.rangeDecoder = rangeDecoderWithBinaryOne()
+	decoder.rangeDecoder.SetInternalValues(
+		[]byte{0x5A, 0xA5},
+		40,
+		1<<31,
+		0,
+	)
+	info := frameSideInfo{
+		startBand: 0,
+		totalBits: 256,
+	}
+
+	err := decoder.decodePostFilter(&info)
+
+	require.NoError(t, err)
+	assert.True(t, info.postFilter.enabled)
+	assert.Equal(t, 5, info.postFilter.octave)
+	assert.Equal(t, 676, info.postFilter.period)
+	assert.Equal(t, float32(0.5625), info.postFilter.gain)
+	assert.Equal(t, 2, info.postFilter.tapset)
+}
+
+func TestDecodePostFilterSkipsWhenBandZeroIsAbsent(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.rangeDecoder = rangeDecoderWithBinaryOne()
+	info := frameSideInfo{
+		startBand: 17,
+		totalBits: 256,
+	}
+
+	err := decoder.decodePostFilter(&info)
+
+	require.NoError(t, err)
+	assert.False(t, info.postFilter.enabled)
+}
+
+func TestDecodeTransientAndIntraFlags(t *testing.T) {
+	t.Run("skip 2.5ms transient flag", func(t *testing.T) {
+		decoder := NewDecoder()
+		decoder.rangeDecoder = rangeDecoderWithBinaryOne()
+		info := frameSideInfo{lm: 0, totalBits: 256}
+
+		decoder.decodeTransientFlag(&info)
+
+		assert.False(t, info.transient)
+		assert.Zero(t, info.shortBlockCount)
+	})
+
+	t.Run("decode transient flag when LM > 0", func(t *testing.T) {
+		decoder := NewDecoder()
+		decoder.rangeDecoder = rangeDecoderWithBinaryOne()
+		info := frameSideInfo{lm: 2, totalBits: 256}
+
+		decoder.decodeTransientFlag(&info)
+
+		assert.True(t, info.transient)
+		assert.Equal(t, 4, info.shortBlockCount)
+	})
+
+	t.Run("decode intra energy flag", func(t *testing.T) {
+		decoder := NewDecoder()
+		decoder.rangeDecoder = rangeDecoderWithBinaryOne()
+		info := frameSideInfo{totalBits: 256}
+
+		decoder.decodeIntraEnergyFlag(&info)
+
+		assert.True(t, info.intraEnergy)
+	})
+}
+
+func rangeDecoderWithBinaryOne() rangecoding.Decoder {
+	decoder := rangecoding.Decoder{}
+	decoder.SetInternalValues(nil, 40, 1<<31, 0)
+
+	return decoder
+}

--- a/internal/celt/frame_test.go
+++ b/internal/celt/frame_test.go
@@ -79,6 +79,65 @@ func TestDecodeFrameSideInfoAllDefaultFlags(t *testing.T) {
 	assert.False(t, info.intraEnergy)
 }
 
+func TestDecodeFrameSideInfoRangeTrace(t *testing.T) {
+	decoder := NewDecoder()
+	info, err := decoder.validateFrameConfig(frameConfig{
+		frameSampleCount: shortBlockSampleCount << 1,
+		startBand:        0,
+		endBand:          maxBands,
+		channelCount:     2,
+	})
+	require.NoError(t, err)
+	info.totalBits = 64
+
+	trace := newRangeTrace(t, &decoder)
+	decoder.rangeDecoder.Init(make([]byte, 8))
+	trace.require(rangeCheckpoint{
+		name:          "range init",
+		tell:          1,
+		tellFrac:      8,
+		remainingBits: 33,
+		finalRange:    2147483648,
+	})
+
+	decoder.decodeSilenceFlag(&info)
+	trace.require(rangeCheckpoint{
+		name:          "silence flag",
+		tell:          2,
+		tellFrac:      9,
+		remainingBits: 33,
+		finalRange:    2147418112,
+	})
+
+	err = decoder.decodePostFilter(&info)
+	require.NoError(t, err)
+	trace.require(rangeCheckpoint{
+		name:          "post-filter disabled",
+		tell:          3,
+		tellFrac:      17,
+		remainingBits: 33,
+		finalRange:    1073709056,
+	})
+
+	decoder.decodeTransientFlag(&info)
+	trace.require(rangeCheckpoint{
+		name:          "transient flag",
+		tell:          3,
+		tellFrac:      18,
+		remainingBits: 33,
+		finalRange:    939495424,
+	})
+
+	decoder.decodeIntraEnergyFlag(&info)
+	trace.require(rangeCheckpoint{
+		name:          "intra energy flag",
+		tell:          3,
+		tellFrac:      20,
+		remainingBits: 33,
+		finalRange:    822058496,
+	})
+}
+
 func TestDecodePostFilter(t *testing.T) {
 	decoder := NewDecoder()
 	decoder.rangeDecoder = rangeDecoderWithBinaryOne()
@@ -92,10 +151,25 @@ func TestDecodePostFilter(t *testing.T) {
 		startBand: 0,
 		totalBits: 256,
 	}
+	trace := newRangeTrace(t, &decoder)
+	trace.require(rangeCheckpoint{
+		name:          "before post-filter",
+		tell:          8,
+		tellFrac:      64,
+		remainingBits: -24,
+		finalRange:    2147483648,
+	})
 
 	err := decoder.decodePostFilter(&info)
 
 	require.NoError(t, err)
+	trace.require(rangeCheckpoint{
+		name:          "after post-filter",
+		tell:          26,
+		tellFrac:      205,
+		remainingBits: -36,
+		finalRange:    44739242,
+	})
 	assert.True(t, info.postFilter.enabled)
 	assert.Equal(t, 5, info.postFilter.octave)
 	assert.Equal(t, 676, info.postFilter.period)

--- a/internal/celt/trace_test.go
+++ b/internal/celt/trace_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"testing"
+
+	"github.com/pion/opus/internal/rangecoding"
+	"github.com/stretchr/testify/require"
+)
+
+type rangeCheckpoint struct {
+	name          string
+	tell          uint
+	tellFrac      uint
+	remainingBits int
+	finalRange    uint32
+}
+
+type rangeTrace struct {
+	t            testing.TB
+	rangeDecoder *rangecoding.Decoder
+}
+
+func newRangeTrace(tb testing.TB, decoder *Decoder) rangeTrace {
+	tb.Helper()
+
+	return rangeTrace{
+		t:            tb,
+		rangeDecoder: &decoder.rangeDecoder,
+	}
+}
+
+func (r rangeTrace) require(expected rangeCheckpoint) {
+	r.t.Helper()
+
+	got := rangeCheckpoint{
+		name:          expected.name,
+		tell:          r.rangeDecoder.Tell(),
+		tellFrac:      r.rangeDecoder.TellFrac(),
+		remainingBits: r.rangeDecoder.RemainingBits(),
+		finalRange:    r.rangeDecoder.FinalRange(),
+	}
+
+	require.Equal(r.t, expected, got)
+}

--- a/internal/rangecoding/decoder.go
+++ b/internal/rangecoding/decoder.go
@@ -80,6 +80,8 @@ type Decoder struct {
 	highAndCodedDifference uint32 // val in RFC 6716
 }
 
+const maxUniformRangeCoderBits = 8
+
 // Init sets the state of the Decoder
 // Let b0 be an 8-bit unsigned integer containing first input byte (or
 // containing zero if there are no bytes in this Opus frame).  The
@@ -130,6 +132,49 @@ func (r *Decoder) DecodeSymbolWithICDF(cumulativeDistributionTable []uint) uint3
 	r.update(scale, low, high, total)
 
 	return symbolIndex
+}
+
+func (r *Decoder) decodeUniformSymbol(total uint32) uint32 {
+	scale := r.rangeSize / total
+	symbol := r.highAndCodedDifference/scale + 1
+
+	return total - uint32(localMin(uint(symbol), uint(total))) //nolint:gosec // G115: symbol is clamped to total.
+}
+
+func (r *Decoder) decodeAndUpdateUniformSymbol(total uint32) uint32 {
+	symbol := r.decodeUniformSymbol(total)
+	r.update(r.rangeSize/total, symbol, symbol+1, total)
+
+	return symbol
+}
+
+// DecodeUniform decodes an RFC 6716 Section 4.1.5 ec_dec_uint() symbol.
+//
+// It returns false when the decoded raw-bit suffix produces a value outside
+// [0,total), in which case the saturated value matches the reference decoder.
+func (r *Decoder) DecodeUniform(total uint32) (uint32, bool) {
+	if total == 0 {
+		return 0, false
+	}
+	if total == 1 {
+		return 0, true
+	}
+
+	limit := total - 1
+	bitCount := bits.Len32(limit)
+	if bitCount <= maxUniformRangeCoderBits {
+		return r.decodeAndUpdateUniformSymbol(total), true
+	}
+
+	rawBitCount := bitCount - maxUniformRangeCoderBits
+	rangeTotal := (limit >> rawBitCount) + 1
+	symbol := r.decodeAndUpdateUniformSymbol(rangeTotal)
+	value := (symbol << rawBitCount) | r.DecodeRawBits(uint(rawBitCount))
+	if value <= limit {
+		return value, true
+	}
+
+	return limit, false
 }
 
 // DecodeSymbolLogP decodes a single binary symbol.

--- a/internal/rangecoding/decoder_test.go
+++ b/internal/rangecoding/decoder_test.go
@@ -226,6 +226,60 @@ func TestDecodeRawBits(t *testing.T) {
 	})
 }
 
+func TestDecodeUniform(t *testing.T) {
+	t.Run("decodes values that fit entirely in the range coder", func(t *testing.T) {
+		for symbol := range 6 {
+			decoder := decoderWithUniformSymbol(uint32(symbol), 6)
+
+			got, ok := decoder.DecodeUniform(6)
+
+			assert.True(t, ok)
+			assert.Equal(t, uint32(symbol), got)
+		}
+	})
+
+	t.Run("combines a range-coded prefix with a raw-bit suffix", func(t *testing.T) {
+		decoder := decoderWithUniformSymbol(128, 150)
+		decoder.data = []byte{0x01}
+
+		got, ok := decoder.DecodeUniform(300)
+
+		assert.True(t, ok)
+		assert.Equal(t, uint32(257), got)
+	})
+
+	t.Run("saturates values outside the requested range", func(t *testing.T) {
+		decoder := decoderWithUniformSymbol(128, 129)
+		decoder.data = []byte{0x01}
+
+		got, ok := decoder.DecodeUniform(257)
+
+		assert.False(t, ok)
+		assert.Equal(t, uint32(256), got)
+	})
+
+	t.Run("accepts degenerate totals defensively", func(t *testing.T) {
+		decoder := &Decoder{}
+
+		got, ok := decoder.DecodeUniform(1)
+		assert.True(t, ok)
+		assert.Zero(t, got)
+
+		got, ok = decoder.DecodeUniform(0)
+		assert.False(t, ok)
+		assert.Zero(t, got)
+	})
+}
+
+func decoderWithUniformSymbol(symbol, total uint32) *Decoder {
+	const scale = 1 << 24
+
+	decoder := &Decoder{}
+	decoder.SetInternalValues(nil, 0, total*scale, (total-symbol-1)*scale)
+
+	return decoder
+}
+
 func TestTell(t *testing.T) {
 	decoder := &Decoder{}
 	decoder.Init(make([]byte, 8))


### PR DESCRIPTION
## Summary

This is the last piece before we get to "real meat" :) it's basically table 56 first eight columns.

Implements the first CELT frame side-info slice for RFC 6716 Section 4.3 work:

- add CELT frame configuration validation and side-info parsing through the intra-energy flag
- decode silence, pitch post-filter header, transient, and intra-energy flags in RFC Table 56 order
- add `rangecoding.Decoder.DecodeUniform` for the RFC 6716 Section 4.1.5 `ec_dec_uint()` path needed by the post-filter octave
- add a CELT-side range trace test harness that records `Tell`, `TellFrac`, remaining bits, and final range at named decode milestones
