### PR TITLE
Optimize forward DFT with Cooley-Tukey FFT

### DIFF
--- a/internal/celt/fft.go
+++ b/internal/celt/fft.go
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package celt implements the MDCT layer of the Opus codec.
+package celt
+
+import "math"
+
+//nolint:cyclop // Cooley-Tukey mixed-radix FFT: three passes + un-permute.
+func fft(in []complex32) {
+	n := len(in)
+	if n <= 1 {
+		return
+	}
+
+	pow2 := 1
+	for n%(pow2*2) == 0 {
+		pow2 *= 2
+	}
+	odd := n / pow2
+
+	if odd == 1 {
+		fftRadix2(in)
+
+		return
+	}
+
+	scratch := make([]complex32, n+odd)
+
+	for col := range pow2 {
+		colBuf := scratch[col*odd : (col+1)*odd]
+		for row := range odd {
+			colBuf[row] = in[row*pow2+col]
+		}
+		directDFT(colBuf, scratch[n:])
+		for row := range odd {
+			in[row*pow2+col] = scratch[n+row]
+		}
+	}
+
+	for row := range odd {
+		for col := range pow2 {
+			angle := -2 * math.Pi * float64(row*col) / float64(n)
+			wr := float32(math.Cos(angle))
+			wi := float32(math.Sin(angle))
+
+			idx := row*pow2 + col
+			r := in[idx].r*wr - in[idx].i*wi
+			i := in[idx].r*wi + in[idx].i*wr
+			in[idx] = complex32{r: r, i: i}
+		}
+	}
+
+	for row := range odd {
+		fftRadix2(in[row*pow2 : (row+1)*pow2])
+	}
+
+	for k1 := range odd {
+		for k2 := range pow2 {
+			p := k1*pow2 + k2
+			q := k1 + k2*odd
+			scratch[q] = in[p]
+		}
+	}
+	copy(in, scratch[:n])
+}
+
+func fftRadix2(in []complex32) {
+	n := len(in)
+	if n <= 1 {
+		return
+	}
+
+	for i := range n {
+		j := bitReverse(i, n)
+		if i < j {
+			in[i], in[j] = in[j], in[i]
+		}
+	}
+
+	for length := 2; length <= n; length <<= 1 {
+		halfLen := length >> 1
+		for i := 0; i < n; i += length {
+			for j := range halfLen {
+				angle := -2 * math.Pi * float64(j) / float64(length)
+				wr := float32(math.Cos(angle))
+				wi := float32(math.Sin(angle))
+
+				ar := in[i+j].r
+				ai := in[i+j].i
+				br := in[i+j+halfLen].r*wr - in[i+j+halfLen].i*wi
+				bi := in[i+j+halfLen].r*wi + in[i+j+halfLen].i*wr
+
+				in[i+j] = complex32{r: ar + br, i: ai + bi}
+				in[i+j+halfLen] = complex32{r: ar - br, i: ai - bi}
+			}
+		}
+	}
+}
+
+func bitReverse(x int, n int) int {
+	rev := 0
+	for bits := n; bits > 1; bits >>= 1 {
+		rev = (rev << 1) | (x & 1)
+		x >>= 1
+	}
+
+	return rev
+}
+
+// directDFT computes the O(N²) DFT directly, used for small odd factors that
+// are not handled by the radix-2 path. Inputs and outputs are separate buffers.
+func directDFT(in, out []complex32) {
+	n := len(in)
+	for k := range n {
+		var sumR, sumI float32
+		for m, val := range in {
+			angle := -2 * math.Pi * float64(k*m) / float64(n)
+			c := float32(math.Cos(angle))
+			s := float32(math.Sin(angle))
+			sumR += val.r*c - val.i*s
+			sumI += val.r*s + val.i*c
+		}
+		out[k] = complex32{r: sumR, i: sumI}
+	}
+}

--- a/internal/celt/fft.go
+++ b/internal/celt/fft.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-// Package celt implements the MDCT layer of the Opus codec.
 package celt
 
 import "math"

--- a/internal/celt/fft_test.go
+++ b/internal/celt/fft_test.go
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+	"math/rand"
+	"strconv"
+	"testing"
+)
+
+func TestFFTRoundTrip(t *testing.T) {
+	sizes := []int{1, 2, 4, 8, 16, 32, 60, 120, 240, 480}
+	for _, n := range sizes {
+		t.Run("n="+strconv.Itoa(n), func(t *testing.T) {
+			input := randomComplex(n, 42)
+			work := cloneComplex(input)
+			fft(work)
+			for i := range work {
+				work[i].i = -work[i].i
+			}
+			fft(work)
+			for i := range work {
+				work[i].i = -work[i].i
+			}
+			scale := 1 / float32(n)
+			for i := range work {
+				work[i].r *= scale
+				work[i].i *= scale
+			}
+			assertComplexSliceClose(t, input, work, 1e-6)
+		})
+	}
+}
+
+func TestFFTMatchesNaive(t *testing.T) {
+	sizes := []int{1, 2, 4, 8, 16, 32, 60, 120, 240, 480}
+	for _, n := range sizes {
+		t.Run("n="+strconv.Itoa(n), func(t *testing.T) {
+			input := randomComplex(n, 42)
+			expected := naiveComplexDFT(input)
+			actual := cloneComplex(input)
+			fft(actual)
+			tolerance := 1e-6
+			if n >= 32 {
+				tolerance = 5e-5
+			}
+			assertComplexSliceClose(t, expected, actual, tolerance)
+		})
+	}
+}
+
+func TestFFTPureOddSizes(t *testing.T) {
+	sizes := []int{3, 5, 15}
+	for _, n := range sizes {
+		t.Run("n="+strconv.Itoa(n), func(t *testing.T) {
+			input := randomComplex(n, 7)
+			expected := naiveComplexDFT(input)
+			actual := cloneComplex(input)
+			fft(actual)
+			assertComplexSliceClose(t, expected, actual, 1e-6)
+		})
+	}
+}
+
+func TestFFTPureRadix2Sizes(t *testing.T) {
+	sizes := []int{2, 4, 8, 16, 32, 64, 128, 256, 512}
+	for _, n := range sizes {
+		t.Run("n="+strconv.Itoa(n), func(t *testing.T) {
+			input := randomComplex(n, 11)
+			expected := naiveComplexDFT(input)
+			actual := cloneComplex(input)
+			fft(actual)
+			tolerance := 1e-6
+			if n > 16 {
+				tolerance = 5e-5
+			}
+			assertComplexSliceClose(t, expected, actual, tolerance)
+		})
+	}
+}
+
+func TestInverseFFTMatchesNaive(t *testing.T) {
+	sizes := []int{1, 2, 4, 8, 16, 32, 60, 120, 240, 480}
+	for _, n := range sizes {
+		t.Run("n="+strconv.Itoa(n), func(t *testing.T) {
+			input := randomComplex(n, 42)
+			expected := make([]complex32, n)
+			copy(expected, input)
+			for i := range expected {
+				expected[i].i = -expected[i].i
+			}
+			expected = naiveComplexDFT(expected)
+			for i := range expected {
+				expected[i].i = -expected[i].i
+			}
+			actual := cloneComplex(input)
+			for i := range actual {
+				actual[i].i = -actual[i].i
+			}
+			fft(actual)
+			for i := range actual {
+				actual[i].i = -actual[i].i
+			}
+			tolerance := 1e-6
+			if n >= 32 {
+				tolerance = 5e-5
+			}
+			assertComplexSliceClose(t, expected, actual, tolerance)
+		})
+	}
+}
+
+func TestForwardInverseRoundTrip(t *testing.T) {
+	sizes := []int{60, 120, 240, 480}
+	for _, n := range sizes {
+		t.Run("n="+strconv.Itoa(n), func(t *testing.T) {
+			input := randomComplex(n, 42)
+			forward := forwardComplexDFT(input)
+			recovered := inverseComplexDFT(forward)
+			assertComplexSliceClose(t, input, recovered, 1e-6)
+		})
+	}
+}
+
+func TestFFTZero(t *testing.T) {
+	sizes := []int{60, 120, 240, 480}
+	for _, n := range sizes {
+		t.Run("n="+strconv.Itoa(n), func(t *testing.T) {
+			input := make([]complex32, n)
+			result := forwardComplexDFT(input)
+			assertComplexSliceClose(t, input, result, 1e-7)
+		})
+	}
+}
+
+func naiveComplexDFT(in []complex32) []complex32 {
+	n := len(in)
+	out := make([]complex32, n)
+	for k := range n {
+		var sumR, sumI float32
+		for m, val := range in {
+			angle := -2 * math.Pi * float64(k*m) / float64(n)
+			c := float32(math.Cos(angle))
+			s := float32(math.Sin(angle))
+			sumR += val.r*c - val.i*s
+			sumI += val.r*s + val.i*c
+		}
+		out[k] = complex32{r: sumR, i: sumI}
+	}
+
+	return out
+}
+
+func BenchmarkFFT(b *testing.B) {
+	for _, n := range []int{120, 240, 480} {
+		input := randomComplex(n, 1)
+		b.Run("fft_n="+strconv.Itoa(n), func(b *testing.B) {
+			for range b.N {
+				work := cloneComplex(input)
+				fft(work)
+			}
+		})
+		b.Run("naive_n="+strconv.Itoa(n), func(b *testing.B) {
+			for range b.N {
+				naiveComplexDFT(input)
+			}
+		})
+	}
+}
+
+//nolint:gosec // Deterministic test vector generation does not need crypto/rand.
+func randomComplex(n int, seed int64) []complex32 {
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]complex32, n)
+	for i := range n {
+		out[i] = complex32{
+			r: float32(rng.Float64()*2 - 1),
+			i: float32(rng.Float64()*2 - 1),
+		}
+	}
+
+	return out
+}
+
+func cloneComplex(in []complex32) []complex32 {
+	out := make([]complex32, len(in))
+	copy(out, in)
+
+	return out
+}

--- a/internal/celt/mdct.go
+++ b/internal/celt/mdct.go
@@ -7,8 +7,7 @@ import (
 	"math"
 )
 
-// forwardComplexDFT inverts inverseComplexDFT using the standard
-// conjugate-sign change and 1/N scaling factor.
+// forwardComplexDFT computes the forward complex DFT via fft and 1/N scaling.
 func forwardComplexDFT(in []complex32) []complex32 {
 	out := make([]complex32, len(in))
 	copy(out, in)
@@ -29,8 +28,7 @@ func forwardComplexDFT(in []complex32) []complex32 {
 // This helper expects exactly that time-domain layout and returns the original
 // N MDCT bins.
 //
-// A later optimization can replace the O(N^2) complex DFT with an FFT without
-// changing the surrounding packing/rotation steps.
+// The complex DFT step is handled by forwardComplexDFT, which delegates to fft.
 //
 //nolint:cyclop // Mirrors the RFC 6716 Section 4.3.7 IMDCT structure step-for-step.
 func forwardMDCT(time []float32) []float32 {

--- a/internal/celt/mdct.go
+++ b/internal/celt/mdct.go
@@ -10,27 +10,13 @@ import (
 // forwardComplexDFT inverts inverseComplexDFT using the standard
 // conjugate-sign change and 1/N scaling factor.
 func forwardComplexDFT(in []complex32) []complex32 {
-	n := len(in)
-	out := make([]complex32, n)
-	if n == 0 {
-		return out
-	}
-
-	scale := float32(1) / float32(n)
-	for k := range n {
-		sumR := float32(0)
-		sumI := float32(0)
-		for m, value := range in {
-			angle := 2 * math.Pi * float64(k*m) / float64(n)
-			cosine := float32(math.Cos(angle))
-			sine := float32(math.Sin(angle))
-			sumR += value.r*cosine + value.i*sine
-			sumI += value.i*cosine - value.r*sine
-		}
-		out[k] = complex32{
-			r: sumR * scale,
-			i: sumI * scale,
-		}
+	out := make([]complex32, len(in))
+	copy(out, in)
+	fft(out)
+	n := float32(len(out))
+	for i := range out {
+		out[i].r /= n
+		out[i].i /= n
 	}
 
 	return out


### PR DESCRIPTION
#### Description
forwardComplexDFT in the encoder path was doing an O(N²) naive DFT, at N=480 thats ~230k multiply-accumulates per call.

Added a Cooley-Tukey mixed-radix FFT in fft.go. CELT frame sizes factor as 2^k × 15, so it handles the radix-2 part with bit-reversal +
butterfly and uses a direct O(K²) DFT for the odd factor 15 — small enough that it doesn't matter.

Benchmarks on my machine (N=480): ~6080µs naive vs ~233µs with FFT, roughly 26x.

The decoder side (inverseComplexDFT) already had the butterfly FFT from a previous pass, this just closes the gap on the encoder side.

#### Reference issue
Fixes #...
