### PR TITLE
Precompute FFT twiddle factors

### DIFF
--- a/internal/celt/fft.go
+++ b/internal/celt/fft.go
@@ -3,7 +3,82 @@
 
 package celt
 
-import "math"
+import (
+	"math"
+	"math/bits"
+	"sync"
+)
+
+// fftPlan caches the twiddle factors for one FFT length so the trigonometry
+// is computed once per size instead of inside the per-frame butterfly loops.
+type fftPlan struct {
+	pow2           int
+	odd            int
+	outerTwiddles  []complex32
+	stageTwiddles  [][]complex32
+	directTwiddles []complex32
+}
+
+var fftPlans sync.Map //nolint:gochecknoglobals // Immutable plan cache keyed by FFT length.
+
+func fftPlanForLength(n int) *fftPlan {
+	if cached, ok := fftPlans.Load(n); ok {
+		if plan, ok := cached.(*fftPlan); ok {
+			return plan
+		}
+	}
+
+	plan := newFFTPlan(n)
+	cached, _ := fftPlans.LoadOrStore(n, plan)
+
+	if cachedPlan, ok := cached.(*fftPlan); ok {
+		return cachedPlan
+	}
+
+	return plan
+}
+
+func newFFTPlan(n int) *fftPlan {
+	pow2 := 1
+	for n%(pow2*2) == 0 {
+		pow2 *= 2
+	}
+	odd := n / pow2
+
+	plan := &fftPlan{
+		pow2:          pow2,
+		odd:           odd,
+		outerTwiddles: make([]complex32, n),
+	}
+
+	for i := range n {
+		angle := -2 * math.Pi * float64(i) / float64(n)
+		plan.outerTwiddles[i] = complex32{r: float32(math.Cos(angle)), i: float32(math.Sin(angle))}
+	}
+
+	stageCount := bits.Len(uint(pow2)) - 1
+	plan.stageTwiddles = make([][]complex32, stageCount)
+	for stage := range stageCount {
+		length := 2 << stage
+		halfLen := length >> 1
+		twiddles := make([]complex32, halfLen)
+		for j := range halfLen {
+			angle := -2 * math.Pi * float64(j) / float64(length)
+			twiddles[j] = complex32{r: float32(math.Cos(angle)), i: float32(math.Sin(angle))}
+		}
+		plan.stageTwiddles[stage] = twiddles
+	}
+
+	plan.directTwiddles = make([]complex32, odd*odd)
+	for k := range odd {
+		for m := range odd {
+			angle := -2 * math.Pi * float64(k*m) / float64(odd)
+			plan.directTwiddles[k*odd+m] = complex32{r: float32(math.Cos(angle)), i: float32(math.Sin(angle))}
+		}
+	}
+
+	return plan
+}
 
 //nolint:cyclop // Cooley-Tukey mixed-radix FFT: three passes + un-permute.
 func fft(in []complex32) {
@@ -12,59 +87,53 @@ func fft(in []complex32) {
 		return
 	}
 
-	pow2 := 1
-	for n%(pow2*2) == 0 {
-		pow2 *= 2
-	}
-	odd := n / pow2
+	plan := fftPlanForLength(n)
 
-	if odd == 1 {
-		fftRadix2(in)
+	if plan.odd == 1 {
+		fftRadix2(in, plan)
 
 		return
 	}
 
-	scratch := make([]complex32, n+odd)
+	scratch := make([]complex32, n+plan.odd)
 
-	for col := range pow2 {
-		colBuf := scratch[col*odd : (col+1)*odd]
-		for row := range odd {
-			colBuf[row] = in[row*pow2+col]
+	for col := range plan.pow2 {
+		colBuf := scratch[col*plan.odd : (col+1)*plan.odd]
+		for row := range plan.odd {
+			colBuf[row] = in[row*plan.pow2+col]
 		}
-		directDFT(colBuf, scratch[n:])
-		for row := range odd {
-			in[row*pow2+col] = scratch[n+row]
+		directDFT(colBuf, scratch[n:], plan.directTwiddles, plan.odd)
+		for row := range plan.odd {
+			in[row*plan.pow2+col] = scratch[n+row]
 		}
 	}
 
-	for row := range odd {
-		for col := range pow2 {
-			angle := -2 * math.Pi * float64(row*col) / float64(n)
-			wr := float32(math.Cos(angle))
-			wi := float32(math.Sin(angle))
+	for row := range plan.odd {
+		for col := range plan.pow2 {
+			twiddle := plan.outerTwiddles[row*col]
 
-			idx := row*pow2 + col
-			r := in[idx].r*wr - in[idx].i*wi
-			i := in[idx].r*wi + in[idx].i*wr
+			idx := row*plan.pow2 + col
+			r := in[idx].r*twiddle.r - in[idx].i*twiddle.i
+			i := in[idx].r*twiddle.i + in[idx].i*twiddle.r
 			in[idx] = complex32{r: r, i: i}
 		}
 	}
 
-	for row := range odd {
-		fftRadix2(in[row*pow2 : (row+1)*pow2])
+	for row := range plan.odd {
+		fftRadix2(in[row*plan.pow2:(row+1)*plan.pow2], plan)
 	}
 
-	for k1 := range odd {
-		for k2 := range pow2 {
-			p := k1*pow2 + k2
-			q := k1 + k2*odd
+	for k1 := range plan.odd {
+		for k2 := range plan.pow2 {
+			p := k1*plan.pow2 + k2
+			q := k1 + k2*plan.odd
 			scratch[q] = in[p]
 		}
 	}
 	copy(in, scratch[:n])
 }
 
-func fftRadix2(in []complex32) {
+func fftRadix2(in []complex32, plan *fftPlan) {
 	n := len(in)
 	if n <= 1 {
 		return
@@ -77,18 +146,17 @@ func fftRadix2(in []complex32) {
 		}
 	}
 
-	for length := 2; length <= n; length <<= 1 {
+	for stage, length := 0, 2; length <= n; stage, length = stage+1, length<<1 {
 		halfLen := length >> 1
+		twiddles := plan.stageTwiddles[stage]
 		for i := 0; i < n; i += length {
 			for j := range halfLen {
-				angle := -2 * math.Pi * float64(j) / float64(length)
-				wr := float32(math.Cos(angle))
-				wi := float32(math.Sin(angle))
+				twiddle := twiddles[j]
 
 				ar := in[i+j].r
 				ai := in[i+j].i
-				br := in[i+j+halfLen].r*wr - in[i+j+halfLen].i*wi
-				bi := in[i+j+halfLen].r*wi + in[i+j+halfLen].i*wr
+				br := in[i+j+halfLen].r*twiddle.r - in[i+j+halfLen].i*twiddle.i
+				bi := in[i+j+halfLen].r*twiddle.i + in[i+j+halfLen].i*twiddle.r
 
 				in[i+j] = complex32{r: ar + br, i: ai + bi}
 				in[i+j+halfLen] = complex32{r: ar - br, i: ai - bi}
@@ -107,18 +175,16 @@ func bitReverse(x int, n int) int {
 	return rev
 }
 
-// directDFT computes the O(N²) DFT directly, used for small odd factors that
-// are not handled by the radix-2 path. Inputs and outputs are separate buffers.
-func directDFT(in, out []complex32) {
-	n := len(in)
+// directDFT computes the O(N²) DFT directly for the small odd factor of the
+// mixed-radix decomposition. The twiddle matrix is precomputed once per size.
+func directDFT(in, out, twiddles []complex32, n int) {
 	for k := range n {
 		var sumR, sumI float32
+		rowOffset := k * n
 		for m, val := range in {
-			angle := -2 * math.Pi * float64(k*m) / float64(n)
-			c := float32(math.Cos(angle))
-			s := float32(math.Sin(angle))
-			sumR += val.r*c - val.i*s
-			sumI += val.r*s + val.i*c
+			twiddle := twiddles[rowOffset+m]
+			sumR += val.r*twiddle.r - val.i*twiddle.i
+			sumI += val.r*twiddle.i + val.i*twiddle.r
 		}
 		out[k] = complex32{r: sumR, i: sumI}
 	}

--- a/internal/celt/fft.go
+++ b/internal/celt/fft.go
@@ -6,12 +6,12 @@ package celt
 import (
 	"math"
 	"math/bits"
-	"sync"
 )
 
 // fftPlan caches the twiddle factors for one FFT length so the trigonometry
 // is computed once per size instead of inside the per-frame butterfly loops.
 type fftPlan struct {
+	n              int
 	pow2           int
 	odd            int
 	outerTwiddles  []complex32
@@ -19,23 +19,24 @@ type fftPlan struct {
 	directTwiddles []complex32
 }
 
-var fftPlans sync.Map //nolint:gochecknoglobals // Immutable plan cache keyed by FFT length.
+// fftPlans holds the plans for every FFT length the encoder uses in
+// production: the forward MDCT transforms n4 = frameSampleCount/2 bins per
+// CELT frame size. Mirrors inverseTransformPlans on the decoder side.
+var fftPlans = [maxLM + 1]*fftPlan{ //nolint:gochecknoglobals
+	newFFTPlan(shortBlockSampleCount >> 1),
+	newFFTPlan(shortBlockSampleCount),
+	newFFTPlan(shortBlockSampleCount << 1),
+	newFFTPlan(shortBlockSampleCount << 2),
+}
 
 func fftPlanForLength(n int) *fftPlan {
-	if cached, ok := fftPlans.Load(n); ok {
-		if plan, ok := cached.(*fftPlan); ok {
+	for _, plan := range fftPlans {
+		if plan.n == n {
 			return plan
 		}
 	}
 
-	plan := newFFTPlan(n)
-	cached, _ := fftPlans.LoadOrStore(n, plan)
-
-	if cachedPlan, ok := cached.(*fftPlan); ok {
-		return cachedPlan
-	}
-
-	return plan
+	return newFFTPlan(n)
 }
 
 func newFFTPlan(n int) *fftPlan {
@@ -46,6 +47,7 @@ func newFFTPlan(n int) *fftPlan {
 	odd := n / pow2
 
 	plan := &fftPlan{
+		n:             n,
 		pow2:          pow2,
 		odd:           odd,
 		outerTwiddles: make([]complex32, n),

--- a/internal/celt/mdct.go
+++ b/internal/celt/mdct.go
@@ -3,10 +3,6 @@
 
 package celt
 
-import (
-	"math"
-)
-
 // forwardComplexDFT computes the forward complex DFT via fft and 1/N scaling.
 func forwardComplexDFT(in []complex32) []complex32 {
 	out := make([]complex32, len(in))
@@ -46,7 +42,9 @@ func forwardMDCT(time []float32) []float32 {
 	n := 2 * n2
 	n4 := n >> 2
 	leftPlain := n4 - overlap/2
-	sine := float32(2 * math.Pi * 0.125 / float64(n))
+	// The pre/post rotation tables are identical for analysis and synthesis,
+	// so the forward MDCT reuses the inverse transform plan.
+	plan := inverseTransformPlanForFrameSampleCount(frameSampleCount)
 
 	deshuffled := make([]float32, n2)
 
@@ -78,9 +76,9 @@ func forwardMDCT(time []float32) []float32 {
 
 	fftOut := make([]complex32, n4)
 	for i := range n4 {
-		yr, yi := undoMDCTShear(postRotated[2*i], postRotated[2*i+1], sine)
-		cosine := float32(math.Cos(2 * math.Pi * float64(i) / float64(n)))
-		sineQuarter := float32(math.Cos(2 * math.Pi * float64(n4-i) / float64(n)))
+		yr, yi := undoMDCTShear(postRotated[2*i], postRotated[2*i+1], plan.sine)
+		cosine := plan.rotateCos[i]
+		sineQuarter := plan.rotateSinQuarter[i]
 
 		fftOut[i] = complex32{
 			r: yr*cosine + yi*sineQuarter,
@@ -92,9 +90,9 @@ func forwardMDCT(time []float32) []float32 {
 	freq := make([]float32, n2)
 
 	for i, value := range preRotated {
-		yr, yi := undoMDCTShear(value.r, value.i, sine)
-		cosine := float32(math.Cos(2 * math.Pi * float64(i) / float64(n)))
-		sineQuarter := float32(math.Cos(2 * math.Pi * float64(n4-i) / float64(n)))
+		yr, yi := undoMDCTShear(value.r, value.i, plan.sine)
+		cosine := plan.rotateCos[i]
+		sineQuarter := plan.rotateSinQuarter[i]
 		xp1 := sineQuarter*yr - cosine*yi
 		xp2 := -cosine*yr - sineQuarter*yi
 		freq[2*i] = xp1

--- a/internal/celt/mdct_test.go
+++ b/internal/celt/mdct_test.go
@@ -77,6 +77,21 @@ func TestForwardMDCTInvalidInput(t *testing.T) {
 	assert.Nil(t, forwardMDCT(make([]float32, shortBlockSampleCount+1)))
 }
 
+func BenchmarkForwardMDCT(b *testing.B) {
+	for _, frameSampleCount := range []int{shortBlockSampleCount << 2, shortBlockSampleCount << 3} {
+		time := make([]float32, frameSampleCount+shortBlockSampleCount)
+		for i := range time {
+			time[i] = float32(math.Sin(2*math.Pi*7*float64(i)/float64(frameSampleCount)) +
+				0.25*math.Cos(2*math.Pi*23*float64(i)/float64(frameSampleCount)))
+		}
+		b.Run(frameSampleCountName(frameSampleCount), func(b *testing.B) {
+			for range b.N {
+				_ = forwardMDCT(time)
+			}
+		})
+	}
+}
+
 func assertFloat32SliceClose(t *testing.T, expected, actual []float32, tolerance float64) {
 	t.Helper()
 	require.Len(t, actual, len(expected))


### PR DESCRIPTION
#### Description
Follow-up to #125. The FFT was still calling math.Cos/math.Sin inside the inner loops — fftRadix2 recomputes the twiddle for every butterfly, directDFT rebuilds its whole matrix per call, and the outer twiddle pass of fft() did the same. All of those angles only depend on the transform size, which is fixed per frame size, so they were being recalculated on every single frame.

This moves them into an fftPlan that's computed once per FFT length and cached (sync.Map, sizes only ever grow). The forward MDCT rotations reuse the tables from the inverse transform plan since they're identical for analysis and synthesis.

Benchmarks on my machine (i3-9100F, 20ms frames):

- FFT n=480: 227µs → 27.6µs (~8x)
- full encode mono: 310µs → 75µs (~4x)
- full encode stereo: 595µs → 127µs (~4.7x)

Also added BenchmarkForwardMDCT so there's a baseline for the MDCT path. Allocations are unchanged, that's a separate follow-up.

#### Reference issue
Fixes #...
