### PR TITLE
Add CELT encoder

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -295,7 +295,11 @@ func interpolateBitsToPulses(
 			if rangeDecoder != nil {
 				skipBit = rangeDecoder.DecodeSymbolLogP(1) != 0
 			} else {
-				rangeEncoder.EncodeSymbolLogP(1, 0)
+				// Encoder keeps every band that fits its threshold; emit 1 so
+				// the decoder stops the skip walk here and codedBands stays
+				// at end.
+				skipBit = true
+				rangeEncoder.EncodeSymbolLogP(1, 1)
 			}
 			if skipBit {
 				codedBands++

--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -48,6 +48,7 @@ func (d *Decoder) computeAllocation(info *frameSideInfo, bits int) allocationSta
 		info.channelCount,
 		info.lm,
 		&d.rangeDecoder,
+		nil,
 	)
 	state.balance = balance
 
@@ -69,6 +70,7 @@ func computeAllocation(
 	channelCount int,
 	lm int,
 	rangeDecoder *rangecoding.Decoder,
+	rangeEncoder *rangecoding.Encoder,
 ) int {
 	if total < 0 {
 		total = 0
@@ -194,6 +196,7 @@ func computeAllocation(
 		channelCount,
 		lm,
 		rangeDecoder,
+		rangeEncoder,
 	)
 }
 
@@ -220,6 +223,7 @@ func interpolateBitsToPulses(
 	channelCount int,
 	lm int,
 	rangeDecoder *rangecoding.Decoder,
+	rangeEncoder *rangecoding.Encoder,
 ) int {
 	allocationFloor := channelCount << bitResolution
 	stereo := boolIndex(channelCount > 1)
@@ -287,7 +291,13 @@ func interpolateBitsToPulses(
 		bandWidth := int(bandEdges[codedBands+1] - bandEdges[band])
 		bandBits := bits[band] + perCoeff*bandWidth + rem
 		if bandBits >= max(threshold[band], allocationFloor+(1<<bitResolution)) {
-			if rangeDecoder.DecodeSymbolLogP(1) != 0 {
+			var skipBit bool
+			if rangeDecoder != nil {
+				skipBit = rangeDecoder.DecodeSymbolLogP(1) != 0
+			} else {
+				rangeEncoder.EncodeSymbolLogP(1, 0)
+			}
+			if skipBit {
 				codedBands++
 				break
 			}
@@ -311,7 +321,13 @@ func interpolateBitsToPulses(
 	// Intensity and dual-stereo symbols are decoded only after codedBands is
 	// known, because their alphabets depend on the surviving band range.
 	if intensityReserved > 0 {
-		value, _ := rangeDecoder.DecodeUniform(uint32(codedBands + 1 - start))
+		var value uint32
+		if rangeDecoder != nil {
+			value, _ = rangeDecoder.DecodeUniform(uint32(codedBands + 1 - start))
+		} else {
+			value = uint32(codedBands)
+			rangeEncoder.EncodeUniform(uint32(codedBands+1-start), value)
+		}
 		*intensity = start + int(value)
 	} else {
 		*intensity = 0
@@ -321,7 +337,12 @@ func interpolateBitsToPulses(
 		dualStereoReserved = 0
 	}
 	if dualStereoReserved > 0 {
-		*dualStereo = int(rangeDecoder.DecodeSymbolLogP(1))
+		if rangeDecoder != nil {
+			*dualStereo = int(rangeDecoder.DecodeSymbolLogP(1))
+		} else {
+			rangeEncoder.EncodeSymbolLogP(1, 0)
+			*dualStereo = 0
+		}
 	} else {
 		*dualStereo = 0
 	}

--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -59,11 +59,11 @@ func analyzeFrame(
 
 	applyPreemphasis(frame, result.preemphasized, &state.preemphasisMem)
 
-	mcdtInput := make([]float32, shortBlockSampleCount+len(frame))
-	copy(mcdtInput, state.prevPCM)
-	copy(mcdtInput[shortBlockSampleCount:], result.preemphasized)
+	mdctInput := make([]float32, shortBlockSampleCount+len(frame))
+	copy(mdctInput, state.prevPCM)
+	copy(mdctInput[shortBlockSampleCount:], result.preemphasized)
 
-	result.mdct = forwardMDCT(mcdtInput)
+	result.mdct = forwardMDCT(mdctInput)
 	if result.mdct == nil {
 		return analysisResult{}, errInvalidFrameSize
 	}

--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+)
+
+const preemphasisCoefficient = 0.85000610
+
+type analysisState struct {
+	prevPCM        []float32
+	preemphasisMem float32
+}
+
+type analysisResult struct {
+	info          frameSideInfo
+	preemphasized []float32
+	mdct          []float32
+	logBandAmp    [maxBands]float32
+}
+
+func newAnalysisState() analysisState {
+	return analysisState{
+		prevPCM: make([]float32, shortBlockSampleCount),
+	}
+}
+
+// analyzeFrame prepares the mono CELT encoder input: applies pre-emphasis,
+// extends the frame with the previous overlap for the MDCT window, runs the
+// forward MDCT, and returns per-band log amplitude for coarse energy coding.
+func analyzeFrame(
+	mode *Mode,
+	frame []float32,
+	startBand int,
+	endBand int,
+	state *analysisState,
+) (analysisResult, error) {
+	lm, err := mode.LMForFrameSampleCount(len(frame))
+	if err != nil {
+		return analysisResult{}, err
+	}
+
+	result := analysisResult{
+		info: frameSideInfo{
+			lm:              lm,
+			startBand:       startBand,
+			endBand:         endBand,
+			channelCount:    1,
+			transient:       false,
+			shortBlockCount: 0,
+			intraEnergy:     false,
+			spread:          defaultSpreadDecision,
+			allocationTrim:  defaultAllocationTrim,
+		},
+		preemphasized: make([]float32, len(frame)),
+	}
+
+	applyPreemphasis(frame, result.preemphasized, &state.preemphasisMem)
+
+	mcdtInput := make([]float32, shortBlockSampleCount+len(frame))
+	copy(mcdtInput, state.prevPCM)
+	copy(mcdtInput[shortBlockSampleCount:], result.preemphasized)
+
+	result.mdct = forwardMDCT(mcdtInput)
+	if result.mdct == nil {
+		return analysisResult{}, errInvalidFrameSize
+	}
+
+	result.logBandAmp = computeBandLogAmp(result.mdct, lm, startBand, endBand)
+	copy(state.prevPCM, result.preemphasized[len(result.preemphasized)-shortBlockSampleCount:])
+
+	return result, nil
+}
+
+func applyPreemphasis(in []float32, out []float32, mem *float32) {
+	prev := *mem
+	for i := range in {
+		current := in[i] * 32768
+		out[i] = current - preemphasisCoefficient*prev
+		prev = current
+	}
+	*mem = prev
+}
+
+// computeBandLogAmp returns the encoder-side quantity that matches the decoder's
+// previousLogE domain: log2(sqrt(sum(x^2))) minus the static mean per band.
+func computeBandLogAmp(freq []float32, lm int, startBand int, endBand int) [maxBands]float32 {
+	logAmp := [maxBands]float32{}
+	scale := 1 << lm
+
+	for band := startBand; band < endBand; band++ {
+		bandStart := scale * int(bandEdges[band])
+		bandEnd := scale * int(bandEdges[band+1])
+
+		energy := float64(1e-27)
+		for i := bandStart; i < bandEnd; i++ {
+			value := float64(freq[i])
+			energy += value * value
+		}
+
+		amplitude := math.Sqrt(energy)
+		logAmp[band] = float32(math.Log2(amplitude)) - energyMeans[band]
+	}
+
+	return logAmp
+}

--- a/internal/celt/cwrs.go
+++ b/internal/celt/cwrs.go
@@ -101,3 +101,47 @@ func cwrsPreviousRow(u []uint32, n int, value0 uint32) {
 	}
 	u[n-1] = value
 }
+
+// encodePulses writes a CWRS index for the PVQ pulse vector y to the range
+// encoder. It is the inverse of decodePulses.
+func encodePulses(y []int, n, k int, rangeEncoder *rangecoding.Encoder) {
+	if k <= 0 {
+		return
+	}
+	index := cwrsEncode(y, n, k)
+	u := cwrsUrow(n, k)
+	total := u[k] + u[k+1]
+	rangeEncoder.EncodeUniform(total, index)
+}
+
+// cwrsEncode maps a PVQ pulse vector to its unique CWRS codeword index.
+// It is the exact inverse of cwrsDecode for a fixed (n, k) codebook.
+func cwrsEncode(y []int, n, k int) uint32 {
+	if n <= 0 || k <= 0 {
+		return 0
+	}
+
+	u := cwrsUrow(n, k)
+	var index uint32
+
+	for j := range n {
+		magnitude := y[j]
+		if magnitude < 0 {
+			magnitude = -magnitude
+		}
+		if magnitude > k {
+			return 0
+		}
+
+		remaining := k - magnitude
+		index += u[remaining]
+		if y[j] < 0 {
+			index += u[k+1]
+		}
+
+		cwrsPreviousRow(u, remaining+2, 0)
+		k = remaining
+	}
+
+	return index
+}

--- a/internal/celt/cwrs_test.go
+++ b/internal/celt/cwrs_test.go
@@ -33,3 +33,43 @@ func TestCWRSDecode(t *testing.T) {
 	decodePulses(y, len(y), 2, &decoder)
 	assert.Equal(t, []int{2, 0, 0}, y)
 }
+
+func TestCWRSEncodeZeroPulses(t *testing.T) {
+	assert.Equal(t, uint32(0), cwrsEncode([]int{0, 0, 0}, 3, 0))
+}
+
+func TestCWRSEncodeRoundTrip(t *testing.T) {
+	n := 4
+	k := 3
+	row := cwrsUrow(n, k)
+	total := row[k] + row[k+1]
+
+	for index := range total {
+		vector := make([]int, n)
+		cwrsDecode(vector, n, k, index, append([]uint32(nil), row...))
+
+		encoded := cwrsEncode(vector, n, k)
+		assert.Equal(t, index, encoded)
+	}
+}
+
+func TestCWRSEncodeDecodeRoundTrip(t *testing.T) {
+	vectors := [][]int{
+		{2, 0, 0},
+		{-2, 0, 0},
+		{1, 1, 0},
+		{1, -1, 0},
+		{0, 1, 1},
+		{0, -1, 1},
+	}
+
+	for _, expected := range vectors {
+		index := cwrsEncode(expected, len(expected), 2)
+
+		got := make([]int, len(expected))
+		row := cwrsUrow(3, 2)
+		cwrsDecode(got, len(got), 2, index, row)
+
+		assert.Equal(t, expected, got)
+	}
+}

--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -1,0 +1,489 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//nolint:cyclop,gocognit,gocyclo,gosec,lll,maintidx,nestif,varnamelen,wastedassign // Keep encoder recursion close to decode/RFC structure.
+package celt
+
+import (
+	"math"
+
+	"github.com/pion/opus/internal/rangecoding"
+)
+
+type bandEncodeState struct {
+	rangeEncoder *rangecoding.Encoder
+	seed         uint32
+	tmpScratch   []float32
+}
+
+func (s *bandEncodeState) floatScratch(n int) []float32 {
+	if cap(s.tmpScratch) < n {
+		s.tmpScratch = make([]float32, n)
+	}
+	s.tmpScratch = s.tmpScratch[:n]
+
+	return s.tmpScratch
+}
+
+func normaliseBandsForEncoding(
+	info *frameSideInfo,
+	mdct []float32,
+	logBandAmp [maxBands]float32,
+) []float32 {
+	out := make([]float32, len(mdct))
+	scale := 1 << info.lm
+
+	for band := info.startBand; band < info.endBand; band++ {
+		start := scale * int(bandEdges[band])
+		end := scale * int(bandEdges[band+1])
+		amp := float32(math.Pow(2, float64(logBandAmp[band]+energyMeans[band])))
+		if amp <= 1e-15 {
+			continue
+		}
+
+		invAmp := 1 / amp
+		for i := start; i < end; i++ {
+			out[i] = mdct[i] * invAmp
+		}
+		renormaliseVector(out[start:end], end-start, normScaling)
+	}
+
+	return out
+}
+
+func quantAllBandsMono(
+	info *frameSideInfo,
+	x []float32,
+	totalBits int,
+	state *bandEncodeState,
+) []byte {
+	blocks := 1
+	if info.transient {
+		blocks = 1 << info.lm
+	}
+	scale := 1 << info.lm
+	frameBins := scale * int(bandEdges[maxBands])
+	norm := make([]float32, frameBins)
+	lowbandScratch := make([]float32, scale*int(bandEdges[maxBands]-bandEdges[maxBands-1]))
+	collapseMasks := make([]byte, maxBands)
+	lowbandOffset := 0
+	updateLowband := true
+	balance := info.allocation.balance
+	for band := info.startBand; band < info.endBand; band++ {
+		tell := int(state.rangeEncoder.TellFrac())
+		if band != info.startBand {
+			balance -= tell
+		}
+		remainingBits := totalBits - tell - 1
+		bandBits := 0
+		if band <= info.allocation.codedBands-1 {
+			currentBalance := balance / min(3, info.allocation.codedBands-band)
+			bandBits = max(0, min(16383, min(remainingBits+1, info.allocation.pulses[band]+currentBalance)))
+		}
+		bandStart := scale * int(bandEdges[band])
+		bandEnd := scale * int(bandEdges[band+1])
+		bandWidth := bandEnd - bandStart
+		if bandStart-bandWidth >= scale*int(bandEdges[info.startBand]) || band == info.startBand+1 {
+			if updateLowband || lowbandOffset == 0 {
+				lowbandOffset = band
+			}
+		}
+		if band == info.startBand+1 && info.startBand+2 <= maxBands {
+			n1 := scale * int(bandEdges[info.startBand+1]-bandEdges[info.startBand])
+			n2 := scale * int(bandEdges[info.startBand+2]-bandEdges[info.startBand+1])
+			offset := scale * int(bandEdges[info.startBand])
+			if n2 > n1 {
+				copy(norm[offset+n1:offset+n2], norm[offset+2*n1-n2:offset+n1])
+			}
+		}
+		effectiveLowband := -1
+		fill := uint(0)
+		if lowbandOffset != 0 && (info.spread != spreadAggressive || blocks > 1 || info.tfChange[band] < 0) {
+			effectiveLowband = max(scale*int(bandEdges[info.startBand]), scale*int(bandEdges[lowbandOffset])-bandWidth)
+			foldStart := lowbandOffset
+			for {
+				foldStart--
+				if scale*int(bandEdges[foldStart]) <= effectiveLowband {
+					break
+				}
+			}
+			foldEnd := lowbandOffset - 1
+			for {
+				foldEnd++
+				if foldEnd >= band || scale*int(bandEdges[foldEnd]) >= effectiveLowband+bandWidth {
+					break
+				}
+			}
+			for fold := foldStart; fold < foldEnd; fold++ {
+				fill |= uint(collapseMasks[fold])
+			}
+		} else {
+			fill = (1 << blocks) - 1
+		}
+		var lowband []float32
+		if effectiveLowband >= 0 {
+			lowband = norm[effectiveLowband:]
+		}
+		mask := quantBandMono(
+			band,
+			x[bandStart:bandEnd],
+			bandWidth,
+			bandBits,
+			info.spread,
+			blocks,
+			info.tfChange[band],
+			lowband,
+			&remainingBits,
+			info.lm,
+			norm[bandStart:],
+			0,
+			1,
+			lowbandScratch,
+			fill,
+			state,
+		)
+		collapseMasks[band] = byte(mask)
+		balance += info.allocation.pulses[band] + tell
+		updateLowband = bandBits > bandWidth<<bitResolution
+	}
+
+	return collapseMasks
+}
+
+func quantBandMono(
+	band int,
+	x []float32,
+	n int,
+	bandBits int,
+	spread int,
+	blocks int,
+	tfChange int,
+	lowband []float32,
+	remainingBits *int,
+	lm int,
+	lowbandOut []float32,
+	level int,
+	gain float32,
+	lowbandScratch []float32,
+	fill uint,
+	state *bandEncodeState,
+) uint {
+	fullBand := x
+	originalN := n
+	nPerBlock := n / blocks
+	originalBlocks := blocks
+	longBlocks := blocks == 1
+	timeDivide := 0
+	recombine := 0
+	collapseMask := uint(0)
+	if n == 1 {
+		sign := uint32(0)
+		if x[0] < 0 {
+			sign = 1
+		}
+		if *remainingBits >= 1<<bitResolution {
+			state.rangeEncoder.EncodeRawBits(1, sign)
+			*remainingBits -= 1 << bitResolution
+		}
+		x[0] = normScaling
+		if sign != 0 {
+			x[0] = -normScaling
+		}
+		if lowbandOut != nil {
+			lowbandOut[0] = x[0]
+		}
+
+		return 1
+	}
+	if level == 0 {
+		if tfChange > 0 {
+			recombine = tfChange
+		}
+		if lowband != nil && (recombine != 0 || (nPerBlock&1) == 0 && tfChange < 0 || originalBlocks > 1) {
+			copy(lowbandScratch[:n], lowband[:n])
+			lowband = lowbandScratch[:n]
+		}
+		for k := range recombine {
+			if lowband != nil {
+				haar1(lowband, n>>k, 1<<k)
+			}
+			fill = bitInterleave(fill)
+		}
+		blocks >>= recombine
+		nPerBlock <<= recombine
+		for (nPerBlock&1) == 0 && tfChange < 0 {
+			if lowband != nil {
+				haar1(lowband, nPerBlock, blocks)
+			}
+			fill |= fill << blocks
+			blocks <<= 1
+			nPerBlock >>= 1
+			timeDivide++
+			tfChange++
+		}
+		originalBlocks = blocks
+	}
+	if level == 0 && originalBlocks > 1 && lowband != nil {
+		tmpState := bandDecodeState{tmpScratch: state.floatScratch(len(lowband))}
+		deinterleaveHadamard(
+			lowband,
+			nPerBlock>>recombine,
+			originalBlocks<<recombine,
+			longBlocks,
+			&tmpState,
+		)
+	}
+	if lm != -1 && shouldSplitBand(band, lm, bandBits) && n > 2 {
+		n >>= 1
+		y := x[n:]
+		x = x[:n]
+		lm--
+		if blocks == 1 {
+			fill = (fill & 1) | (fill << 1)
+		}
+		blocks = (blocks + 1) >> 1
+		pulseCap := logN400[band] + lm*(1<<bitResolution)
+		qn := computeQN(n, bandBits, (pulseCap>>1)-qThetaOffset, pulseCap, false)
+		tell := int(state.rangeEncoder.TellFrac())
+		thetaSym := 0
+		itheta := 0
+		if qn != 1 {
+			thetaSym = quantizeMonoSplitTheta(x, y, qn)
+			encodeBandThetaMono(thetaSym, qn, blocks, state.rangeEncoder)
+			itheta = thetaSym * 16384 / qn
+		}
+		qalloc := int(state.rangeEncoder.TellFrac()) - tell
+		bandBits -= qalloc
+		originalFill := fill
+		delta := 0
+		imid := 0
+		iside := 0
+		switch itheta {
+		case 0:
+			imid = 32767
+			fill &= (1 << blocks) - 1
+			delta = -16384
+		case 16384:
+			iside = 32767
+			fill &= ((1 << blocks) - 1) << blocks
+			delta = 16384
+		default:
+			imid = bitexactCos(itheta)
+			iside = bitexactCos(16384 - itheta)
+			delta = fracMul16((n-1)<<7, bitexactLog2Tan(iside, imid))
+		}
+		mid := float32(imid) / 32768
+		side := float32(iside) / 32768
+		if originalBlocks > 1 && itheta&0x3fff != 0 {
+			if itheta > 8192 {
+				delta -= delta >> (4 - lm)
+			} else {
+				delta = min(0, delta+(n<<bitResolution>>(5-lm)))
+			}
+		}
+		midBits := max(0, min(bandBits, (bandBits-delta)/2))
+		sideBits := bandBits - midBits
+		*remainingBits -= qalloc
+		var nextLowband2 []float32
+		if lowband != nil {
+			nextLowband2 = lowband[n:]
+		}
+		nextLevel := level + 1
+		collapseShift := originalBlocks >> 1
+		rebalance := *remainingBits
+		if midBits >= sideBits {
+			collapseMask = quantBandMono(
+				band,
+				x,
+				n,
+				midBits,
+				spread,
+				blocks,
+				tfChange,
+				lowband,
+				remainingBits,
+				lm,
+				nil,
+				nextLevel,
+				gain*mid,
+				lowbandScratch,
+				fill,
+				state,
+			)
+			rebalance = midBits - (rebalance - *remainingBits)
+			if rebalance > 3<<bitResolution && itheta != 0 {
+				sideBits += rebalance - (3 << bitResolution)
+			}
+			collapseMask |= quantBandMono(
+				band,
+				y,
+				n,
+				sideBits,
+				spread,
+				blocks,
+				tfChange,
+				nextLowband2,
+				remainingBits,
+				lm,
+				nil,
+				nextLevel,
+				gain*side,
+				lowbandScratch,
+				originalFill>>blocks,
+				state,
+			) << collapseShift
+		} else {
+			collapseMask = quantBandMono(
+				band,
+				y,
+				n,
+				sideBits,
+				spread,
+				blocks,
+				tfChange,
+				nextLowband2,
+				remainingBits,
+				lm,
+				nil,
+				nextLevel,
+				gain*side,
+				lowbandScratch,
+				originalFill>>blocks,
+				state,
+			) << collapseShift
+			rebalance = sideBits - (rebalance - *remainingBits)
+			if rebalance > 3<<bitResolution && itheta != 16384 {
+				midBits += rebalance - (3 << bitResolution)
+			}
+			collapseMask |= quantBandMono(
+				band,
+				x,
+				n,
+				midBits,
+				spread,
+				blocks,
+				tfChange,
+				lowband,
+				remainingBits,
+				lm,
+				nil,
+				nextLevel,
+				gain*mid,
+				lowbandScratch,
+				fill,
+				state,
+			)
+		}
+	} else {
+		q := bitsToPulses(band, lm, bandBits)
+		currentBits := pulsesToBits(band, lm, q)
+		*remainingBits -= currentBits
+		for *remainingBits < 0 && q > 0 {
+			*remainingBits += currentBits
+			q--
+			currentBits = pulsesToBits(band, lm, q)
+			*remainingBits -= currentBits
+		}
+		if q != 0 {
+			collapseMask = algQuant(x, n, getPulses(q), spread, blocks, state.rangeEncoder, gain)
+		} else {
+			mask := uint(1<<blocks) - 1
+			fill &= mask
+			if fill == 0 {
+				for i := range n {
+					x[i] = 0
+				}
+			} else {
+				if lowband == nil {
+					for i := range n {
+						state.seed = lcgRand(state.seed)
+						x[i] = float32(int32(state.seed) >> 20)
+					}
+					collapseMask = mask
+				} else {
+					for i := range n {
+						state.seed = lcgRand(state.seed)
+						noise := float32(1.0 / 256)
+						if state.seed&0x8000 == 0 {
+							noise = -noise
+						}
+						x[i] = lowband[i] + noise
+					}
+					collapseMask = fill
+				}
+				renormaliseVector(x, n, gain)
+			}
+		}
+	}
+	if level == 0 {
+		x = fullBand
+		if originalBlocks > 1 {
+			tmpState := bandDecodeState{tmpScratch: state.floatScratch(len(x))}
+			interleaveHadamard(x, nPerBlock>>recombine, originalBlocks<<recombine, longBlocks, &tmpState)
+		}
+		nPerBlock = originalN / originalBlocks
+		blocks = originalBlocks
+		for range timeDivide {
+			blocks >>= 1
+			nPerBlock <<= 1
+			collapseMask |= collapseMask >> blocks
+			haar1(x, nPerBlock, blocks)
+		}
+		for k := range recombine {
+			collapseMask = bitDeinterleave(collapseMask)
+			haar1(x, originalN>>k, 1<<k)
+		}
+		blocks <<= recombine
+		if lowbandOut != nil {
+			scale := float32(math.Sqrt(float64(originalN)))
+			for i := range originalN {
+				lowbandOut[i] = scale * x[i]
+			}
+		}
+		collapseMask &= (1 << blocks) - 1
+	}
+
+	return collapseMask
+}
+
+func quantizeMonoSplitTheta(x []float32, y []float32, qn int) int {
+	if qn <= 1 {
+		return 0
+	}
+
+	var ex, ey float64
+	for i := range x {
+		ex += float64(x[i] * x[i])
+		ey += float64(y[i] * y[i])
+	}
+	if ex+ey <= 1e-30 {
+		return 0
+	}
+
+	theta := math.Atan2(math.Sqrt(ey), math.Sqrt(ex))
+	symbol := int(math.Round(theta * float64(qn) / (0.5 * math.Pi)))
+
+	return min(qn, max(0, symbol))
+}
+
+func encodeBandThetaMono(symbol int, qn int, blocks int, rangeEncoder *rangecoding.Encoder) {
+	if blocks > 1 {
+		rangeEncoder.EncodeUniform(uint32(qn+1), uint32(symbol))
+
+		return
+	}
+
+	half := qn >> 1
+	total := uint32((half + 1) * (half + 1))
+	if symbol <= half {
+		low := symbol * (symbol + 1) >> 1
+		freq := symbol + 1
+		rangeEncoder.EncodeCumulative(uint32(low), uint32(low+freq), total)
+
+		return
+	}
+
+	freq := qn + 1 - symbol
+	low := int(total) - (freq * (freq + 1) >> 1)
+	rangeEncoder.EncodeCumulative(uint32(low), uint32(low+freq), total)
+}

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -1,0 +1,419 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//nolint:gosec // G115/G602: integer conversions are bounded by CELT frame and band sizes.
+package celt
+
+import "github.com/pion/opus/internal/rangecoding"
+
+// Encoder encodes PCM audio into CELT-only Opus frames.
+//
+// It maintains the inter-frame state required by RFC 6716 Section 5.3:
+// the previous log-energy per band used to predict coarse energy deltas
+// (Section 5.3.3), and the analysis state (pre-emphasis memory and MDCT
+// overlap buffer) needed to produce a continuous bitstream across frames.
+//
+// The encoder and decoder share the same deterministic bit-allocation
+// algorithm (computeAllocation, Section 5.3.4). After encoding a sequence
+// of symbols the value of rng must match the decoder's rng exactly
+// (RFC 6716 Section 5.1) — use FinalRange on both sides to verify this
+// invariant during testing.
+type Encoder struct {
+	mode         *Mode
+	rangeEncoder rangecoding.Encoder
+	rng          uint32
+
+	previousLogE  [2][maxBands]float32
+	previousLogE1 [2][maxBands]float32
+	previousLogE2 [2][maxBands]float32
+
+	analysis analysisState
+}
+
+func NewEncoder() Encoder {
+	encoder := Encoder{mode: DefaultMode()}
+	encoder.Reset()
+
+	return encoder
+}
+
+func (e *Encoder) Reset() {
+	e.mode = DefaultMode()
+	e.rangeEncoder = rangecoding.Encoder{}
+	e.rng = 0
+	e.analysis = newAnalysisState()
+
+	clear(e.previousLogE[0][:])
+	clear(e.previousLogE[1][:])
+
+	for channel := range e.previousLogE1 {
+		for band := range e.previousLogE1[channel] {
+			e.previousLogE1[channel][band] = -28
+			e.previousLogE2[channel][band] = -28
+		}
+	}
+}
+
+func (e *Encoder) Mode() *Mode {
+	if e.mode == nil {
+		e.mode = DefaultMode()
+	}
+
+	return e.mode
+}
+
+func (e *Encoder) encodeCoarseEnergy(info *frameSideInfo, targetLogE [2][maxBands]float32) {
+	probModel := eProbModel[info.lm][boolIndex(info.intraEnergy)]
+	previousBandPrediction := [2]float32{}
+	coef := energyPredictionCoefficients[info.lm]
+	beta := energyBetaCoefficients[info.lm]
+	if info.intraEnergy {
+		coef = 0
+		beta = energyIntraBeta
+	}
+	info.coarseEnergy = e.previousLogE
+	for band := info.startBand; band < info.endBand; band++ {
+		for channel := range info.channelCount {
+			oldEnergy := max(float32(-9), e.previousLogE[channel][band])
+			predicted := coef*oldEnergy + previousBandPrediction[channel]
+			q := quantizeCoarseEnergyDelta(targetLogE[channel][band] - predicted)
+			qEncoded := e.encodeCoarseEnergyDelta(info, probModel[:], band, q)
+			qf := float32(qEncoded)
+			energy := predicted + qf
+			e.previousLogE[channel][band] = energy
+			info.coarseEnergy[channel][band] = energy
+			previousBandPrediction[channel] += qf - beta*qf
+		}
+	}
+	if info.channelCount == 1 {
+		copy(e.previousLogE[1][:], e.previousLogE[0][:])
+	}
+}
+
+// encodeSilenceFlag writes the RFC 6716 Table 56 silence flag.
+func (e *Encoder) encodeSilenceFlag() {
+	if e.rangeEncoder.Tell() == 1 {
+		e.rangeEncoder.EncodeSymbolLogP(15, 0)
+	}
+}
+
+// encodePostFilter writes the disabled RFC 6716 post-filter symbol.
+func (e *Encoder) encodePostFilter(info *frameSideInfo) {
+	if info.startBand == 0 && e.rangeEncoder.Tell()+16 <= info.totalBits {
+		e.rangeEncoder.EncodeSymbolLogP(1, 0)
+	}
+}
+
+// encodeTransientFlag writes the RFC 6716 Section 4.3.1 transient flag (no transient).
+func (e *Encoder) encodeTransientFlag(info *frameSideInfo) {
+	if info.lm > 0 && e.rangeEncoder.Tell()+3 <= info.totalBits {
+		e.rangeEncoder.EncodeSymbolLogP(3, 0)
+	}
+}
+
+// encodeIntraEnergyFlag writes the RFC 6716 Section 4.3.2.1 intra flag (inter).
+func (e *Encoder) encodeIntraEnergyFlag(info *frameSideInfo) {
+	if e.rangeEncoder.Tell()+3 <= info.totalBits {
+		e.rangeEncoder.EncodeSymbolLogP(3, 0)
+	}
+}
+
+// encodeTimeFrequencyChanges writes zero tf_change for all bands.
+func (e *Encoder) encodeTimeFrequencyChanges(info *frameSideInfo) {
+	logP := firstTimeFrequencyChangeLogP
+	if info.transient {
+		logP = firstTransientFrequencyChangeLogP
+	}
+
+	budget := info.totalBits
+	tell := e.rangeEncoder.Tell()
+	tfSelectReserved := info.lm > 0 && tell+uint(logP)+1 <= budget
+	if tfSelectReserved {
+		budget--
+	}
+
+	for band := info.startBand; band < info.endBand; band++ {
+		if tell+uint(logP) <= budget {
+			e.rangeEncoder.EncodeSymbolLogP(uint(logP), 0)
+			tell = e.rangeEncoder.Tell()
+		}
+
+		if info.transient {
+			logP = nextTransientFrequencyChangeLogP
+		} else {
+			logP = nextTimeFrequencyChangeLogP
+		}
+	}
+
+	table := tfSelectTable[info.lm]
+	if tfSelectReserved &&
+		table[4*boolIndex(info.transient)] !=
+			table[4*boolIndex(info.transient)+2] {
+		e.rangeEncoder.EncodeSymbolLogP(1, 0)
+	}
+}
+
+// encodeSpread writes the default spread decision.
+func (e *Encoder) encodeSpread(info *frameSideInfo) {
+	if e.rangeEncoder.Tell()+4 <= info.totalBits {
+		e.rangeEncoder.EncodeSymbolWithICDF(icdfSpread, uint32(info.spread))
+	}
+}
+
+// encodeDynamicAllocation writes zero boost for all bands.
+func (e *Encoder) encodeDynamicAllocation(info *frameSideInfo) uint {
+	totalBitsEighth := info.totalBits << bitResolution
+	dynamicAllocationLogP := initialDynamicAllocationLogP
+	tellFrac := e.rangeEncoder.TellFrac()
+
+	for band := info.startBand; band < info.endBand; band++ {
+		width := info.channelCount * (int(bandEdges[band+1]-bandEdges[band]) << info.lm)
+		quanta := min(width<<bitResolution, max(allocationTrimBitCost<<bitResolution, width))
+		quantaBits := uint(quanta)
+
+		for tellFrac+uint(dynamicAllocationLogP<<bitResolution) < totalBitsEighth {
+			if quantaBits >= totalBitsEighth {
+				totalBitsEighth = 0
+			} else {
+				totalBitsEighth -= quantaBits
+			}
+
+			break
+		}
+	}
+
+	return totalBitsEighth
+}
+
+// encodeAllocationTrim writes the default allocation trim.
+func (e *Encoder) encodeAllocationTrim(info *frameSideInfo, totalBitsEighth uint) {
+	if e.rangeEncoder.TellFrac()+uint(allocationTrimBitCost<<bitResolution) <= totalBitsEighth {
+		e.rangeEncoder.EncodeSymbolWithICDF(icdfAllocationTrim, uint32(info.allocationTrim))
+	}
+}
+
+// EncodeFrame encodes one CELT frame from float PCM.
+func (e *Encoder) EncodeFrame(
+	pcm []float32,
+	frameBytes int,
+	startBand int,
+	endBand int,
+) ([]byte, error) {
+	if e.Mode() == nil {
+		e.mode = DefaultMode()
+	}
+
+	if len(pcm) != shortBlockSampleCount<<e.mode.MaxLM() {
+		return nil, errInvalidFrameSize
+	}
+	if startBand < 0 || startBand >= e.mode.BandCount() {
+		return nil, errInvalidBand
+	}
+	if endBand <= startBand || endBand > e.mode.BandCount() {
+		return nil, errInvalidBand
+	}
+	_ = frameBytes
+
+	e.rangeEncoder.Init()
+
+	analysis, err := analyzeFrame(e.mode, pcm, startBand, endBand, &e.analysis)
+	if err != nil {
+		return nil, err
+	}
+
+	info := analysis.info
+	info.totalBits = uint(frameBytes) * 8
+
+	if e.rangeEncoder.Tell() > info.totalBits {
+		return e.rangeEncoder.Done(), nil
+	}
+
+	e.encodeSilenceFlag()
+	e.encodePostFilter(&info)
+	e.encodeTransientFlag(&info)
+	e.encodeIntraEnergyFlag(&info)
+
+	var targetLogE [2][maxBands]float32
+	targetLogE[0] = analysis.logBandAmp
+	e.encodeCoarseEnergy(&info, targetLogE)
+
+	e.encodeTimeFrequencyChanges(&info)
+	e.encodeSpread(&info)
+	totalBitsEighth := e.encodeDynamicAllocation(&info)
+	e.encodeAllocationTrim(&info, totalBitsEighth)
+
+	tellFrac := int(e.rangeEncoder.TellFrac())
+	bits := (int(info.totalBits) << bitResolution) - tellFrac - 1
+	info.antiCollapseRsv = 0
+	bits -= info.antiCollapseRsv
+	info.allocation = e.computeAllocationMono(&info, bits)
+	e.encodeFineEnergy(&info, info.allocation.fineQuant, targetLogE)
+
+	totalBits := (int(info.totalBits) << bitResolution) - info.antiCollapseRsv
+	shape := normaliseBandsForEncoding(&info, analysis.mdct, analysis.logBandAmp)
+	bandState := bandEncodeState{
+		rangeEncoder: &e.rangeEncoder,
+		seed:         e.rng,
+	}
+	_ = quantAllBandsMono(&info, shape, totalBits, &bandState)
+
+	bitsLeft := int(info.totalBits) - int(e.rangeEncoder.Tell())
+	e.finalizeFineEnergy(&info, info.allocation.fineQuant, info.allocation.finePriority, targetLogE, bitsLeft)
+
+	e.rng = e.rangeEncoder.FinalRange()
+
+	return e.rangeEncoder.Done(), nil
+}
+
+func smallEnergySymbol(delta int) uint32 {
+	switch {
+	case delta < 0:
+		return 1
+	case delta > 0:
+		return 2
+	default:
+		return 0
+	}
+}
+
+func (e *Encoder) encodeCoarseEnergyDelta(info *frameSideInfo, probModel []uint8, band int, delta int) int {
+	tell := e.rangeEncoder.Tell()
+	if tell >= info.totalBits {
+		return -1
+	}
+
+	bitsLeft := info.totalBits - tell
+	switch {
+	case bitsLeft >= 15:
+		probIndex := 2 * min(band, maxBands-1)
+		e.rangeEncoder.EncodeLaplace(
+			uint32(probModel[probIndex])<<7,
+			uint32(probModel[probIndex+1])<<6,
+			delta,
+		)
+
+		return delta
+	case bitsLeft >= 2:
+		if delta < -1 {
+			delta = -1
+		} else if delta > 1 {
+			delta = 1
+		}
+		e.rangeEncoder.EncodeSymbolWithICDF(icdfSmallEnergy, smallEnergySymbol(delta))
+
+		return delta
+	default:
+		if delta < 0 {
+			e.rangeEncoder.EncodeSymbolLogP(1, 1)
+
+			return -1
+		}
+		e.rangeEncoder.EncodeSymbolLogP(1, 0)
+
+		return 0
+	}
+}
+
+func quantizeCoarseEnergyDelta(target float32) int {
+	if target >= 0 {
+		return int(target + 0.5)
+	}
+
+	return -int(-target + 0.5)
+}
+
+func clampFineEnergySymbol(value int, bits int) int {
+	if value < 0 {
+		return 0
+	}
+	maxValue := (1 << bits) - 1
+	if value > maxValue {
+		return maxValue
+	}
+
+	return value
+}
+
+func fineEnergyStep(bits int) float32 {
+	return float32(uint(1)<<(14-bits)) / 16384
+}
+
+func (e *Encoder) encodeFineEnergy(info *frameSideInfo, fineQuant [maxBands]int, targetLogE [2][maxBands]float32) {
+	for band := info.startBand; band < info.endBand; band++ {
+		if fineQuant[band] <= 0 {
+			continue
+		}
+
+		step := fineEnergyStep(fineQuant[band])
+		for channel := range info.channelCount {
+			residual := targetLogE[channel][band] - e.previousLogE[channel][band]
+			q2 := clampFineEnergySymbol(int((residual+0.5)/step), fineQuant[band])
+
+			e.rangeEncoder.EncodeRawBits(uint(fineQuant[band]), uint32(q2))
+
+			offset := (float32(q2)+0.5)*step - 0.5
+			e.previousLogE[channel][band] += offset
+		}
+	}
+
+	if info.channelCount == 1 {
+		copy(e.previousLogE[1][:], e.previousLogE[0][:])
+	}
+}
+
+func (e *Encoder) computeAllocationMono(info *frameSideInfo, bits int) allocationState {
+	state := allocationState{bits: bits}
+	caps := allocationCaps(info.lm, info.channelCount)
+	balance := 0
+	state.codedBands = computeAllocation(
+		info.startBand,
+		info.endBand,
+		info.bandBoost[:],
+		caps[:],
+		info.allocationTrim,
+		&state.intensity,
+		&state.dualStereo,
+		bits,
+		&balance,
+		state.pulses[:],
+		state.fineQuant[:],
+		state.finePriority[:],
+		info.channelCount,
+		info.lm,
+		nil,
+		&e.rangeEncoder,
+	)
+	state.balance = balance
+
+	return state
+}
+
+func (e *Encoder) finalizeFineEnergy(
+	info *frameSideInfo,
+	fineQuant [maxBands]int,
+	finePriority [maxBands]int,
+	targetLogE [2][maxBands]float32,
+	bitsLeft int,
+) {
+	for priority := range 2 {
+		for band := info.startBand; band < info.endBand && bitsLeft >= info.channelCount; band++ {
+			if fineQuant[band] >= maxFineBits || finePriority[band] != priority {
+				continue
+			}
+			step := float32(uint(1)<<(14-fineQuant[band]-1)) / 16384
+			for channel := range info.channelCount {
+				q2 := uint32(0)
+				if targetLogE[channel][band]-e.previousLogE[channel][band] >= 0 {
+					q2 = 1
+				}
+				e.rangeEncoder.EncodeRawBits(1, q2)
+				offset := (float32(q2) - 0.5) * step
+				e.previousLogE[channel][band] += offset
+				bitsLeft--
+			}
+		}
+	}
+	if info.channelCount == 1 {
+		copy(e.previousLogE[1][:], e.previousLogE[0][:])
+	}
+}

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -160,26 +160,22 @@ func (e *Encoder) encodeSpread(info *frameSideInfo) {
 	}
 }
 
-// encodeDynamicAllocation writes zero boost for all bands.
+// encodeDynamicAllocation mirrors decodeDynamicAllocation by emitting a zero
+// boost flag per band while budget allows. The decoder reads one flag per
+// band per RFC 6716 Section 4.3.3, so the encoder must emit the matching
+// flags in the same order to keep the range coder in sync — even when no
+// boost is applied.
 func (e *Encoder) encodeDynamicAllocation(info *frameSideInfo) uint {
 	totalBitsEighth := info.totalBits << bitResolution
 	dynamicAllocationLogP := initialDynamicAllocationLogP
 	tellFrac := e.rangeEncoder.TellFrac()
 
 	for band := info.startBand; band < info.endBand; band++ {
-		width := info.channelCount * (int(bandEdges[band+1]-bandEdges[band]) << info.lm)
-		quanta := min(width<<bitResolution, max(allocationTrimBitCost<<bitResolution, width))
-		quantaBits := uint(quanta)
-
-		for tellFrac+uint(dynamicAllocationLogP<<bitResolution) < totalBitsEighth {
-			if quantaBits >= totalBitsEighth {
-				totalBitsEighth = 0
-			} else {
-				totalBitsEighth -= quantaBits
-			}
-
-			break
+		if tellFrac+uint(dynamicAllocationLogP<<bitResolution) < totalBitsEighth {
+			e.rangeEncoder.EncodeSymbolLogP(uint(dynamicAllocationLogP), 0)
+			tellFrac = e.rangeEncoder.TellFrac()
 		}
+		info.bandBoost[band] = 0
 	}
 
 	return totalBitsEighth
@@ -212,7 +208,6 @@ func (e *Encoder) EncodeFrame(
 	if endBand <= startBand || endBand > e.mode.BandCount() {
 		return nil, errInvalidBand
 	}
-	_ = frameBytes
 
 	e.rangeEncoder.Init()
 

--- a/internal/celt/encoder_test.go
+++ b/internal/celt/encoder_test.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeFrameRoundTripMono20ms(t *testing.T) {
+	encoder := NewEncoder()
+	decoder := NewDecoder()
+
+	frameSampleCount := shortBlockSampleCount << maxLM
+	frameBytes := 60
+
+	pcm := make([]float32, frameSampleCount)
+	for i := range pcm {
+		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
+	}
+
+	for i := range 3 {
+		data, err := encoder.EncodeFrame(pcm, frameBytes, 0, maxBands)
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+		assert.LessOrEqual(t, len(data), frameBytes,
+			"encoded frame should not exceed byte budget")
+
+		out := make([]float32, frameSampleCount)
+		err = decoder.Decode(data, out, false, 1, frameSampleCount, 0, maxBands)
+		require.NoError(t, err)
+
+		energy := float32(vectorEnergy(out))
+		t.Logf("frame %d: encoded %d bytes, output energy %f", i, len(data), energy)
+		assert.Greater(t, float64(energy), 1e-6,
+			"decoded frame %d should have non-zero energy", i)
+	}
+}
+
+func TestEncodeFrameRoundTripMono20msTightBudget(t *testing.T) {
+	encoder := NewEncoder()
+	decoder := NewDecoder()
+
+	frameSampleCount := shortBlockSampleCount << maxLM
+	frameBytes := 10
+
+	pcm := make([]float32, frameSampleCount)
+	for i := range pcm {
+		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
+	}
+
+	data, err := encoder.EncodeFrame(pcm, frameBytes, 0, maxBands)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+	assert.LessOrEqual(t, len(data), frameBytes)
+
+	out := make([]float32, frameSampleCount)
+	err = decoder.Decode(data, out, false, 1, frameSampleCount, 0, maxBands)
+	require.NoError(t, err)
+
+	energy := float32(vectorEnergy(out))
+	t.Logf("tight budget: encoded %d bytes, output energy %f", len(data), energy)
+	assert.Greater(t, float64(energy), 1e-6,
+		"decoded frame should have non-zero energy even on tight budget")
+}
+
+func TestEncodeFrameMonoPersistence(t *testing.T) {
+	encoder := NewEncoder()
+	decoder := NewDecoder()
+
+	frameSampleCount := shortBlockSampleCount << maxLM
+	frameBytes := 60
+
+	pcm := make([]float32, frameSampleCount)
+	for i := range pcm {
+		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
+	}
+
+	data1, err := encoder.EncodeFrame(pcm, frameBytes, 0, maxBands)
+	require.NoError(t, err)
+
+	out1 := make([]float32, frameSampleCount)
+	require.NoError(t, decoder.Decode(data1, out1, false, 1, frameSampleCount, 0, maxBands))
+
+	var out1b float64
+	for i := range frameSampleCount {
+		out1b += float64(out1[i])
+	}
+
+	data2, err := encoder.EncodeFrame(pcm, frameBytes, 0, maxBands)
+	require.NoError(t, err)
+
+	out2 := make([]float32, frameSampleCount)
+	require.NoError(t, decoder.Decode(data2, out2, false, 1, frameSampleCount, 0, maxBands))
+
+	var out2b float64
+	for i := range frameSampleCount {
+		out2b += float64(out2[i])
+	}
+
+	t.Logf("frame1 sum=%f frame2 sum=%f", out1b, out2b)
+}
+
+func TestEncodeFrameMonoRngStability(t *testing.T) {
+	encoder := NewEncoder()
+	frameSampleCount := shortBlockSampleCount << maxLM
+	frameBytes := 60
+
+	pcm := make([]float32, frameSampleCount)
+	for i := range pcm {
+		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
+	}
+
+	for range 3 {
+		data, err := encoder.EncodeFrame(pcm, frameBytes, 0, maxBands)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, data)
+		_ = encoder.rangeEncoder.FinalRange()
+	}
+}

--- a/internal/celt/mdct.go
+++ b/internal/celt/mdct.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+)
+
+// forwardComplexDFT inverts inverseComplexDFT using the standard
+// conjugate-sign change and 1/N scaling factor.
+func forwardComplexDFT(in []complex32) []complex32 {
+	n := len(in)
+	out := make([]complex32, n)
+	if n == 0 {
+		return out
+	}
+
+	scale := float32(1) / float32(n)
+	for k := range n {
+		sumR := float32(0)
+		sumI := float32(0)
+		for m, value := range in {
+			angle := 2 * math.Pi * float64(k*m) / float64(n)
+			cosine := float32(math.Cos(angle))
+			sine := float32(math.Sin(angle))
+			sumR += value.r*cosine + value.i*sine
+			sumI += value.i*cosine - value.r*sine
+		}
+		out[k] = complex32{
+			r: sumR * scale,
+			i: sumI * scale,
+		}
+	}
+
+	return out
+}
+
+// forwardMDCT inverts the current inverseMDCT implementation.
+//
+// The input shape matches the decoder's IMDCT output: a CELT frame of N MDCT
+// bins maps to N+overlap time samples, where overlap is always 120 samples.
+// This helper expects exactly that time-domain layout and returns the original
+// N MDCT bins.
+//
+// A later optimization can replace the O(N^2) complex DFT with an FFT without
+// changing the surrounding packing/rotation steps.
+//
+//nolint:cyclop // Mirrors the RFC 6716 Section 4.3.7 IMDCT structure step-for-step.
+func forwardMDCT(time []float32) []float32 {
+	overlap := shortBlockSampleCount
+	if len(time) <= overlap {
+		return nil
+	}
+
+	frameSampleCount := len(time) - overlap
+	if frameSampleCount <= 0 || frameSampleCount%2 != 0 {
+		return nil
+	}
+
+	n2 := frameSampleCount
+	n := 2 * n2
+	n4 := n >> 2
+	leftPlain := n4 - overlap/2
+	sine := float32(2 * math.Pi * 0.125 / float64(n))
+
+	deshuffled := make([]float32, n2)
+
+	for i := 0; i < overlap/2; i++ {
+		windowValue := celtWindow(i)
+		if windowValue == 0 {
+			continue
+		}
+		// inverseMDCT: out[i] = -celtWindow(i) * deshuffled[overlap/2-1-i]
+		deshuffled[overlap/2-1-i] = -time[i] / windowValue
+	}
+
+	for i := overlap / 2; i < n4; i++ {
+		deshuffled[i] = time[overlap/2+i]
+	}
+
+	for i := range leftPlain {
+		deshuffled[n4+i] = time[n4+overlap/2+i]
+	}
+
+	for i := 0; i < overlap/2; i++ {
+		windowValue := celtWindow(i)
+		if windowValue == 0 {
+			continue
+		}
+		// inverseMDCT: out[n2+overlap-1-i] = celtWindow(i) * deshuffled[n2-overlap/2+i]
+		deshuffled[n2-overlap/2+i] = time[n2+overlap-1-i] / windowValue
+	}
+
+	postRotated := make([]float32, n2)
+	for i := range n4 {
+		postRotated[2*i] = -deshuffled[2*i]
+		postRotated[n2-1-2*i] = deshuffled[2*i+1]
+	}
+
+	fftOut := make([]complex32, n4)
+	for i := range n4 {
+		yr, yi := undoMDCTShear(postRotated[2*i], postRotated[2*i+1], sine)
+		cosine := float32(math.Cos(2 * math.Pi * float64(i) / float64(n)))
+		sineQuarter := float32(math.Cos(2 * math.Pi * float64(n4-i) / float64(n)))
+
+		fftOut[i] = complex32{
+			r: yr*cosine + yi*sineQuarter,
+			i: yi*cosine - yr*sineQuarter,
+		}
+	}
+
+	preRotated := forwardComplexDFT(fftOut)
+	freq := make([]float32, n2)
+
+	for i, value := range preRotated {
+		yr, yi := undoMDCTShear(value.r, value.i, sine)
+		cosine := float32(math.Cos(2 * math.Pi * float64(i) / float64(n)))
+		sineQuarter := float32(math.Cos(2 * math.Pi * float64(n4-i) / float64(n)))
+		xp1 := sineQuarter*yr - cosine*yi
+		xp2 := -cosine*yr - sineQuarter*yi
+		freq[2*i] = xp1
+		freq[n2-1-2*i] = xp2
+	}
+
+	return freq
+}
+
+func undoMDCTShear(a, b, sine float32) (float32, float32) {
+	denominator := 1 + sine*sine
+
+	return (a + b*sine) / denominator, (b - a*sine) / denominator
+}

--- a/internal/celt/mdct_test.go
+++ b/internal/celt/mdct_test.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+package celt
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForwardComplexDFTRoundTrip(t *testing.T) {
+	input := []complex32{
+		{r: 1.0, i: 0.0},
+		{r: -0.25, i: 0.75},
+		{r: 0.5, i: -0.5},
+		{r: 0.125, i: 0.25},
+	}
+	forward := forwardComplexDFT(input)
+	recovered := inverseComplexDFT(forward)
+	require.Len(t, recovered, len(input))
+	assertComplexSliceClose(t, input, recovered, 1e-4)
+}
+
+func TestForwardMDCTInvertsInverseMDCT(t *testing.T) {
+	testCases := []int{
+		shortBlockSampleCount,
+		shortBlockSampleCount << 1,
+		shortBlockSampleCount << 2,
+		shortBlockSampleCount << 3,
+	}
+	for _, frameSampleCount := range testCases {
+		t.Run(frameSampleCountName(frameSampleCount), func(t *testing.T) {
+			freq := make([]float32, frameSampleCount)
+			for i := range freq {
+				freq[i] = float32(math.Sin(0.013*float64(i)) + 0.25*math.Cos(0.037*float64(i)))
+			}
+			time := inverseMDCT(freq)
+			recovered := forwardMDCT(time)
+			require.Len(t, recovered, len(freq))
+			assertFloat32SliceClose(t, freq, recovered, 1e-3)
+		})
+	}
+}
+
+func TestForwardMDCTZero(t *testing.T) {
+	freq := make([]float32, shortBlockSampleCount<<1)
+	time := inverseMDCT(freq)
+	recovered := forwardMDCT(time)
+	require.Len(t, recovered, len(freq))
+	assertFloat32SliceClose(t, freq, recovered, 1e-7)
+}
+
+func TestForwardMDCTInvalidInput(t *testing.T) {
+	assert.Nil(t, forwardMDCT(nil))
+	assert.Nil(t, forwardMDCT(make([]float32, shortBlockSampleCount)))
+	assert.Nil(t, forwardMDCT(make([]float32, shortBlockSampleCount+1)))
+}
+
+func assertFloat32SliceClose(t *testing.T, expected, actual []float32, tolerance float64) {
+	t.Helper()
+	require.Len(t, actual, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i], actual[i], tolerance, "index %d", i)
+	}
+}
+
+func assertComplexSliceClose(t *testing.T, expected, actual []complex32, tolerance float64) {
+	t.Helper()
+	require.Len(t, actual, len(expected))
+	for i := range expected {
+		assert.InDelta(t, expected[i].r, actual[i].r, tolerance, "real index %d", i)
+		assert.InDelta(t, expected[i].i, actual[i].i, tolerance, "imag index %d", i)
+	}
+}
+
+func frameSampleCountName(frameSampleCount int) string {
+	return "frame_" + strconv.Itoa(frameSampleCount)
+}

--- a/internal/celt/pvq.go
+++ b/internal/celt/pvq.go
@@ -131,6 +131,76 @@ func expRotation(x []float32, length int, direction int, stride int, pulses int,
 	}
 }
 
+// pvqSearch finds the best PVQ pulse vector y for target x with K pulses.
+// Uses greedy per-pulse allocation: each pulse goes to the dimension that
+// maximizes (x[i]·y[i])^2 / ||y||^2.
+func pvqSearch(x []float32, n, k int) []int {
+	y := make([]int, n)
+
+	absX := make([]float32, n)
+	sign := make([]float32, n)
+	for i := range n {
+		if x[i] >= 0 {
+			absX[i] = x[i]
+			sign[i] = 1
+		} else {
+			absX[i] = -x[i]
+			sign[i] = -1
+		}
+	}
+
+	var dot, ener float32
+	for range k {
+		bestScore := float32(-1)
+		bestIdx := 0
+		for i := range n {
+			newDot := dot + absX[i]
+			newEner := ener + float32(2*y[i]+1)
+			score := (newDot * newDot) / newEner
+			if score > bestScore {
+				bestScore = score
+				bestIdx = i
+			}
+		}
+		y[bestIdx]++
+		dot += absX[bestIdx]
+		ener += float32(2*y[bestIdx] - 1)
+	}
+
+	for i := range n {
+		if sign[i] < 0 {
+			y[i] = -y[i]
+		}
+	}
+
+	return y
+}
+
+// algQuant encodes the PVQ pulse vector for band shape and writes it to the
+// range encoder. It is the encoder-side inverse of algUnquant.
+func algQuant(
+	x []float32,
+	n, k int,
+	spread int,
+	blocks int,
+	rangeEncoder *rangecoding.Encoder,
+	gain float32,
+) uint {
+	expRotation(x, n, 1, blocks, k, spread)
+
+	iy := pvqSearch(x, n, k)
+	encodePulses(iy, n, k, rangeEncoder)
+
+	energy := 0
+	for i := range n {
+		energy += iy[i] * iy[i]
+	}
+	normaliseResidual(iy, x, n, energy, gain)
+	expRotation(x, n, -1, blocks, k, spread)
+
+	return extractCollapseMask(iy, n, blocks)
+}
+
 func expRotation1(x []float32, length int, stride int, c float32, s float32) {
 	for i := 0; i < length-stride; i++ {
 		x1 := x[i]

--- a/internal/celt/pvq_test.go
+++ b/internal/celt/pvq_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/pion/opus/internal/rangecoding"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,6 +50,66 @@ func TestAlgUnquant(t *testing.T) {
 	assert.Equal(t, uint(1), mask)
 	assert.InDelta(t, 1, vectorEnergy(x), 0.000001)
 	assert.Len(t, state.pulseScratch, len(x))
+}
+
+func TestPVQSearchBasic(t *testing.T) {
+	// Target with energy in first few dimensions
+	x := []float32{3, 2, 1, 0}
+	iy := pvqSearch(x, len(x), 3)
+
+	pulses := 0
+	for _, v := range iy {
+		if v < 0 {
+			pulses -= v
+		} else {
+			pulses += v
+		}
+	}
+	assert.Equal(t, 3, pulses)
+
+	// Signs should match target
+	assert.Greater(t, iy[0], 0)
+	assert.Greater(t, iy[1], 0)
+}
+
+func TestPVQSearchZeroPulses(t *testing.T) {
+	x := []float32{1, 2, 3}
+	iy := pvqSearch(x, len(x), 0)
+	for _, v := range iy {
+		assert.Equal(t, 0, v)
+	}
+}
+
+func TestAlgQuantRoundTrip(t *testing.T) {
+	n := 4
+	pulseCount := 2
+	spread := spreadNormal
+	gain := float32(2)
+
+	// Original target
+	original := []float32{3, 1, 0, -1}
+
+	// Encode
+	var enc rangecoding.Encoder
+	enc.Init()
+	xEnc := make([]float32, n)
+	copy(xEnc, original)
+	mask := algQuant(xEnc, n, pulseCount, spread, 1, &enc, gain)
+	assert.NotZero(t, mask)
+
+	bits := enc.Done()
+
+	// Decode
+	var dec rangecoding.Decoder
+	dec.Init(bits)
+	state := bandDecodeState{}
+	xDec := make([]float32, n)
+	algUnquant(xDec, n, pulseCount, spread, 1, &dec, gain, &state)
+
+	// Encoder output and decoder output should match
+	for i := range n {
+		assert.InDelta(t, xEnc[i], xDec[i], 0.0001)
+	}
 }
 
 func TestStereoMerge(t *testing.T) {


### PR DESCRIPTION
---
#### Description
Implements the CELT encoder core defined in RFC 6716 Section 5.3.

This adds the forward MDCT, CWRS encoder, PVQ search, frame side-info
encoding, and band quantization — the encoder-side mirror of the
existing decoder.
Scope: mono, fullband, 20 ms, static defaults. No transient detection,
stereo, or post-filter encoding yet. 
Verified with round-trip tests against the existing CELT decoder.

---