### PR TITLE
Optimize CELT inverse FFT

### DIFF
--- a/internal/celt/synthesis.go
+++ b/internal/celt/synthesis.go
@@ -57,8 +57,14 @@ type inverseTransformPlan struct {
 	sine             float32
 	rotateCos        []float32
 	rotateSinQuarter []float32
-	fftCos           []float32
-	fftSin           []float32
+	fftTwiddles      []complex32
+	fftBitrev        []int
+	fftFactors       []fftFactor
+}
+
+type fftFactor struct {
+	radix int
+	size  int
 }
 
 var inverseTransformPlans = [maxLM + 1]inverseTransformPlan{ //nolint:gochecknoglobals
@@ -549,83 +555,196 @@ func inverseComplexDFTInto(in []complex32, out []complex32, work []complex32, pl
 		return
 	}
 
-	inverseComplexFFTRecursive(in, 1, out, work, len(in), plan)
+	for i, value := range in {
+		out[plan.fftBitrev[i]] = value
+	}
+
+	for stage := len(plan.fftFactors) - 1; stage >= 0; stage-- {
+		factor := plan.fftFactors[stage]
+		fstride := plan.n4 / (factor.radix * factor.size)
+		switch factor.radix {
+		case 2:
+			inverseFFTButterfly2(out, factor.size, fstride, plan)
+		case 3:
+			inverseFFTButterfly3(out, factor.size, fstride, plan)
+		case 4:
+			inverseFFTButterfly4(out, factor.size, fstride, plan)
+		case 5:
+			inverseFFTButterfly5(out, factor.size, fstride, plan)
+		default:
+			inverseFFTButterflyGeneric(out, work, factor.radix, factor.size, fstride, plan)
+		}
+	}
 }
 
-func inverseComplexFFTRecursive(
-	in []complex32,
-	stride int,
+func inverseFFTButterfly2(out []complex32, subtransformLength, fstride int, plan *inverseTransformPlan) {
+	groupSize := 2 * subtransformLength
+	for group := 0; group < fstride; group++ {
+		base := group * groupSize
+		for frequencyIndex := 0; frequencyIndex < subtransformLength; frequencyIndex++ {
+			out0 := out[base+frequencyIndex]
+			out1 := out[base+subtransformLength+frequencyIndex]
+			twiddle := plan.fftTwiddles[frequencyIndex*fstride]
+			out1 = multiplyComplex32(out1, twiddle)
+			out[base+frequencyIndex] = addComplex32(out0, out1)
+			out[base+subtransformLength+frequencyIndex] = subtractComplex32(out0, out1)
+		}
+	}
+}
+
+func inverseFFTButterfly3(out []complex32, subtransformLength, fstride int, plan *inverseTransformPlan) {
+	groupSize := 3 * subtransformLength
+	epi3 := plan.fftTwiddles[fstride*subtransformLength]
+	for group := 0; group < fstride; group++ {
+		base := group * groupSize
+		for frequencyIndex := 0; frequencyIndex < subtransformLength; frequencyIndex++ {
+			out0 := out[base+frequencyIndex]
+			out1 := multiplyComplex32(out[base+subtransformLength+frequencyIndex], plan.fftTwiddles[frequencyIndex*fstride])
+			out2 := multiplyComplex32(out[base+2*subtransformLength+frequencyIndex], plan.fftTwiddles[2*frequencyIndex*fstride])
+			sum := addComplex32(out1, out2)
+			diff := multiplyComplex32ByFloat32(subtractComplex32(out1, out2), epi3.i)
+			mid := subtractComplex32(out0, multiplyComplex32ByFloat32(sum, 0.5))
+			out[base+frequencyIndex] = addComplex32(out0, sum)
+			out[base+subtransformLength+frequencyIndex] = complex32{r: mid.r - diff.i, i: mid.i + diff.r}
+			out[base+2*subtransformLength+frequencyIndex] = complex32{r: mid.r + diff.i, i: mid.i - diff.r}
+		}
+	}
+}
+
+func inverseFFTButterfly4(out []complex32, subtransformLength, fstride int, plan *inverseTransformPlan) {
+	groupSize := 4 * subtransformLength
+	for group := 0; group < fstride; group++ {
+		base := group * groupSize
+		for frequencyIndex := 0; frequencyIndex < subtransformLength; frequencyIndex++ {
+			out0 := out[base+frequencyIndex]
+			out1 := multiplyComplex32(out[base+subtransformLength+frequencyIndex], plan.fftTwiddles[frequencyIndex*fstride])
+			out2 := multiplyComplex32(out[base+2*subtransformLength+frequencyIndex], plan.fftTwiddles[2*frequencyIndex*fstride])
+			out3 := multiplyComplex32(out[base+3*subtransformLength+frequencyIndex], plan.fftTwiddles[3*frequencyIndex*fstride])
+			evenDifference := subtractComplex32(out0, out2)
+			evenSum := addComplex32(out0, out2)
+			oddSum := addComplex32(out1, out3)
+			oddDifference := subtractComplex32(out1, out3)
+			out[base+frequencyIndex] = addComplex32(evenSum, oddSum)
+			out[base+2*subtransformLength+frequencyIndex] = subtractComplex32(evenSum, oddSum)
+			out[base+subtransformLength+frequencyIndex] = complex32{r: evenDifference.r - oddDifference.i, i: evenDifference.i + oddDifference.r}
+			out[base+3*subtransformLength+frequencyIndex] = complex32{r: evenDifference.r + oddDifference.i, i: evenDifference.i - oddDifference.r}
+		}
+	}
+}
+
+func inverseFFTButterfly5(out []complex32, subtransformLength, fstride int, plan *inverseTransformPlan) {
+	groupSize := 5 * subtransformLength
+	ya := plan.fftTwiddles[fstride*subtransformLength]
+	yb := plan.fftTwiddles[2*fstride*subtransformLength]
+	for group := 0; group < fstride; group++ {
+		base := group * groupSize
+		for frequencyIndex := 0; frequencyIndex < subtransformLength; frequencyIndex++ {
+			out0 := out[base+frequencyIndex]
+			out1 := multiplyComplex32(out[base+subtransformLength+frequencyIndex], plan.fftTwiddles[frequencyIndex*fstride])
+			out2 := multiplyComplex32(out[base+2*subtransformLength+frequencyIndex], plan.fftTwiddles[2*frequencyIndex*fstride])
+			out3 := multiplyComplex32(out[base+3*subtransformLength+frequencyIndex], plan.fftTwiddles[3*frequencyIndex*fstride])
+			out4 := multiplyComplex32(out[base+4*subtransformLength+frequencyIndex], plan.fftTwiddles[4*frequencyIndex*fstride])
+			sum14 := addComplex32(out1, out4)
+			diff14 := subtractComplex32(out1, out4)
+			sum23 := addComplex32(out2, out3)
+			diff23 := subtractComplex32(out2, out3)
+			out[base+frequencyIndex] = addComplex32(out0, addComplex32(sum14, sum23))
+
+			base14 := addComplex32(
+				out0,
+				addComplex32(
+					multiplyComplex32ByFloat32(sum14, ya.r),
+					multiplyComplex32ByFloat32(sum23, yb.r),
+				),
+			)
+			rotate14 := complex32{
+				r: -diff14.i*ya.i - diff23.i*yb.i,
+				i: diff14.r*ya.i + diff23.r*yb.i,
+			}
+			out[base+subtransformLength+frequencyIndex] = addComplex32(base14, rotate14)
+			out[base+4*subtransformLength+frequencyIndex] = subtractComplex32(base14, rotate14)
+
+			base23 := addComplex32(
+				out0,
+				addComplex32(
+					multiplyComplex32ByFloat32(sum14, yb.r),
+					multiplyComplex32ByFloat32(sum23, ya.r),
+				),
+			)
+			rotate23 := complex32{
+				r: -diff14.i*yb.i + diff23.i*ya.i,
+				i: diff14.r*yb.i - diff23.r*ya.i,
+			}
+			out[base+2*subtransformLength+frequencyIndex] = addComplex32(base23, rotate23)
+			out[base+3*subtransformLength+frequencyIndex] = subtractComplex32(base23, rotate23)
+		}
+	}
+}
+
+func inverseFFTButterflyGeneric(
 	out []complex32,
 	work []complex32,
-	n int,
+	radix int,
+	subtransformLength int,
+	fstride int,
 	plan *inverseTransformPlan,
 ) {
-	if n <= 1 {
-		if n == 1 {
-			out[0] = in[0]
-		}
-
-		return
-	}
-
-	radix := fftRadix(n)
-	subtransformLength := n / radix
-	for subtransform := range radix {
-		inverseComplexFFTRecursive(
-			in[subtransform*stride:],
-			stride*radix,
-			work[subtransform*subtransformLength:(subtransform+1)*subtransformLength],
-			out[subtransform*subtransformLength:(subtransform+1)*subtransformLength],
-			subtransformLength,
-			plan,
-		)
-	}
-
-	for k := range subtransformLength {
-		for frequencyGroup := range radix {
-			sum := complex32{}
-			for subtransform := range radix {
-				value := work[subtransform*subtransformLength+k]
-				twiddle := plan.fftTwiddle(subtransform*(k+frequencyGroup*subtransformLength), n)
-				sum.r += value.r*twiddle.r - value.i*twiddle.i
-				sum.i += value.r*twiddle.i + value.i*twiddle.r
+	groupSize := radix * subtransformLength
+	for group := 0; group < fstride; group++ {
+		base := group * groupSize
+		for frequencyIndex := 0; frequencyIndex < subtransformLength; frequencyIndex++ {
+			for frequencyGroup := 0; frequencyGroup < radix; frequencyGroup++ {
+				sum := complex32{}
+				for subtransform := 0; subtransform < radix; subtransform++ {
+					value := out[base+subtransform*subtransformLength+frequencyIndex]
+					twiddle := plan.fftTwiddles[subtransform*(frequencyIndex+frequencyGroup*subtransformLength)*fstride%plan.n4]
+					sum.r += value.r*twiddle.r - value.i*twiddle.i
+					sum.i += value.r*twiddle.i + value.i*twiddle.r
+				}
+				work[frequencyGroup] = sum
 			}
-			out[k+frequencyGroup*subtransformLength] = sum
+			for frequencyGroup := 0; frequencyGroup < radix; frequencyGroup++ {
+				out[base+frequencyGroup*subtransformLength+frequencyIndex] = work[frequencyGroup]
+			}
 		}
 	}
 }
 
-func fftRadix(n int) int {
-	switch {
-	case n%2 == 0:
-		return 2
-	case n%3 == 0:
-		return 3
-	case n%5 == 0:
-		return 5
-	default:
-		return n
-	}
+func addComplex32(a, b complex32) complex32 {
+	return complex32{r: a.r + b.r, i: a.i + b.i}
+}
+
+func subtractComplex32(a, b complex32) complex32 {
+	return complex32{r: a.r - b.r, i: a.i - b.i}
+}
+
+func multiplyComplex32(a, b complex32) complex32 {
+	return complex32{r: a.r*b.r - a.i*b.i, i: a.r*b.i + a.i*b.r}
+}
+
+func multiplyComplex32ByFloat32(value complex32, factor float32) complex32 {
+	return complex32{r: value.r * factor, i: value.i * factor}
 }
 
 func newInverseTransformPlan(frameSampleCount int) inverseTransformPlan {
 	n := 2 * frameSampleCount
 	n4 := n >> 2
+	fftFactors := newFFTFactors(n4)
 	plan := inverseTransformPlan{
 		frameSampleCount: frameSampleCount,
 		n4:               n4,
 		sine:             float32(2 * math.Pi * 0.125 / float64(n)),
 		rotateCos:        make([]float32, n4),
 		rotateSinQuarter: make([]float32, n4),
-		fftCos:           make([]float32, n4),
-		fftSin:           make([]float32, n4),
+		fftTwiddles:      make([]complex32, n4),
+		fftBitrev:        newFFTBitrev(n4, fftFactors),
+		fftFactors:       fftFactors,
 	}
 	for i := range n4 {
 		plan.rotateCos[i] = float32(math.Cos(2 * math.Pi * float64(i) / float64(n)))
 		plan.rotateSinQuarter[i] = float32(math.Cos(2 * math.Pi * float64(n4-i) / float64(n)))
 		angle := 2 * math.Pi * float64(i) / float64(n4)
-		plan.fftCos[i] = float32(math.Cos(angle))
-		plan.fftSin[i] = float32(math.Sin(angle))
+		plan.fftTwiddles[i] = complex32{r: float32(math.Cos(angle)), i: float32(math.Sin(angle))}
 	}
 
 	return plan
@@ -643,14 +762,53 @@ func inverseTransformPlanForFrameSampleCount(frameSampleCount int) *inverseTrans
 	return &plan
 }
 
-func (p *inverseTransformPlan) fftTwiddle(index, transformSize int) complex32 {
-	index *= p.n4 / transformSize
-	index %= p.n4
-	if index < 0 {
-		index += p.n4
+func newFFTFactors(n int) []fftFactor {
+	factors := make([]fftFactor, 0, 5)
+	radix := 4
+	for {
+		for n%radix != 0 {
+			switch radix {
+			case 4:
+				radix = 2
+			case 2:
+				radix = 3
+			default:
+				radix += 2
+			}
+			if radix*radix > n {
+				radix = n
+			}
+		}
+		n /= radix
+		factors = append(factors, fftFactor{radix: radix, size: n})
+		if n == 1 {
+			return factors
+		}
+	}
+}
+
+func newFFTBitrev(n int, factors []fftFactor) []int {
+	bitrev := make([]int, n)
+	fillFFTBitrev(bitrev, 0, 1, 0, factors, 0)
+
+	return bitrev
+}
+
+func fillFFTBitrev(bitrev []int, outputIndex, fstride, fftOutput int, factors []fftFactor, factorIndex int) {
+	factor := factors[factorIndex]
+	if factor.size == 1 {
+		for j := 0; j < factor.radix; j++ {
+			bitrev[outputIndex+j*fstride] = fftOutput + j
+		}
+
+		return
 	}
 
-	return complex32{r: p.fftCos[index], i: p.fftSin[index]}
+	for j := 0; j < factor.radix; j++ {
+		fillFFTBitrev(bitrev, outputIndex, fstride*factor.radix, fftOutput, factors, factorIndex+1)
+		outputIndex += fstride
+		fftOutput += factor.size
+	}
 }
 
 func celtWindow(i int) float32 {


### PR DESCRIPTION
## Summary

Replace CELT's recursive complex inverse FFT with an iterative mixed-radix implementation.

This PR changes only `internal/celt/synthesis.go`. It is a pure-Go optimization: the surrounding inverse MDCT mapping, CELT synthesis behavior, decoder API, and encoded-bitstream handling remain unchanged.

## Context

CELT reconstructs time-domain audio through the following synthesis pipeline:

```text
frequency coefficients
  -> MDCT pre-rotation
  -> complex inverse FFT
  -> MDCT post-rotation
  -> windowing and overlap-add
  -> PCM samples
```

This PR changes only the complex inverse FFT in the middle of that pipeline.

## Previous algorithm

The previous implementation recursively divided each FFT into smaller sub-transforms:

```text
FFT(N)
  -> FFT(N / radix)
  -> FFT(N / radix)
  -> ...
  -> combine sub-transforms with twiddle factors
```

The recursive implementation is mathematically correct, but it adds avoidable work in a CELT decode hotspot:

- recursive function calls for every transform stage
- repeated slice construction while descending into sub-transforms
- generic nested summation loops for every radix
- repeated twiddle-factor index calculations
- less predictable memory access during recursive traversal

## New algorithm

The new implementation performs the same mixed-radix inverse FFT iteratively.

When the inverse-transform plan is created, it now precomputes:

1. The FFT factorization into small radices.
2. The twiddle-factor table.
3. The input permutation used to arrange values for iterative processing.

During decoding, the hot path becomes:

```text
1. Reorder inputs once using the cached permutation.
2. Process each FFT stage iteratively.
3. Use a specialized butterfly for radix 2, 3, 4, or 5.
4. Fall back to the generic butterfly only for unexpected radices.
```

A butterfly combines smaller transforms into a larger one. For radix 2, the operation is conceptually:

```text
a = input0
b = input1 * twiddle

output0 = a + b
output1 = a - b
```

The radix-3, radix-4, and radix-5 paths apply equivalent specialized formulas. These avoid the generic inner summation loop for the normal Opus transform sizes.

## Why this is faster

The asymptotic complexity remains `O(N log N)`. The improvement comes from reducing constant costs in the decode hot path:

- removes recursive traversal
- caches FFT factorization
- caches twiddle values
- caches the input permutation
- uses specialized small-radix arithmetic
- processes iterative stages with more predictable memory access

## Performance

Measured with the production-shaped RFC conformance-vector benchmark: 48 kHz stereo serial `DecodeToInt16`, with verification excluded from benchmark timing.

```text
BenchmarkPionDecodeToInt16Conformance48kStereoSerial
merged main median: 20,517 packets/s
this PR median:     27,313 packets/s
improvement:        +33.1%
```

The comparison used alternating full-corpus runs to reduce machine-load bias.

## Validation

- `go test ./...`
- `GOLANGCI_LINT_CACHE=/private/tmp/golangci-lint-celt-iterative-fft-pr golangci-lint run`
- Full RFC conformance matrix:

```text
OPUS_RFC6716_REFERENCE=/Users/zshang/code/archieve/opus-rfc6716 \
OPUS_RFC6716_TESTVECTORS=/Users/zshang/code/archieve/opus-rfc6716/testvectors \
go test -tags conformance -run '^TestRFC6716Conformance$' -count=1
```

All checks pass.
