### PR TITLE
pkg/oggreader: parse logical Ogg packets

### DIFF
--- a/pkg/oggreader/oggreader.go
+++ b/pkg/oggreader/oggreader.go
@@ -11,20 +11,28 @@ import (
 )
 
 const (
+	pageHeaderTypeContinuedPacket   = 0x01
 	pageHeaderTypeBeginningOfStream = 0x02
 	pageHeaderSignature             = "OggS"
+	pageChecksumOffset              = 22
+	pageSegmentCountOffset          = 26
 
 	idPageSignature = "OpusHead"
 
-	pageHeaderLen       = 27
-	idPagePayloadLength = 19
+	pageHeaderLen           = 27
+	idPagePayloadLength     = 19
+	idPageStreamCountIndex  = 19
+	idPageCoupledCountIndex = 20
+	idPageMappingIndex      = 21
+
+	maxPageSegmentSize = 255
 )
 
 var (
 	errNilStream                 = errors.New("stream is nil")
 	errBadIDPageSignature        = errors.New("bad header signature")
 	errBadIDPageType             = errors.New("wrong header, expected beginning of stream")
-	errBadIDPageLength           = errors.New("payload for id page must be 19 bytes")
+	errBadIDPageLength           = errors.New("payload for id page has invalid length")
 	errBadIDPagePayloadSignature = errors.New("bad payload signature")
 	errShortPageHeader           = errors.New("not enough data for payload header")
 	errChecksumMismatch          = errors.New("expected and actual checksum do not match")
@@ -36,6 +44,12 @@ type OggReader struct {
 	bytesReadSuccesfully int64
 	checksumTable        *[256]uint32
 	doChecksum           bool
+	packetQueue          []oggPacket
+	partialPacket        []byte
+	discardingPacket     bool
+	channelMapping       OggChannelMapping
+	lastPacketPageIndex  uint32
+	hasLastPacketPage    bool
 }
 
 // OggHeader is the metadata from the first two pages
@@ -51,6 +65,14 @@ type OggHeader struct {
 	Version    uint8
 }
 
+// OggChannelMapping carries extended multistream metadata from the Opus ID header.
+type OggChannelMapping struct {
+	StreamCount    uint8
+	CoupledCount   uint8
+	Mapping        []uint8
+	DemixingMatrix []int16
+}
+
 // OggPageHeader is the metadata for a Page
 // Pages are the fundamental unit of multiplexing in an Ogg stream
 //
@@ -64,6 +86,11 @@ type OggPageHeader struct {
 	serial        uint32
 	index         uint32
 	segmentsCount uint8
+}
+
+type oggPacket struct {
+	data   []byte
+	header *OggPageHeader
 }
 
 // NewWith returns a new Ogg reader and Ogg header
@@ -92,7 +119,7 @@ func newWith(in io.Reader, doChecksum bool) (*OggReader, *OggHeader, error) {
 }
 
 func (o *OggReader) readHeaders() (*OggHeader, error) {
-	segments, pageHeader, err := o.ParseNextPage()
+	packet, pageHeader, err := o.ParseNextPacket()
 	if err != nil {
 		return nil, err
 	}
@@ -106,34 +133,132 @@ func (o *OggReader) readHeaders() (*OggHeader, error) {
 		return nil, errBadIDPageType
 	}
 
-	if len(segments[0]) != idPagePayloadLength {
+	if len(packet) < idPagePayloadLength {
 		return nil, errBadIDPageLength
 	}
 
-	if s := string(segments[0][:8]); s != idPageSignature {
+	if s := string(packet[:8]); s != idPageSignature {
 		return nil, errBadIDPagePayloadSignature
 	}
 
-	header.Version = segments[0][8]
-	header.Channels = segments[0][9]
-	header.PreSkip = binary.LittleEndian.Uint16(segments[0][10:12])
-	header.SampleRate = binary.LittleEndian.Uint32(segments[0][12:16])
-	header.OutputGain = binary.LittleEndian.Uint16(segments[0][16:18])
-	header.ChannelMap = segments[0][18]
+	header.Version = packet[8]
+	header.Channels = packet[9]
+	header.PreSkip = binary.LittleEndian.Uint16(packet[10:12])
+	header.SampleRate = binary.LittleEndian.Uint32(packet[12:16])
+	header.OutputGain = binary.LittleEndian.Uint16(packet[16:18])
+	header.ChannelMap = packet[18]
+
+	switch header.ChannelMap {
+	case 0:
+		if len(packet) != idPagePayloadLength {
+			return nil, errBadIDPageLength
+		}
+	case 1, 2, 255:
+		expectedLength := idPageMappingIndex + int(header.Channels)
+		if len(packet) != expectedLength {
+			return nil, errBadIDPageLength
+		}
+
+		o.channelMapping = OggChannelMapping{
+			StreamCount:  packet[idPageStreamCountIndex],
+			CoupledCount: packet[idPageCoupledCountIndex],
+			Mapping:      append([]uint8(nil), packet[idPageMappingIndex:]...),
+		}
+	case 3:
+		if len(packet) < idPageMappingIndex {
+			return nil, errBadIDPageLength
+		}
+
+		o.channelMapping.StreamCount = packet[idPageStreamCountIndex]
+		o.channelMapping.CoupledCount = packet[idPageCoupledCountIndex]
+		decodedChannels := int(o.channelMapping.StreamCount) + int(o.channelMapping.CoupledCount)
+		expectedLength := idPageMappingIndex + (2 * int(header.Channels) * decodedChannels)
+		if len(packet) != expectedLength {
+			return nil, errBadIDPageLength
+		}
+
+		o.channelMapping.Mapping = nil
+		o.channelMapping.DemixingMatrix = make([]int16, int(header.Channels)*decodedChannels)
+		offset := idPageMappingIndex
+		for i := range o.channelMapping.DemixingMatrix {
+			o.channelMapping.DemixingMatrix[i] = int16(binary.LittleEndian.Uint16(packet[offset : offset+2]))
+			offset += 2
+		}
+	default:
+		o.channelMapping = OggChannelMapping{}
+	}
 
 	return header, nil
 }
 
+// ChannelMapping returns a copy of the parsed multistream channel mapping metadata.
+func (o *OggReader) ChannelMapping() OggChannelMapping {
+	return OggChannelMapping{
+		StreamCount:    o.channelMapping.StreamCount,
+		CoupledCount:   o.channelMapping.CoupledCount,
+		Mapping:        append([]uint8(nil), o.channelMapping.Mapping...),
+		DemixingMatrix: append([]int16(nil), o.channelMapping.DemixingMatrix...),
+	}
+}
+
 // ParseNextPage reads from stream and returns Ogg page segments, header,
 // and an error if there is incomplete page data.
+//
+// ParseNextPage and ParseNextPacket are alternative read paths and should not
+// be mixed on the same OggReader.
 func (o *OggReader) ParseNextPage() ([][]byte, *OggPageHeader, error) {
+	segments, _, pageHeader, err := o.parseNextPageData()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o.markPacketPageRead(pageHeader)
+
+	return segments, pageHeader, nil
+}
+
+// ParseNextPacket reads from stream and returns one logical Ogg packet.
+//
+// ParseNextPage and ParseNextPacket are alternative read paths and should not
+// be mixed on the same OggReader.
+func (o *OggReader) ParseNextPacket() ([]byte, *OggPageHeader, error) {
+	if len(o.packetQueue) > 0 {
+		packet := o.packetQueue[0]
+		o.packetQueue = o.packetQueue[1:]
+
+		return packet.data, packet.header, nil
+	}
+
+	for {
+		segments, sizeBuffer, pageHeader, err := o.parseNextPageData()
+		if err != nil {
+			if err == io.EOF && len(o.partialPacket) != 0 {
+				return nil, nil, io.ErrUnexpectedEOF
+			}
+
+			return nil, nil, err
+		}
+
+		if err = o.queuePagePackets(segments, sizeBuffer, pageHeader); err != nil {
+			return nil, nil, err
+		}
+		if len(o.packetQueue) > 0 {
+			packet := o.packetQueue[0]
+			o.packetQueue = o.packetQueue[1:]
+
+			return packet.data, packet.header, nil
+		}
+	}
+}
+
+func (o *OggReader) parseNextPageData() ([][]byte, []byte, *OggPageHeader, error) {
 	header := make([]byte, pageHeaderLen)
 
 	n, err := io.ReadFull(o.stream, header)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	} else if n < len(header) {
-		return nil, nil, errShortPageHeader
+		return nil, nil, nil, errShortPageHeader
 	}
 
 	pageHeader := &OggPageHeader{
@@ -145,11 +270,11 @@ func (o *OggReader) ParseNextPage() ([][]byte, *OggPageHeader, error) {
 	pageHeader.GranulePosition = binary.LittleEndian.Uint64(header[6 : 6+8])
 	pageHeader.serial = binary.LittleEndian.Uint32(header[14 : 14+4])
 	pageHeader.index = binary.LittleEndian.Uint32(header[18 : 18+4])
-	pageHeader.segmentsCount = header[26]
+	pageHeader.segmentsCount = header[pageSegmentCountOffset]
 
 	sizeBuffer := make([]byte, pageHeader.segmentsCount)
 	if _, err = io.ReadFull(o.stream, sizeBuffer); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	segments := [][]byte{}
@@ -157,7 +282,7 @@ func (o *OggReader) ParseNextPage() ([][]byte, *OggPageHeader, error) {
 	for _, s := range sizeBuffer {
 		segment := make([]byte, int(s))
 		if _, err = io.ReadFull(o.stream, segment); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		segments = append(segments, segment)
@@ -165,11 +290,68 @@ func (o *OggReader) ParseNextPage() ([][]byte, *OggPageHeader, error) {
 
 	if o.doChecksum {
 		if err = o.validateChecksum(header, sizeBuffer, segments); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
-	return segments, pageHeader, nil
+	return segments, sizeBuffer, pageHeader, nil
+}
+
+func (o *OggReader) queuePagePackets(segments [][]byte, sizeBuffer []byte, pageHeader *OggPageHeader) error {
+	isContinuedPacket := (pageHeader.headerType & pageHeaderTypeContinuedPacket) != 0
+	isConsecutivePage := !o.hasLastPacketPage || pageHeader.index == o.lastPacketPageIndex+1
+
+	if o.discardingPacket && !isContinuedPacket {
+		o.discardingPacket = false
+	}
+
+	if len(o.partialPacket) != 0 {
+		if !isContinuedPacket || !isConsecutivePage {
+			return io.ErrUnexpectedEOF
+		}
+	} else if isContinuedPacket {
+		// RFC 7845 allows the first packet on an audio page to be a continuation
+		// from data we do not have, such as when joining a live stream mid-broadcast.
+		// Skip that incomplete packet and resume at the next packet boundary.
+		o.discardingPacket = true
+	}
+
+	for i, segment := range segments {
+		if o.discardingPacket {
+			if sizeBuffer[i] != maxPageSegmentSize {
+				o.discardingPacket = false
+			}
+
+			continue
+		}
+
+		o.partialPacket = append(o.partialPacket, segment...)
+
+		if sizeBuffer[i] == maxPageSegmentSize {
+			continue
+		}
+
+		packet := append([]byte(nil), o.partialPacket...)
+		headerCopy := *pageHeader
+		o.packetQueue = append(o.packetQueue, oggPacket{
+			data:   packet,
+			header: &headerCopy,
+		})
+		o.partialPacket = nil
+	}
+
+	o.markPacketPageRead(pageHeader)
+
+	return nil
+}
+
+func (o *OggReader) markPacketPageRead(pageHeader *OggPageHeader) {
+	if pageHeader.segmentsCount == 0 {
+		return
+	}
+
+	o.lastPacketPageIndex = pageHeader.index
+	o.hasLastPacketPage = true
 }
 
 func (o *OggReader) validateChecksum(header, sizeBuffer []byte, segments [][]byte) error {
@@ -180,7 +362,7 @@ func (o *OggReader) validateChecksum(header, sizeBuffer []byte, segments [][]byt
 
 	for index := range header {
 		// Don't include expected checksum in our generation
-		if index > 21 && index < 26 {
+		if index >= pageChecksumOffset && index < pageSegmentCountOffset {
 			updateChecksum(0)
 
 			continue
@@ -198,7 +380,7 @@ func (o *OggReader) validateChecksum(header, sizeBuffer []byte, segments [][]byt
 		}
 	}
 
-	if binary.LittleEndian.Uint32(header[22:22+4]) != checksum {
+	if binary.LittleEndian.Uint32(header[pageChecksumOffset:pageChecksumOffset+4]) != checksum {
 		return errChecksumMismatch
 	}
 

--- a/pkg/oggreader/oggreader.go
+++ b/pkg/oggreader/oggreader.go
@@ -11,20 +11,28 @@ import (
 )
 
 const (
+	pageHeaderTypeContinuedPacket   = 0x01
 	pageHeaderTypeBeginningOfStream = 0x02
 	pageHeaderSignature             = "OggS"
+	pageChecksumOffset              = 22
+	pageSegmentCountOffset          = 26
 
 	idPageSignature = "OpusHead"
 
-	pageHeaderLen       = 27
-	idPagePayloadLength = 19
+	pageHeaderLen           = 27
+	idPagePayloadLength     = 19
+	idPageStreamCountIndex  = 19
+	idPageCoupledCountIndex = 20
+	idPageMappingIndex      = 21
+
+	maxPageSegmentSize = 255
 )
 
 var (
 	errNilStream                 = errors.New("stream is nil")
 	errBadIDPageSignature        = errors.New("bad header signature")
 	errBadIDPageType             = errors.New("wrong header, expected beginning of stream")
-	errBadIDPageLength           = errors.New("payload for id page must be 19 bytes")
+	errBadIDPageLength           = errors.New("payload for id page has invalid length")
 	errBadIDPagePayloadSignature = errors.New("bad payload signature")
 	errShortPageHeader           = errors.New("not enough data for payload header")
 	errChecksumMismatch          = errors.New("expected and actual checksum do not match")
@@ -36,6 +44,8 @@ type OggReader struct {
 	bytesReadSuccesfully int64
 	checksumTable        *[256]uint32
 	doChecksum           bool
+	packetState          *oggPacketState
+	channelMapping       *OggChannelMapping
 }
 
 // OggHeader is the metadata from the first two pages
@@ -49,6 +59,14 @@ type OggHeader struct {
 	PreSkip    uint16
 	SampleRate uint32
 	Version    uint8
+}
+
+// OggChannelMapping carries extended multistream metadata from the Opus ID header.
+type OggChannelMapping struct {
+	StreamCount    uint8
+	CoupledCount   uint8
+	Mapping        []uint8
+	DemixingMatrix []int16
 }
 
 // OggPageHeader is the metadata for a Page
@@ -66,6 +84,19 @@ type OggPageHeader struct {
 	segmentsCount uint8
 }
 
+type oggPacket struct {
+	data   []byte
+	header *OggPageHeader
+}
+
+type oggPacketState struct {
+	packetQueue         []oggPacket
+	partialPacket       []byte
+	discardingPacket    bool
+	lastPacketPageIndex uint32
+	hasLastPacketPage   bool
+}
+
 // NewWith returns a new Ogg reader and Ogg header
 // with an io.Reader input.
 func NewWith(in io.Reader) (*OggReader, *OggHeader, error) {
@@ -81,6 +112,7 @@ func newWith(in io.Reader, doChecksum bool) (*OggReader, *OggHeader, error) {
 		stream:        in,
 		checksumTable: generateChecksumTable(),
 		doChecksum:    doChecksum,
+		packetState:   &oggPacketState{},
 	}
 
 	header, err := reader.readHeaders()
@@ -92,48 +124,96 @@ func newWith(in io.Reader, doChecksum bool) (*OggReader, *OggHeader, error) {
 }
 
 func (o *OggReader) readHeaders() (*OggHeader, error) {
-	segments, pageHeader, err := o.ParseNextPage()
+	packet, pageHeader, err := o.ParseNextPacket()
 	if err != nil {
 		return nil, err
 	}
 
-	header := &OggHeader{}
-	if string(pageHeader.sig[:]) != pageHeaderSignature {
-		return nil, errBadIDPageSignature
+	header, err := parseIDHeader(pageHeader, packet)
+	if err != nil {
+		return nil, err
 	}
 
-	if pageHeader.headerType != pageHeaderTypeBeginningOfStream {
-		return nil, errBadIDPageType
+	if err = o.parseChannelMapping(header, packet); err != nil {
+		return nil, err
 	}
-
-	if len(segments[0]) != idPagePayloadLength {
-		return nil, errBadIDPageLength
-	}
-
-	if s := string(segments[0][:8]); s != idPageSignature {
-		return nil, errBadIDPagePayloadSignature
-	}
-
-	header.Version = segments[0][8]
-	header.Channels = segments[0][9]
-	header.PreSkip = binary.LittleEndian.Uint16(segments[0][10:12])
-	header.SampleRate = binary.LittleEndian.Uint32(segments[0][12:16])
-	header.OutputGain = binary.LittleEndian.Uint16(segments[0][16:18])
-	header.ChannelMap = segments[0][18]
 
 	return header, nil
 }
 
+// ChannelMapping returns a copy of the parsed multistream channel mapping metadata.
+func (o *OggReader) ChannelMapping() OggChannelMapping {
+	if o.channelMapping == nil {
+		return OggChannelMapping{}
+	}
+
+	return OggChannelMapping{
+		StreamCount:    o.channelMapping.StreamCount,
+		CoupledCount:   o.channelMapping.CoupledCount,
+		Mapping:        append([]uint8(nil), o.channelMapping.Mapping...),
+		DemixingMatrix: append([]int16(nil), o.channelMapping.DemixingMatrix...),
+	}
+}
+
 // ParseNextPage reads from stream and returns Ogg page segments, header,
 // and an error if there is incomplete page data.
+//
+// ParseNextPage and ParseNextPacket are alternative read paths and should not
+// be mixed on the same OggReader.
 func (o *OggReader) ParseNextPage() ([][]byte, *OggPageHeader, error) {
+	segments, _, pageHeader, err := o.parseNextPageData()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	o.markPacketPageRead(pageHeader)
+
+	return segments, pageHeader, nil
+}
+
+// ParseNextPacket reads from stream and returns one logical Ogg packet.
+//
+// ParseNextPage and ParseNextPacket are alternative read paths and should not
+// be mixed on the same OggReader.
+func (o *OggReader) ParseNextPacket() ([]byte, *OggPageHeader, error) {
+	packetState := o.getPacketState()
+	if len(packetState.packetQueue) > 0 {
+		packet := packetState.packetQueue[0]
+		packetState.packetQueue = packetState.packetQueue[1:]
+
+		return packet.data, packet.header, nil
+	}
+
+	for {
+		segments, sizeBuffer, pageHeader, err := o.parseNextPageData()
+		if err != nil {
+			if errors.Is(err, io.EOF) && len(packetState.partialPacket) != 0 {
+				return nil, nil, io.ErrUnexpectedEOF
+			}
+
+			return nil, nil, err
+		}
+
+		if err = o.queuePagePackets(segments, sizeBuffer, pageHeader); err != nil {
+			return nil, nil, err
+		}
+		if len(packetState.packetQueue) > 0 {
+			packet := packetState.packetQueue[0]
+			packetState.packetQueue = packetState.packetQueue[1:]
+
+			return packet.data, packet.header, nil
+		}
+	}
+}
+
+func (o *OggReader) parseNextPageData() ([][]byte, []byte, *OggPageHeader, error) {
 	header := make([]byte, pageHeaderLen)
 
 	n, err := io.ReadFull(o.stream, header)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	} else if n < len(header) {
-		return nil, nil, errShortPageHeader
+		return nil, nil, nil, errShortPageHeader
 	}
 
 	pageHeader := &OggPageHeader{
@@ -145,11 +225,11 @@ func (o *OggReader) ParseNextPage() ([][]byte, *OggPageHeader, error) {
 	pageHeader.GranulePosition = binary.LittleEndian.Uint64(header[6 : 6+8])
 	pageHeader.serial = binary.LittleEndian.Uint32(header[14 : 14+4])
 	pageHeader.index = binary.LittleEndian.Uint32(header[18 : 18+4])
-	pageHeader.segmentsCount = header[26]
+	pageHeader.segmentsCount = header[pageSegmentCountOffset]
 
 	sizeBuffer := make([]byte, pageHeader.segmentsCount)
 	if _, err = io.ReadFull(o.stream, sizeBuffer); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	segments := [][]byte{}
@@ -157,7 +237,7 @@ func (o *OggReader) ParseNextPage() ([][]byte, *OggPageHeader, error) {
 	for _, s := range sizeBuffer {
 		segment := make([]byte, int(s))
 		if _, err = io.ReadFull(o.stream, segment); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		segments = append(segments, segment)
@@ -165,11 +245,49 @@ func (o *OggReader) ParseNextPage() ([][]byte, *OggPageHeader, error) {
 
 	if o.doChecksum {
 		if err = o.validateChecksum(header, sizeBuffer, segments); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
-	return segments, pageHeader, nil
+	return segments, sizeBuffer, pageHeader, nil
+}
+
+func (o *OggReader) queuePagePackets(segments [][]byte, sizeBuffer []byte, pageHeader *OggPageHeader) error {
+	packetState := o.getPacketState()
+	if err := o.preparePacketQueue(pageHeader); err != nil {
+		return err
+	}
+
+	for i, segment := range segments {
+		segmentSize := sizeBuffer[i]
+		if packetState.discardingPacket {
+			packetState.finishDiscard(segmentSize)
+
+			continue
+		}
+
+		packetState.partialPacket = append(packetState.partialPacket, segment...)
+		if segmentSize == maxPageSegmentSize {
+			continue
+		}
+
+		o.enqueuePacket(pageHeader, packetState.partialPacket)
+		packetState.partialPacket = nil
+	}
+
+	o.markPacketPageRead(pageHeader)
+
+	return nil
+}
+
+func (o *OggReader) markPacketPageRead(pageHeader *OggPageHeader) {
+	if pageHeader.segmentsCount == 0 {
+		return
+	}
+
+	packetState := o.getPacketState()
+	packetState.lastPacketPageIndex = pageHeader.index
+	packetState.hasLastPacketPage = true
 }
 
 func (o *OggReader) validateChecksum(header, sizeBuffer []byte, segments [][]byte) error {
@@ -180,7 +298,7 @@ func (o *OggReader) validateChecksum(header, sizeBuffer []byte, segments [][]byt
 
 	for index := range header {
 		// Don't include expected checksum in our generation
-		if index > 21 && index < 26 {
+		if index >= pageChecksumOffset && index < pageSegmentCountOffset {
 			updateChecksum(0)
 
 			continue
@@ -198,7 +316,7 @@ func (o *OggReader) validateChecksum(header, sizeBuffer []byte, segments [][]byt
 		}
 	}
 
-	if binary.LittleEndian.Uint32(header[22:22+4]) != checksum {
+	if binary.LittleEndian.Uint32(header[pageChecksumOffset:pageChecksumOffset+4]) != checksum {
 		return errChecksumMismatch
 	}
 
@@ -230,4 +348,151 @@ func generateChecksumTable() *[256]uint32 {
 	}
 
 	return &table
+}
+
+func parseIDHeader(pageHeader *OggPageHeader, packet []byte) (*OggHeader, error) {
+	if string(pageHeader.sig[:]) != pageHeaderSignature {
+		return nil, errBadIDPageSignature
+	}
+
+	if pageHeader.headerType != pageHeaderTypeBeginningOfStream {
+		return nil, errBadIDPageType
+	}
+
+	if len(packet) < idPagePayloadLength {
+		return nil, errBadIDPageLength
+	}
+
+	if s := string(packet[:8]); s != idPageSignature {
+		return nil, errBadIDPagePayloadSignature
+	}
+
+	return &OggHeader{
+		Version:    packet[8],
+		Channels:   packet[9],
+		PreSkip:    binary.LittleEndian.Uint16(packet[10:12]),
+		SampleRate: binary.LittleEndian.Uint32(packet[12:16]),
+		OutputGain: binary.LittleEndian.Uint16(packet[16:18]),
+		ChannelMap: packet[18],
+	}, nil
+}
+
+func (o *OggReader) parseChannelMapping(header *OggHeader, packet []byte) error {
+	switch header.ChannelMap {
+	case 0:
+		if len(packet) != idPagePayloadLength {
+			return errBadIDPageLength
+		}
+		o.channelMapping = nil
+
+		return nil
+	case 1, 2, 255:
+		return o.parseStreamChannelMapping(header, packet)
+	case 3:
+		return o.parseDemixingChannelMapping(header, packet)
+	default:
+		o.channelMapping = nil
+
+		return nil
+	}
+}
+
+func (o *OggReader) parseStreamChannelMapping(header *OggHeader, packet []byte) error {
+	expectedLength := idPageMappingIndex + int(header.Channels)
+	if len(packet) != expectedLength {
+		return errBadIDPageLength
+	}
+
+	o.channelMapping = &OggChannelMapping{
+		StreamCount:  packet[idPageStreamCountIndex],
+		CoupledCount: packet[idPageCoupledCountIndex],
+		Mapping:      append([]uint8(nil), packet[idPageMappingIndex:]...),
+	}
+
+	return nil
+}
+
+func (o *OggReader) parseDemixingChannelMapping(header *OggHeader, packet []byte) error {
+	if len(packet) < idPageMappingIndex {
+		return errBadIDPageLength
+	}
+
+	streamCount := packet[idPageStreamCountIndex]
+	coupledCount := packet[idPageCoupledCountIndex]
+	decodedChannels := int(streamCount) + int(coupledCount)
+	expectedLength := idPageMappingIndex + (2 * int(header.Channels) * decodedChannels)
+	if len(packet) != expectedLength {
+		return errBadIDPageLength
+	}
+
+	o.channelMapping = &OggChannelMapping{
+		StreamCount:    streamCount,
+		CoupledCount:   coupledCount,
+		DemixingMatrix: parseDemixingMatrix(packet[idPageMappingIndex:]),
+	}
+
+	return nil
+}
+
+func parseDemixingMatrix(in []byte) []int16 {
+	matrix := make([]int16, len(in)/2)
+	for i := range matrix {
+		offset := i * 2
+		matrix[i] = parseInt16LittleEndian(in[offset : offset+2])
+	}
+
+	return matrix
+}
+
+func parseInt16LittleEndian(in []byte) int16 {
+	return int16(in[0]) | (int16(in[1]) << 8)
+}
+
+func (o *OggReader) getPacketState() *oggPacketState {
+	if o.packetState == nil {
+		o.packetState = &oggPacketState{}
+	}
+
+	return o.packetState
+}
+
+func (o *OggReader) preparePacketQueue(pageHeader *OggPageHeader) error {
+	packetState := o.getPacketState()
+	isContinuedPacket := (pageHeader.headerType & pageHeaderTypeContinuedPacket) != 0
+	isConsecutivePage := !packetState.hasLastPacketPage || pageHeader.index == packetState.lastPacketPageIndex+1
+
+	if packetState.discardingPacket && !isContinuedPacket {
+		packetState.discardingPacket = false
+	}
+
+	if len(packetState.partialPacket) != 0 {
+		if !isContinuedPacket || !isConsecutivePage {
+			return io.ErrUnexpectedEOF
+		}
+
+		return nil
+	}
+
+	if isContinuedPacket {
+		// RFC 7845 allows the first packet on an audio page to be a continuation
+		// from data we do not have, such as when joining a live stream mid-broadcast.
+		// Skip that incomplete packet and resume at the next packet boundary.
+		packetState.discardingPacket = true
+	}
+
+	return nil
+}
+
+func (o *OggReader) enqueuePacket(pageHeader *OggPageHeader, packet []byte) {
+	headerCopy := *pageHeader
+	o.getPacketState().packetQueue = append(o.getPacketState().packetQueue, oggPacket{
+		data:   append([]byte(nil), packet...),
+		header: &headerCopy,
+	})
+}
+
+func (s *oggPacketState) finishDiscard(segmentSize byte) {
+	if segmentSize != maxPageSegmentSize {
+		s.discardingPacket = false
+	}
 }

--- a/pkg/oggreader/oggreader_test.go
+++ b/pkg/oggreader/oggreader_test.go
@@ -5,6 +5,7 @@ package oggreader
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"testing"
 
@@ -101,4 +102,290 @@ func TestOggReader_ParseErrors(t *testing.T) {
 		_, _, err := NewWith(bytes.NewReader(ogg))
 		assert.ErrorIs(t, errChecksumMismatch, err)
 	})
+}
+
+func TestOggReader_ParseHeaderFamily1(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(1, 3, 2, 1, []uint8{0, 1, 2}, nil),
+		}),
+	))
+
+	reader, header, err := NewWith(stream)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(1), header.ChannelMap)
+	assert.Equal(t, uint8(3), header.Channels)
+	assert.Equal(t, OggChannelMapping{
+		StreamCount:  2,
+		CoupledCount: 1,
+		Mapping:      []uint8{0, 1, 2},
+	}, reader.ChannelMapping())
+}
+
+func TestOggReader_ParseHeaderFamily3(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(3, 4, 2, 1, nil, []int16{
+				32767, 0, 0, 0,
+				0, 32767, 0, 0,
+				0, 0, 32767, 0,
+			}),
+		}),
+	))
+
+	reader, header, err := NewWith(stream)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(3), header.ChannelMap)
+	assert.Equal(t, uint8(4), header.Channels)
+	assert.Equal(t, OggChannelMapping{
+		StreamCount:  2,
+		CoupledCount: 1,
+		DemixingMatrix: []int16{
+			32767, 0, 0, 0,
+			0, 32767, 0, 0,
+			0, 0, 32767, 0,
+		},
+	}, reader.ChannelMapping())
+}
+
+func TestOggReader_ChannelMappingReturnsCopy(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(1, 3, 2, 1, []uint8{0, 1, 2}, nil),
+		}),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	mapping := reader.ChannelMapping()
+	mapping.Mapping[0] = 9
+
+	assert.Equal(t, OggChannelMapping{
+		StreamCount:  2,
+		CoupledCount: 1,
+		Mapping:      []uint8{0, 1, 2},
+	}, reader.ChannelMapping())
+}
+
+func TestOggReader_ParseHeaderErrors(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(1, 3, 2, 1, []uint8{0, 1}, nil),
+		}),
+	))
+
+	_, _, err := NewWith(stream)
+	assert.ErrorIs(t, err, errBadIDPageLength)
+}
+
+func TestOggReader_ParseNextPacketMultipleSegmentsOnePage(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xAB}, 300)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(0, 960, 1, 1, splitSegments(payload, 255, 45)),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	packet, header, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, payload, packet)
+	assert.Equal(t, uint64(960), header.GranulePosition)
+}
+
+func TestOggReader_ParseNextPacketContinuedAcrossPages(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xCD}, 300)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(0, 0, 1, 1, splitSegments(payload[:255], 255)),
+		buildOggPage(pageHeaderTypeContinuedPacket, 960, 1, 2, splitSegments(payload[255:], 45)),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	packet, header, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, payload, packet)
+	assert.Equal(t, uint64(960), header.GranulePosition)
+}
+
+func TestOggReader_ParseNextPacketSkipsLeadingContinuedPacketAcrossPages(t *testing.T) {
+	discarded := bytes.Repeat([]byte{0xDE}, 300)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(pageHeaderTypeContinuedPacket, 0, 1, 1, splitSegments(discarded[:255], 255)),
+		buildOggPage(pageHeaderTypeContinuedPacket, 960, 1, 2, [][]byte{
+			discarded[255:],
+			{0xAA, 0xBB},
+		}),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	packet, header, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0xAA, 0xBB}, packet)
+	assert.Equal(t, uint64(960), header.GranulePosition)
+}
+
+func TestOggReader_ParseNextPacketMultiplePacketsOnePage(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(0, 960, 1, 1, [][]byte{
+			{0xAA},
+			{0xBB, 0xCC},
+		}),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	firstPacket, _, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0xAA}, firstPacket)
+
+	secondPacket, _, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0xBB, 0xCC}, secondPacket)
+
+	_, _, err = reader.ParseNextPacket()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestOggReader_ParseNextPacketUnexpectedEOF(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xEF}, 255)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(0, 0, 1, 1, splitSegments(payload, 255)),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	_, _, err = reader.ParseNextPacket()
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestOggReader_ParseNextPacketSequenceGapReturnsUnexpectedEOF(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xAB}, 300)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(pageHeaderTypeBeginningOfStream, 0, 1, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(0, 0, 1, 1, splitSegments(payload[:255], 255)),
+		buildOggPage(pageHeaderTypeContinuedPacket, 960, 1, 3, splitSegments(payload[255:], 45)),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	_, _, err = reader.ParseNextPacket()
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func buildOggStream(pages ...[]byte) []byte {
+	stream := make([]byte, 0)
+	for _, page := range pages {
+		stream = append(stream, page...)
+	}
+
+	return stream
+}
+
+func buildOggPage(headerType byte, granule uint64, serial, index uint32, segments [][]byte) []byte {
+	page := make([]byte, pageHeaderLen)
+	copy(page[:4], []byte(pageHeaderSignature))
+	page[4] = 0
+	page[5] = headerType
+	binary.LittleEndian.PutUint64(page[6:14], granule)
+	binary.LittleEndian.PutUint32(page[14:18], serial)
+	binary.LittleEndian.PutUint32(page[18:22], index)
+	page[26] = byte(len(segments))
+
+	for _, segment := range segments {
+		page = append(page, byte(len(segment)))
+	}
+	for _, segment := range segments {
+		page = append(page, segment...)
+	}
+
+	checksum := oggChecksum(page)
+	binary.LittleEndian.PutUint32(page[22:26], checksum)
+
+	return page
+}
+
+func buildOpusIDHeader(
+	channelMapFamily, channels, streamCount, coupledCount uint8,
+	mapping []uint8,
+	demixingMatrix []int16,
+) []byte {
+	header := make([]byte, 0, 21+len(mapping)+(2*len(demixingMatrix)))
+	header = append(header, []byte(idPageSignature)...)
+	header = append(header, 1)
+	header = append(header, channels)
+
+	preskip := make([]byte, 2)
+	binary.LittleEndian.PutUint16(preskip, 0x0F00)
+	header = append(header, preskip...)
+
+	sampleRate := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sampleRate, 48000)
+	header = append(header, sampleRate...)
+
+	header = append(header, 0, 0)
+	header = append(header, channelMapFamily)
+
+	switch channelMapFamily {
+	case 1, 2, 255:
+		header = append(header, streamCount, coupledCount)
+		header = append(header, mapping...)
+	case 3:
+		header = append(header, streamCount, coupledCount)
+		for _, coefficient := range demixingMatrix {
+			packed := make([]byte, 2)
+			binary.LittleEndian.PutUint16(packed, uint16(coefficient))
+			header = append(header, packed...)
+		}
+	}
+
+	return header
+}
+
+func splitSegments(in []byte, sizes ...int) [][]byte {
+	segments := make([][]byte, 0, len(sizes))
+	offset := 0
+	for _, size := range sizes {
+		segments = append(segments, append([]byte(nil), in[offset:offset+size]...))
+		offset += size
+	}
+
+	return segments
+}
+
+func oggChecksum(page []byte) uint32 {
+	table := generateChecksumTable()
+	var checksum uint32
+	for index, value := range page {
+		if index >= 22 && index < 26 {
+			value = 0
+		}
+		checksum = (checksum << 8) ^ table[byte(checksum>>24)^value]
+	}
+
+	return checksum
 }

--- a/pkg/oggreader/oggreader_test.go
+++ b/pkg/oggreader/oggreader_test.go
@@ -5,6 +5,7 @@ package oggreader
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"testing"
 
@@ -101,4 +102,302 @@ func TestOggReader_ParseErrors(t *testing.T) {
 		_, _, err := NewWith(bytes.NewReader(ogg))
 		assert.ErrorIs(t, errChecksumMismatch, err)
 	})
+}
+
+func TestOggReader_ParseHeaderFamily1(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(1, 3, 2, 1, []uint8{0, 1, 2}, nil),
+		}),
+	))
+
+	reader, header, err := NewWith(stream)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(1), header.ChannelMap)
+	assert.Equal(t, uint8(3), header.Channels)
+	assert.Equal(t, OggChannelMapping{
+		StreamCount:  2,
+		CoupledCount: 1,
+		Mapping:      []uint8{0, 1, 2},
+	}, reader.ChannelMapping())
+}
+
+func TestOggReader_ParseHeaderFamily3(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(3, 4, 2, 1, nil, []int16{
+				32767, 0, 0, 0,
+				0, 32767, 0, 0,
+				0, 0, 32767, 0,
+			}),
+		}),
+	))
+
+	reader, header, err := NewWith(stream)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(3), header.ChannelMap)
+	assert.Equal(t, uint8(4), header.Channels)
+	assert.Equal(t, OggChannelMapping{
+		StreamCount:  2,
+		CoupledCount: 1,
+		DemixingMatrix: []int16{
+			32767, 0, 0, 0,
+			0, 32767, 0, 0,
+			0, 0, 32767, 0,
+		},
+	}, reader.ChannelMapping())
+}
+
+func TestOggReader_ChannelMappingReturnsCopy(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(1, 3, 2, 1, []uint8{0, 1, 2}, nil),
+		}),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	mapping := reader.ChannelMapping()
+	mapping.Mapping[0] = 9
+
+	assert.Equal(t, OggChannelMapping{
+		StreamCount:  2,
+		CoupledCount: 1,
+		Mapping:      []uint8{0, 1, 2},
+	}, reader.ChannelMapping())
+}
+
+func TestOggReader_ParseHeaderErrors(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(1, 3, 2, 1, []uint8{0, 1}, nil),
+		}),
+	))
+
+	_, _, err := NewWith(stream)
+	assert.ErrorIs(t, err, errBadIDPageLength)
+}
+
+func TestOggReader_ParseNextPacketMultipleSegmentsOnePage(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xAB}, 300)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(t, 0, 960, 1, splitSegments(payload, 255, 45)),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	packet, header, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, payload, packet)
+	assert.Equal(t, uint64(960), header.GranulePosition)
+}
+
+func TestOggReader_ParseNextPacketContinuedAcrossPages(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xCD}, 300)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(t, 0, 0, 1, splitSegments(payload[:255], 255)),
+		buildOggPage(t, pageHeaderTypeContinuedPacket, 960, 2, splitSegments(payload[255:], 45)),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	packet, header, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, payload, packet)
+	assert.Equal(t, uint64(960), header.GranulePosition)
+}
+
+func TestOggReader_ParseNextPacketSkipsLeadingContinuedPacketAcrossPages(t *testing.T) {
+	discarded := bytes.Repeat([]byte{0xDE}, 300)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(t, pageHeaderTypeContinuedPacket, 0, 1, splitSegments(discarded[:255], 255)),
+		buildOggPage(t, pageHeaderTypeContinuedPacket, 960, 2, [][]byte{
+			discarded[255:],
+			{0xAA, 0xBB},
+		}),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	packet, header, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0xAA, 0xBB}, packet)
+	assert.Equal(t, uint64(960), header.GranulePosition)
+}
+
+func TestOggReader_ParseNextPacketMultiplePacketsOnePage(t *testing.T) {
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(t, 0, 960, 1, [][]byte{
+			{0xAA},
+			{0xBB, 0xCC},
+		}),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	firstPacket, _, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0xAA}, firstPacket)
+
+	secondPacket, _, err := reader.ParseNextPacket()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0xBB, 0xCC}, secondPacket)
+
+	_, _, err = reader.ParseNextPacket()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestOggReader_ParseNextPacketUnexpectedEOF(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xEF}, 255)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(t, 0, 0, 1, splitSegments(payload, 255)),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	_, _, err = reader.ParseNextPacket()
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestOggReader_ParseNextPacketSequenceGapReturnsUnexpectedEOF(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xAB}, 300)
+	stream := bytes.NewReader(buildOggStream(
+		buildOggPage(t, pageHeaderTypeBeginningOfStream, 0, 0, [][]byte{
+			buildOpusIDHeader(0, 2, 0, 0, nil, nil),
+		}),
+		buildOggPage(t, 0, 0, 1, splitSegments(payload[:255], 255)),
+		buildOggPage(t, pageHeaderTypeContinuedPacket, 960, 3, splitSegments(payload[255:], 45)),
+	))
+
+	reader, _, err := NewWith(stream)
+	assert.NoError(t, err)
+
+	_, _, err = reader.ParseNextPacket()
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func buildOggStream(pages ...[]byte) []byte {
+	stream := make([]byte, 0)
+	for _, page := range pages {
+		stream = append(stream, page...)
+	}
+
+	return stream
+}
+
+func buildOggPage(t *testing.T, headerType byte, granule uint64, index uint32, segments [][]byte) []byte {
+	t.Helper()
+	assert.LessOrEqual(t, len(segments), maxPageSegmentSize)
+
+	payloadSize := 0
+	for _, segment := range segments {
+		assert.LessOrEqual(t, len(segment), maxPageSegmentSize)
+		payloadSize += len(segment)
+	}
+
+	page := make([]byte, pageHeaderLen+len(segments)+payloadSize)
+	copy(page[:4], []byte(pageHeaderSignature))
+	page[4] = 0
+	page[5] = headerType
+	binary.LittleEndian.PutUint64(page[6:14], granule)
+	binary.LittleEndian.PutUint32(page[14:18], 1)
+	binary.LittleEndian.PutUint32(page[18:22], index)
+	page[26] = uint8(len(segments)) //nolint:gosec // validated above
+
+	offset := pageHeaderLen
+	for _, segment := range segments {
+		page[offset] = uint8(len(segment)) //nolint:gosec // validated above
+		offset++
+	}
+	for _, segment := range segments {
+		copy(page[offset:], segment)
+		offset += len(segment)
+	}
+
+	checksum := oggChecksum(page)
+	binary.LittleEndian.PutUint32(page[22:26], checksum)
+
+	return page
+}
+
+func buildOpusIDHeader(
+	channelMapFamily, channels, streamCount, coupledCount uint8,
+	mapping []uint8,
+	demixingMatrix []int16,
+) []byte {
+	header := make([]byte, 0, 21+len(mapping)+(2*len(demixingMatrix)))
+	header = append(header, []byte(idPageSignature)...)
+	header = append(header, 1)
+	header = append(header, channels)
+
+	preskip := make([]byte, 2)
+	binary.LittleEndian.PutUint16(preskip, 0x0F00)
+	header = append(header, preskip...)
+
+	sampleRate := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sampleRate, 48000)
+	header = append(header, sampleRate...)
+
+	header = append(header, 0, 0)
+	header = append(header, channelMapFamily)
+
+	switch channelMapFamily {
+	case 1, 2, 255:
+		header = append(header, streamCount, coupledCount)
+		header = append(header, mapping...)
+	case 3:
+		header = append(header, streamCount, coupledCount)
+		for _, coefficient := range demixingMatrix {
+			packed := make([]byte, 2)
+			binary.LittleEndian.PutUint16(packed, uint16(coefficient))
+			header = append(header, packed...)
+		}
+	}
+
+	return header
+}
+
+func splitSegments(in []byte, sizes ...int) [][]byte {
+	segments := make([][]byte, 0, len(sizes))
+	offset := 0
+	for _, size := range sizes {
+		segments = append(segments, append([]byte(nil), in[offset:offset+size]...))
+		offset += size
+	}
+
+	return segments
+}
+
+func oggChecksum(page []byte) uint32 {
+	table := generateChecksumTable()
+	var checksum uint32
+	for index, value := range page {
+		if index >= 22 && index < 26 {
+			value = 0
+		}
+		checksum = (checksum << 8) ^ table[byte(checksum>>24)^value]
+	}
+
+	return checksum
 }


### PR DESCRIPTION
Closes #49.

`pkg/oggreader` currently exposes raw page segments, but Ogg Opus packets can span multiple segments and multiple pages. This change adds a logical packet read path without changing the existing page API.

Overview:
- add `ParseNextPacket()` to reconstruct packets across segments and continued pages
- parse multistream `OpusHead` metadata for channel mapping families `1`, `2`, and `3`
- keep ParseNextPage() semantics unchanged for existing callers
- keep `OggHeader` backward compatible and expose multistream metadata through `ChannelMapping()`
- add coverage for multi-segment packets, continued packets, leading continued packets, page-sequence gaps, and multistream ID headers
