### PR TITLE
Changed creating decoder to return a pointer

### DIFF
--- a/conformance_test.go
+++ b/conformance_test.go
@@ -261,7 +261,7 @@ func decodeRFC6716Vector(t *testing.T, rate, channels int, bitstream, outPath st
 			t.Fatalf("frame %d: Go decode: %v", frame, err)
 		}
 
-		gotFinalRange, err := conformanceFinalRange(&decoder)
+		gotFinalRange, err := conformanceFinalRange(decoder)
 		if err != nil {
 			t.Fatalf("frame %d: final range unavailable: %v", frame, err)
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -64,21 +64,21 @@ type silkCeltAddition struct {
 }
 
 // NewDecoder creates a new Opus Decoder.
-func NewDecoder() Decoder {
+func NewDecoder() *Decoder {
 	decoder, _ := NewDecoderWithOutput(BandwidthFullband.SampleRate(), 1)
 
 	return decoder
 }
 
 // NewDecoderWithOutput creates a new Opus Decoder with the requested output sample rate and channel count.
-func NewDecoderWithOutput(sampleRate, channels int) (Decoder, error) {
-	decoder := Decoder{
+func NewDecoderWithOutput(sampleRate, channels int) (*Decoder, error) {
+	decoder := &Decoder{
 		silkDecoder: silk.NewDecoder(),
 		silkBuffer:  make([]float32, maxSilkFrameSampleCount),
 		celtDecoder: celt.NewDecoder(),
 	}
 	if err := decoder.Init(sampleRate, channels); err != nil {
-		return Decoder{}, err
+		return nil, err
 	}
 
 	return decoder, nil


### PR DESCRIPTION
I think creating new decoder should return a pointer instead of struct directly because it can confuse the user that the decoder is stateless and it can be copied between functions without a problem.

This can be more confusion when user is working for example with samplebuilder that returning a pointer.

This is a breaking change and should only merge before a new major version.