### PR TITLE
[codex] Add Opus packet loss concealment

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -47,8 +47,12 @@ type Decoder struct {
 	silkRedundancyFades    []silkRedundancyFade
 	silkCeltAdditions      []silkCeltAddition
 	floatBuffer            []float32
+	plcBuffer              []float32
+	plcOutputBuffer        []float32
 	sampleRate             int
 	channels               int
+	lastPacketBandwidth    Bandwidth
+	lastPacketIsStereo     bool
 }
 
 type silkRedundancyFade struct {
@@ -114,6 +118,8 @@ func (d *Decoder) Init(sampleRate, channels int) error {
 	d.rangeFinal = 0
 	d.previousMode = 0
 	d.previousRedundancy = false
+	d.lastPacketBandwidth = 0
+	d.lastPacketIsStereo = false
 
 	return nil
 }
@@ -1183,8 +1189,153 @@ func (d *Decoder) decodeToFloat32(
 	if err != nil {
 		return 0, 0, false, err
 	}
+	d.lastPacketBandwidth = bandwidth
+	d.lastPacketIsStereo = isStereo
 
 	return samplesPerChannel, bandwidth, isStereo, nil
+}
+
+func (d *Decoder) decodePLCToFloat32(out []float32) error {
+	if err := d.validatePLCOutput(len(out)); err != nil {
+		return err
+	}
+
+	if d.previousMode == 0 {
+		clear(out)
+
+		return nil
+	}
+
+	mode := d.previousMode
+	if d.previousRedundancy {
+		mode = configurationModeCELTOnly
+	}
+	samplesPerChannel := d.sampleRate / 50
+	var err error
+	switch mode {
+	case configurationModeSilkOnly:
+		err = d.decodeSilkPLCFrame(out, samplesPerChannel, d.lastPacketBandwidth, false)
+	case configurationModeCELTOnly:
+		err = d.decodeCeltPLCFrame(out, samplesPerChannel, false)
+	case configurationModeHybrid:
+		err = d.decodeHybridPLCFrame(out, samplesPerChannel)
+	default:
+		err = fmt.Errorf("%w: %d", errUnsupportedConfigurationMode, mode)
+	}
+	if err != nil {
+		return err
+	}
+	d.rangeFinal = 0
+
+	return nil
+}
+
+func (d *Decoder) validatePLCOutput(sampleCount int) error {
+	switch {
+	case d.sampleRate == 0:
+		return errInvalidSampleRate
+	case d.channels == 0:
+		return errInvalidChannelCount
+	case sampleCount != d.sampleRate/50*d.channels:
+		return errInvalidPLCFrameSize
+	default:
+		return nil
+	}
+}
+
+func (d *Decoder) decodeCeltPLCFrame(out []float32, samplesPerChannel int, hybrid bool) error {
+	frameSampleCount := samplesPerChannel * celtSampleRate / d.sampleRate
+	var (
+		startBand int
+		endBand   int
+		err       error
+	)
+	if hybrid {
+		startBand, endBand, err = d.celtDecoder.Mode().HybridBandRange(d.lastPacketBandwidth.SampleRate())
+	} else {
+		startBand, endBand, err = d.celtDecoder.Mode().BandRangeForSampleRate(d.lastPacketBandwidth.SampleRate())
+	}
+	if err != nil {
+		return err
+	}
+
+	return d.celtDecoder.DecodeToSampleRate(
+		nil,
+		out,
+		d.lastPacketIsStereo,
+		d.channels,
+		frameSampleCount,
+		startBand,
+		endBand,
+		d.sampleRate,
+	)
+}
+
+func (d *Decoder) decodeSilkPLCFrame(
+	out []float32,
+	samplesPerChannel int,
+	bandwidth Bandwidth,
+	hybrid bool,
+) error {
+	durationNanoseconds := samplesPerChannel * 1000000000 / d.sampleRate
+	internalChannelCount := silkOutputChannelCount(d.lastPacketIsStereo, d.channels)
+	internalSamplesPerChannel := bandwidth.SampleRate() * durationNanoseconds / 1000000000
+	internal := resizeFloat32Buffer(&d.plcBuffer, internalSamplesPerChannel*internalChannelCount)
+	if err := d.silkDecoder.DecodePLC(
+		internal,
+		d.lastPacketIsStereo,
+		internalChannelCount,
+		durationNanoseconds,
+		silk.Bandwidth(bandwidth),
+	); err != nil {
+		return err
+	}
+
+	resampled := resizeFloat32Buffer(
+		&d.plcOutputBuffer,
+		samplesPerChannel*internalChannelCount,
+	)
+	var err error
+	if hybrid {
+		err = d.resampleHybridSilk(internal, resampled, internalChannelCount)
+	} else {
+		err = d.resampleSilk(internal, resampled, internalChannelCount, bandwidth)
+	}
+	if err != nil {
+		return err
+	}
+
+	if hybrid {
+		d.addHybridSilk(out, resampled, internalChannelCount, d.channels, samplesPerChannel)
+	} else {
+		copyChannels(out, resampled, internalChannelCount, d.channels, samplesPerChannel)
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeHybridPLCFrame(out []float32, samplesPerChannel int) error {
+	if err := d.decodeCeltPLCFrame(out, samplesPerChannel, true); err != nil {
+		return err
+	}
+
+	return d.decodeSilkPLCFrame(out, samplesPerChannel, BandwidthWideband, true)
+}
+
+func copyChannels(out, in []float32, inputChannels, outputChannels, samplesPerChannel int) {
+	for sample := range samplesPerChannel {
+		inIndex := sample * inputChannels
+		outIndex := sample * outputChannels
+		switch {
+		case inputChannels == outputChannels:
+			copy(out[outIndex:outIndex+outputChannels], in[inIndex:inIndex+inputChannels])
+		case inputChannels == 1 && outputChannels == 2:
+			out[outIndex] = in[inIndex]
+			out[outIndex+1] = in[inIndex]
+		case inputChannels == 2 && outputChannels == 1:
+			out[outIndex] = 0.5 * (in[inIndex] + in[inIndex+1])
+		}
+	}
 }
 
 func (d *Decoder) finishDecodeToFloat32(
@@ -1418,6 +1569,17 @@ func (d *Decoder) DecodeToInt16(in []byte, out []int16) (int, error) {
 	float32ToInt16(d.floatBuffer, out, sampleCount*d.channels)
 
 	return sampleCount, nil
+}
+
+// DecodePLC recovers one missing 20 ms packet into signed 16-bit PCM.
+func (d *Decoder) DecodePLC(out []int16) error {
+	d.floatBuffer = resizeFloat32Buffer(&d.floatBuffer, len(out))
+	if err := d.decodePLCToFloat32(d.floatBuffer); err != nil {
+		return err
+	}
+	float32ToInt16(d.floatBuffer, out, len(out))
+
+	return nil
 }
 
 // DecodeToFloat32 decodes Opus data into float32 PCM and returns the sample count per channel.

--- a/decoder.go
+++ b/decoder.go
@@ -1277,9 +1277,9 @@ func (d *Decoder) decodeSilkPLCFrame(
 	bandwidth Bandwidth,
 	hybrid bool,
 ) error {
-	durationNanoseconds := samplesPerChannel * 1000000000 / d.sampleRate
+	durationNanoseconds := int(int64(samplesPerChannel) * 1000000000 / int64(d.sampleRate))
 	internalChannelCount := silkOutputChannelCount(d.lastPacketIsStereo, d.channels)
-	internalSamplesPerChannel := bandwidth.SampleRate() * durationNanoseconds / 1000000000
+	internalSamplesPerChannel := int(int64(bandwidth.SampleRate()) * int64(durationNanoseconds) / 1000000000)
 	internal := resizeFloat32Buffer(&d.plcBuffer, internalSamplesPerChannel*internalChannelCount)
 	if err := d.silkDecoder.DecodePLC(
 		internal,

--- a/decoder.go
+++ b/decoder.go
@@ -1178,6 +1178,8 @@ func (d *Decoder) decodeToFloat32(
 	if err != nil {
 		return 0, 0, false, err
 	}
+	d.lastPacketBandwidth = bandwidth
+	d.lastPacketIsStereo = isStereo
 
 	samplesPerChannel, err = d.finishDecodeToFloat32(
 		out,
@@ -1189,8 +1191,6 @@ func (d *Decoder) decodeToFloat32(
 	if err != nil {
 		return 0, 0, false, err
 	}
-	d.lastPacketBandwidth = bandwidth
-	d.lastPacketIsStereo = isStereo
 
 	return samplesPerChannel, bandwidth, isStereo, nil
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -298,6 +298,17 @@ func TestDecodePLCUsesCELTForRedundancy(t *testing.T) {
 	require.NoError(t, decoder.DecodePLC(make([]int16, decoder.sampleRate/50*decoder.channels)))
 }
 
+func TestDecodePLCFrameErrors(t *testing.T) {
+	decoder := NewDecoder()
+	out := make([]float32, decoder.sampleRate/50*decoder.channels)
+	decoder.lastPacketBandwidth = Bandwidth(255)
+
+	assert.Error(t, decoder.decodeCeltPLCFrame(out, decoder.sampleRate/50, false))
+	assert.Error(t, decoder.decodeHybridPLCFrame(out, decoder.sampleRate/50))
+	assert.Error(t, decoder.decodeSilkPLCFrame(out, 0, BandwidthWideband, false))
+	assert.Error(t, decoder.decodeSilkPLCFrame(out, decoder.sampleRate/50, Bandwidth(255), false))
+}
+
 func TestCopyChannels(t *testing.T) {
 	for _, test := range []struct {
 		name           string

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -264,6 +264,60 @@ func TestDecodePLCFrameSizeValidation(t *testing.T) {
 	assert.ErrorIs(t, err, errInvalidPLCFrameSize)
 }
 
+func TestDecodePLCStateValidation(t *testing.T) {
+	var uninitialized Decoder
+	assert.ErrorIs(t, uninitialized.DecodePLC(nil), errInvalidSampleRate)
+
+	decoder := NewDecoder()
+	decoder.channels = 0
+	assert.ErrorIs(t, decoder.DecodePLC(nil), errInvalidChannelCount)
+}
+
+func TestDecodePLCWithoutPreviousPacket(t *testing.T) {
+	decoder := NewDecoder()
+	out := make([]int16, decoder.sampleRate/50*decoder.channels)
+
+	require.NoError(t, decoder.DecodePLC(out))
+	assert.Equal(t, make([]int16, len(out)), out)
+}
+
+func TestDecodePLCUnsupportedMode(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.previousMode = configurationMode(255)
+
+	err := decoder.DecodePLC(make([]int16, decoder.sampleRate/50*decoder.channels))
+	assert.ErrorIs(t, err, errUnsupportedConfigurationMode)
+}
+
+func TestDecodePLCUsesCELTForRedundancy(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.previousMode = configurationModeSilkOnly
+	decoder.previousRedundancy = true
+	decoder.lastPacketBandwidth = BandwidthWideband
+
+	require.NoError(t, decoder.DecodePLC(make([]int16, decoder.sampleRate/50*decoder.channels)))
+}
+
+func TestCopyChannels(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		in             []float32
+		inputChannels  int
+		outputChannels int
+		expected       []float32
+	}{
+		{name: "same", in: []float32{0.25, 0.5}, inputChannels: 2, outputChannels: 2, expected: []float32{0.25, 0.5}},
+		{name: "mono to stereo", in: []float32{0.25}, inputChannels: 1, outputChannels: 2, expected: []float32{0.25, 0.25}},
+		{name: "stereo to mono", in: []float32{0.25, 0.75}, inputChannels: 2, outputChannels: 1, expected: []float32{0.5}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			out := make([]float32, len(test.expected))
+			copyChannels(out, test.in, test.inputChannels, test.outputChannels, 1)
+			assert.Equal(t, test.expected, out)
+		})
+	}
+}
+
 func TestDecodePLCModes(t *testing.T) {
 	for _, test := range []struct {
 		name          string

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -8,6 +8,7 @@ import (
 	_ "embed"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/pion/opus/pkg/oggreader"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // nolint: gochecknoglobals
@@ -85,6 +87,25 @@ func benchmarkData(b *testing.B, data []byte) {
 
 //go:embed testdata/tiny.ogg
 var tinyogg []byte // nolint: gochecknoglobals
+
+func firstTinyOggPacket(t *testing.T) []byte {
+	t.Helper()
+
+	ogg, _, err := oggreader.NewWith(bytes.NewReader(tinyogg))
+	require.NoError(t, err)
+	for {
+		segments, _, err := ogg.ParseNextPage()
+		if errors.Is(err, io.EOF) {
+			require.FailNow(t, "no Opus audio packet found")
+		}
+		require.NoError(t, err)
+		if len(segments) == 0 || bytes.HasPrefix(segments[0], []byte("OpusTags")) {
+			continue
+		}
+
+		return segments[0]
+	}
+}
 
 func TestTinyOgg(t *testing.T) {
 	var out [1920]byte
@@ -203,6 +224,65 @@ func TestDecodeToInt16(t *testing.T) {
 	sampleCount, err := decoder.DecodeToInt16([]byte{byte(0<<3) | byte(frameCodeOneFrame)}, out)
 	assert.NoError(t, err)
 	assert.Equal(t, 80, sampleCount)
+}
+
+func TestDecodePLC(t *testing.T) {
+	packet := firstTinyOggPacket(t)
+
+	for _, channels := range []int{1, 2} {
+		t.Run(fmt.Sprintf("%d_channel", channels), func(t *testing.T) {
+			decoder, err := NewDecoderWithOutput(24000, channels)
+			require.NoError(t, err)
+
+			decoded := make([]int16, 5760*channels)
+			_, err = decoder.DecodeToInt16(packet, decoded)
+			require.NoError(t, err)
+
+			plc := make([]int16, 480*channels)
+			require.NoError(t, decoder.DecodePLC(plc))
+			assert.NotEqual(t, make([]int16, len(plc)), plc)
+
+			require.NoError(t, decoder.DecodePLC(plc))
+		})
+	}
+}
+
+func TestDecodePLCFrameSizeValidation(t *testing.T) {
+	decoder, err := NewDecoderWithOutput(24000, 1)
+	require.NoError(t, err)
+
+	err = decoder.DecodePLC(nil)
+	assert.ErrorIs(t, err, errInvalidPLCFrameSize)
+
+	err = decoder.DecodePLC(make([]int16, 479))
+	assert.ErrorIs(t, err, errInvalidPLCFrameSize)
+
+	err = decoder.DecodePLC(make([]int16, 481))
+	assert.ErrorIs(t, err, errInvalidPLCFrameSize)
+
+	err = decoder.DecodePLC(make([]int16, 960))
+	assert.ErrorIs(t, err, errInvalidPLCFrameSize)
+}
+
+func TestDecodePLCModes(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		configuration Configuration
+		frameSamples  int
+	}{
+		{name: "SILK", configuration: 8, frameSamples: 480},
+		{name: "Hybrid", configuration: 12, frameSamples: 480},
+		{name: "CELT", configuration: 16, frameSamples: 120},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			decoder := NewDecoder()
+			packet := []byte{byte(test.configuration << 3)}
+			_, err := decoder.DecodeToFloat32(packet, make([]float32, test.frameSamples))
+			require.NoError(t, err)
+
+			require.NoError(t, decoder.DecodePLC(make([]int16, 960)))
+		})
+	}
 }
 
 func TestDecodeSilkFrameDurations(t *testing.T) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -176,8 +176,13 @@ func TestDecodeToFloat32(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 160, sampleCount)
 
-	_, err = decoder.DecodeToFloat32([]byte{byte(8<<3) | byte(frameCodeOneFrame)}, out[:319])
+	_, err = decoder.DecodeToFloat32(
+		[]byte{byte(12<<3) | 0b00000100 | byte(frameCodeOneFrame)},
+		out[:319],
+	)
 	assert.ErrorIs(t, err, errOutBufferTooSmall)
+	assert.Equal(t, BandwidthSuperwideband, decoder.lastPacketBandwidth)
+	assert.True(t, decoder.lastPacketIsStereo)
 }
 
 func TestFinishDecodeToFloat32ClearsSilkRedundancyOnError(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -29,4 +29,6 @@ var (
 	errInvalidFrameSize = errors.New("invalid frame size")
 
 	errInvalidFrameByteBudget = errors.New("invalid frame byte budget")
+
+	errInvalidPLCFrameSize = errors.New("PLC output must contain exactly 20 ms of interleaved samples")
 )

--- a/internal/celt/decoder.go
+++ b/internal/celt/decoder.go
@@ -271,7 +271,6 @@ func (d *Decoder) cwrsRowCache() map[cwrsRowKey][]uint32 {
 }
 
 func (d *Decoder) decodeLostFrame(info *frameSideInfo, out []float32) {
-	clear(out)
 	decay := float32(1.5)
 	if d.lossCount > 0 {
 		decay = 0.5
@@ -284,14 +283,46 @@ func (d *Decoder) decodeLostFrame(info *frameSideInfo, out []float32) {
 	if info.channelCount == 1 {
 		copy(d.previousLogE[1][:], d.previousLogE[0][:])
 	}
-	d.resetInactiveBandState(info)
-	for channel := range d.overlap {
-		clear(d.overlap[channel])
-		clear(d.postfilterMem[channel])
+
+	info.postFilter = postFilter{
+		enabled: d.postfilter.gain != 0,
+		period:  d.postfilter.period,
+		gain:    d.postfilter.gain,
+		tapset:  d.postfilter.tapset,
 	}
-	clear(d.preemphasisMem[:])
+	scratch := d.scratchBuffer()
+	x := scratch.x[:infoFrameSampleCount(info)]
+	clear(x)
+	var y []float32
+	if info.channelCount == 2 {
+		y = scratch.y[:len(x)]
+		clear(y)
+	}
+	seed := d.rng
+	if seed == 0 {
+		seed = 0x4A3B2C1D
+	}
+	channels := [2][]float32{x, y}
+	for channel := range info.channelCount {
+		for band := info.startBand; band < info.endBand; band++ {
+			start := int(bandEdges[band]) << info.lm
+			end := int(bandEdges[band+1]) << info.lm
+			for i := start; i < end; i++ {
+				seed = lcgRand(seed)
+				channels[channel][i] = float32(int32(seed) >> 20) //nolint:gosec // Matches the CELT PLC noise source.
+			}
+			renormaliseVector(channels[channel][start:end], end-start, normScaling)
+		}
+	}
+	d.rng = seed
+	d.denormaliseAndSynthesize(info, x, y, d.log2Amp(info), out)
+	d.resetInactiveBandState(info)
 	d.rangeDecoder = rangecoding.Decoder{}
 	d.lossCount++
+}
+
+func infoFrameSampleCount(info *frameSideInfo) int {
+	return shortBlockSampleCount << info.lm
 }
 
 // Mode returns the static CELT mode used by this decoder.

--- a/internal/celt/frame_test.go
+++ b/internal/celt/frame_test.go
@@ -83,6 +83,7 @@ func TestDecodeLostFrameBypassesSilenceSideInfo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, float32(2.5), decoder.previousLogE[0][0])
 	assert.Equal(t, float32(2.5), decoder.previousLogE[1][0])
+	assert.NotZero(t, vectorEnergy(out))
 	assert.Zero(t, decoder.FinalRange())
 	assert.Equal(t, 1, decoder.lossCount)
 }

--- a/internal/celt/synthesis_test.go
+++ b/internal/celt/synthesis_test.go
@@ -273,3 +273,24 @@ func TestDecodeLostFrameSynthesizesAndPreservesHistory(t *testing.T) {
 	assert.NotZero(t, vectorEnergy(decoder.postfilterMem[0]))
 	assert.NotZero(t, vectorEnergy(decoder.postfilterMem[1]))
 }
+
+func TestDecodeConsecutiveLostFrameUsesFallbackSeed(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.lossCount = 1
+	decoder.rng = 0
+	decoder.previousLogE[0][0] = 4
+	decoder.previousLogE[1][0] = 2
+	out := make([]float32, 2*shortBlockSampleCount)
+
+	decoder.decodeLostFrame(&frameSideInfo{
+		startBand:          0,
+		endBand:            maxBands,
+		channelCount:       2,
+		outputChannelCount: 2,
+		outputSampleRate:   sampleRate,
+	}, out)
+	assert.Equal(t, float32(3.5), decoder.previousLogE[0][0])
+	assert.Equal(t, float32(1.5), decoder.previousLogE[1][0])
+	assert.NotZero(t, decoder.rng)
+	assert.Equal(t, 2, decoder.lossCount)
+}

--- a/internal/celt/synthesis_test.go
+++ b/internal/celt/synthesis_test.go
@@ -259,8 +259,9 @@ func TestInverseMDCTAndDeemphasisHelpers(t *testing.T) {
 	assert.NotZero(t, decoder.preemphasisMem[1])
 }
 
-func TestDecodeLostFrameClearsPostfilterHistory(t *testing.T) {
+func TestDecodeLostFrameSynthesizesAndPreservesHistory(t *testing.T) {
 	decoder := NewDecoder()
+	decoder.previousLogE[0][0] = 4
 	decoder.postfilterMem[0][0] = 1
 	decoder.postfilterMem[1][0] = 2
 	out := make([]float32, shortBlockSampleCount)
@@ -268,6 +269,7 @@ func TestDecodeLostFrameClearsPostfilterHistory(t *testing.T) {
 	err := decoder.Decode(nil, out, false, 1, shortBlockSampleCount, 0, maxBands)
 
 	require.NoError(t, err)
-	assert.Zero(t, vectorEnergy(decoder.postfilterMem[0]))
-	assert.Zero(t, vectorEnergy(decoder.postfilterMem[1]))
+	assert.NotZero(t, vectorEnergy(out))
+	assert.NotZero(t, vectorEnergy(decoder.postfilterMem[0]))
+	assert.NotZero(t, vectorEnergy(decoder.postfilterMem[1]))
 }

--- a/internal/silk/decoder.go
+++ b/internal/silk/decoder.go
@@ -80,6 +80,9 @@ type Decoder struct {
 	pitchLags             []int
 	bQ7                   [][]int8
 	bQ7Data               []int8
+	plcLossCount          int
+	plcRandSeed           uint32
+	plcConcealedEnergy    float64
 }
 
 // NewDecoder creates a new Silk Decoder.
@@ -106,6 +109,9 @@ func (d *Decoder) resetPredictionState() {
 	d.previousFrameLPCValues = nil
 	clear(d.finalOutValues)
 	d.n0Q15 = nil
+	d.plcLossCount = 0
+	d.plcRandSeed = 0
+	d.plcConcealedEnergy = 0
 }
 
 // RFC 6716 Sections 4.2.7.4, 4.2.7.5.5, and 4.2.7.6.1 require the side
@@ -2261,8 +2267,10 @@ func (d *Decoder) decodeFrame(
 		aQ12,
 		gainQ16, out,
 	)
+	d.gluePLCFrame(out)
 
 	d.isPreviousFrameVoiced = signalType == frameSignalTypeVoiced
+	d.plcRandSeed = lcgSeed
 
 	// n0Q15 is the LSF coefficients decoded for the prior frame
 	// see normalizeLSFInterpolation.

--- a/internal/silk/plc.go
+++ b/internal/silk/plc.go
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package silk
+
+import "math"
+
+const (
+	plcFirstHarmonicAttenuation = 0.99
+	plcLaterHarmonicAttenuation = 0.95
+	plcFirstNoiseAttenuation    = 0.99
+	plcLaterNoiseAttenuation    = 0.90
+	plcRandomHistorySize        = 128
+)
+
+// DecodePLC conceals a missing SILK packet while matching the channel count
+// selected by the outer Opus decoder.
+//
+//nolint:cyclop
+func (d *Decoder) DecodePLC(
+	out []float32,
+	isStereo bool,
+	outputChannelCount int,
+	nanoseconds int,
+	bandwidth Bandwidth,
+) error {
+	frameCount := silkFrameCount(nanoseconds)
+	silkFrameNanoseconds := min(nanoseconds, nanoseconds20Ms)
+	sfCount := subframeCount(silkFrameNanoseconds)
+	subframeSize := d.samplesInSubframe(bandwidth)
+	if outputChannelCount != 1 && outputChannelCount != 2 {
+		return errOutBufferTooSmall
+	}
+
+	channelCount := 1
+	if isStereo && outputChannelCount == 2 {
+		channelCount = 2
+	}
+	frameSampleCount := subframeSize * sfCount
+	switch {
+	case frameCount == 0 || sfCount == 0:
+		return errUnsupportedSilkFrameDuration
+	case frameSampleCount*frameCount*channelCount > len(out):
+		return errOutBufferTooSmall
+	}
+
+	if !isStereo {
+		for frame := range frameCount {
+			frameOut := out[frame*frameSampleCount : (frame+1)*frameSampleCount]
+			d.concealFrame(frameOut, bandwidth)
+		}
+		d.delayMono(out[:frameSampleCount*frameCount])
+
+		return nil
+	}
+
+	if d.sideDecoder == nil {
+		d.sideDecoder = newChannelDecoder()
+	}
+	mid, side := d.stereoScratchBuffers(frameSampleCount)
+	for frame := range frameCount {
+		d.concealFrame(mid, bandwidth)
+		if d.previousDecodeOnlyMid {
+			clear(side)
+		} else {
+			d.sideDecoder.concealFrame(side, bandwidth)
+		}
+		d.writeStereoFrame(
+			out,
+			mid,
+			side,
+			frame,
+			frameSampleCount,
+			d.previousStereoWeights[0],
+			d.previousStereoWeights[1],
+			bandwidth,
+			outputChannelCount == 2,
+		)
+	}
+	d.finishStereoOutput(out, frameSampleCount, frameCount, outputChannelCount == 2)
+
+	return nil
+}
+
+func (d *Decoder) concealFrame(out []float32, bandwidth Bandwidth) {
+	clear(out)
+	if !d.haveDecoded {
+		return
+	}
+
+	history := d.finalOutValues
+	if d.isPreviousFrameVoiced {
+		d.concealVoiced(out, history, bandwidth)
+	} else {
+		d.concealUnvoiced(out, history, bandwidth)
+	}
+
+	d.plcConcealedEnergy = signalEnergy(out)
+	d.plcLossCount++
+	d.savePLCState(out)
+}
+
+func (d *Decoder) concealVoiced(out, history []float32, bandwidth Bandwidth) {
+	lag := d.previousLag
+	if len(d.pitchLags) > 0 {
+		lag = d.pitchLags[len(d.pitchLags)-1]
+	}
+	lag = max(1, min(lag, len(history)))
+
+	attenuationStep := float32(plcFirstHarmonicAttenuation)
+	if d.plcLossCount > 0 {
+		attenuationStep = plcLaterHarmonicAttenuation
+	}
+	attenuation := attenuationStep
+	subframeSize := max(1, d.samplesInSubframe(bandwidth))
+	for i := range out {
+		if i > 0 && i%subframeSize == 0 {
+			attenuation *= attenuationStep
+		}
+
+		var sample float32
+		if i >= lag {
+			sample = out[i-lag]
+		} else {
+			sample = history[len(history)-lag+i]
+		}
+
+		d.plcRandSeed = 196314165*d.plcRandSeed + 907633515
+		noiseIndex := int(d.plcRandSeed % plcRandomHistorySize)
+		noise := history[len(history)-1-noiseIndex] * (1 - attenuation) * 0.1
+		out[i] = clampNegativeOneToOne(sample*attenuation + noise)
+	}
+
+	maxLag := d.samplesInSubframe(bandwidth) * 18 / 5
+	d.previousLag = min(maxLag, lag+(lag+50)/100)
+}
+
+func (d *Decoder) concealUnvoiced(out, history []float32, bandwidth Bandwidth) {
+	attenuationStep := float32(plcFirstNoiseAttenuation)
+	if d.plcLossCount > 0 {
+		attenuationStep = plcLaterNoiseAttenuation
+	}
+	attenuation := attenuationStep
+	subframeSize := max(1, d.samplesInSubframe(bandwidth))
+	randomStart := len(history) - plcRandomHistorySize
+	for i := range out {
+		if i > 0 && i%subframeSize == 0 {
+			attenuation *= attenuationStep
+		}
+		d.plcRandSeed = 196314165*d.plcRandSeed + 907633515
+		source := history[randomStart+int(d.plcRandSeed%plcRandomHistorySize)]
+		out[i] = clampNegativeOneToOne(source * attenuation)
+	}
+}
+
+func (d *Decoder) savePLCState(out []float32) {
+	d.saveFinalOutValues(out)
+	dLPC := len(d.n0Q15)
+	if dLPC == 0 {
+		return
+	}
+	if cap(d.previousFrameLPCValues) < dLPC {
+		d.previousFrameLPCValues = make([]float32, dLPC)
+	} else {
+		d.previousFrameLPCValues = d.previousFrameLPCValues[:dLPC]
+	}
+	if len(out) >= dLPC {
+		copy(d.previousFrameLPCValues, out[len(out)-dLPC:])
+	}
+}
+
+func (d *Decoder) gluePLCFrame(out []float32) {
+	if d.plcLossCount == 0 {
+		return
+	}
+
+	decodedEnergy := signalEnergy(out)
+	if decodedEnergy > d.plcConcealedEnergy && decodedEnergy > 0 {
+		gain := float32(0)
+		if d.plcConcealedEnergy > 0 {
+			gain = float32(math.Sqrt(d.plcConcealedEnergy / decodedEnergy))
+		}
+		rampSamples := max(1, len(out)/4)
+		gainStep := (1 - gain) / float32(rampSamples)
+		for i := range rampSamples {
+			out[i] *= gain
+			gain = min(float32(1), gain+gainStep)
+		}
+	}
+
+	d.plcLossCount = 0
+	d.plcConcealedEnergy = 0
+}
+
+func signalEnergy(samples []float32) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	var energy float64
+	for _, sample := range samples {
+		energy += float64(sample) * float64(sample)
+	}
+
+	return energy / float64(len(samples))
+}

--- a/internal/silk/plc_test.go
+++ b/internal/silk/plc_test.go
@@ -88,6 +88,7 @@ func TestDecodePLCValidation(t *testing.T) {
 	decoder := NewDecoder()
 	out := make([]float32, 320)
 
+	assert.Zero(t, signalEnergy(nil))
 	assert.ErrorIs(t, decoder.DecodePLC(out, false, 0, nanoseconds20Ms, BandwidthWideband), errOutBufferTooSmall)
 	assert.ErrorIs(t, decoder.DecodePLC(out, false, 1, 0, BandwidthWideband), errUnsupportedSilkFrameDuration)
 	assert.ErrorIs(t, decoder.DecodePLC(out[:319], false, 1, nanoseconds20Ms, BandwidthWideband), errOutBufferTooSmall)

--- a/internal/silk/plc_test.go
+++ b/internal/silk/plc_test.go
@@ -57,3 +57,53 @@ func TestDecodePLCStereoToMono(t *testing.T) {
 	))
 	assert.Positive(t, signalEnergy(out))
 }
+
+func TestDecodePLCVoiced(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.haveDecoded = true
+	decoder.isPreviousFrameVoiced = true
+	decoder.previousLag = 100
+	decoder.pitchLags = []int{100}
+	decoder.n0Q15 = make([]int16, 16)
+	for i := range decoder.finalOutValues {
+		decoder.finalOutValues[i] = float32(i%20-10) / 10
+	}
+
+	firstPLC := make([]float32, 320)
+	require.NoError(t, decoder.DecodePLC(firstPLC, false, 1, nanoseconds20Ms, BandwidthWideband))
+	firstEnergy := signalEnergy(firstPLC)
+	assert.Positive(t, firstEnergy)
+	assert.Equal(t, 101, decoder.previousLag)
+	assert.Len(t, decoder.previousFrameLPCValues, len(decoder.n0Q15))
+
+	decoder.pitchLags = nil
+	secondPLC := make([]float32, 320)
+	require.NoError(t, decoder.DecodePLC(secondPLC, false, 1, nanoseconds20Ms, BandwidthWideband))
+	assert.Less(t, signalEnergy(secondPLC), firstEnergy)
+	assert.Equal(t, 2, decoder.plcLossCount)
+	assert.Equal(t, 102, decoder.previousLag)
+}
+
+func TestDecodePLCValidation(t *testing.T) {
+	decoder := NewDecoder()
+	out := make([]float32, 320)
+
+	assert.ErrorIs(t, decoder.DecodePLC(out, false, 0, nanoseconds20Ms, BandwidthWideband), errOutBufferTooSmall)
+	assert.ErrorIs(t, decoder.DecodePLC(out, false, 1, 0, BandwidthWideband), errUnsupportedSilkFrameDuration)
+	assert.ErrorIs(t, decoder.DecodePLC(out[:319], false, 1, nanoseconds20Ms, BandwidthWideband), errOutBufferTooSmall)
+}
+
+func TestDecodePLCStereoMidOnly(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.haveDecoded = true
+	decoder.sideDecoder = nil
+	decoder.previousDecodeOnlyMid = true
+	for i := range decoder.finalOutValues {
+		decoder.finalOutValues[i] = float32(i%17) / 17
+	}
+
+	out := make([]float32, 640)
+	require.NoError(t, decoder.DecodePLC(out, true, 2, nanoseconds20Ms, BandwidthWideband))
+	assert.NotNil(t, decoder.sideDecoder)
+	assert.Positive(t, signalEnergy(out))
+}

--- a/internal/silk/plc_test.go
+++ b/internal/silk/plc_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package silk
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodePLC(t *testing.T) {
+	decoder := NewDecoder()
+	initialPLC := make([]float32, 320)
+	require.NoError(t, decoder.DecodePLC(initialPLC, false, 1, nanoseconds20Ms, BandwidthWideband))
+	assert.Zero(t, signalEnergy(initialPLC))
+
+	decoded := make([]float32, 320)
+	require.NoError(t, decoder.Decode(testSilkFrame(), decoded, false, nanoseconds20Ms, BandwidthWideband))
+
+	firstPLC := make([]float32, 320)
+	require.NoError(t, decoder.DecodePLC(firstPLC, false, 1, nanoseconds20Ms, BandwidthWideband))
+	firstEnergy := signalEnergy(firstPLC)
+	assert.Positive(t, firstEnergy)
+
+	secondPLC := make([]float32, 320)
+	require.NoError(t, decoder.DecodePLC(secondPLC, false, 1, nanoseconds20Ms, BandwidthWideband))
+	assert.Less(t, signalEnergy(secondPLC), firstEnergy)
+
+	recovered := make([]float32, 320)
+	require.NoError(t, decoder.Decode(testSilkFrame(), recovered, false, nanoseconds20Ms, BandwidthWideband))
+	for _, sample := range recovered {
+		assert.False(t, math.IsNaN(float64(sample)))
+		assert.False(t, math.IsInf(float64(sample), 0))
+	}
+	assert.Zero(t, decoder.plcLossCount)
+}
+
+func TestDecodePLCStereoToMono(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.haveDecoded = true
+	decoder.sideDecoder.haveDecoded = true
+	for i := range decoder.finalOutValues {
+		decoder.finalOutValues[i] = float32(i%17) / 17
+		decoder.sideDecoder.finalOutValues[i] = float32(i%11) / 22
+	}
+
+	out := make([]float32, 320)
+	require.NoError(t, decoder.DecodePLC(
+		out,
+		true,
+		1,
+		nanoseconds20Ms,
+		BandwidthWideband,
+	))
+	assert.Positive(t, signalEnergy(out))
+}


### PR DESCRIPTION
## Summary

- add `Decoder.DecodePLC([]int16) error` to conceal one missing 20 ms packet
- implement stateful, mode-aware concealment for SILK, CELT, and hybrid streams
- preserve decoder history across repeated losses and smooth recovery into the next decoded SILK frame
- support mono and stereo output at every decoder output sample rate
- use wide arithmetic for frame-duration conversion so PLC works on 32-bit targets

## RFC 6716 relationship

[RFC 6716 Section 4.4](https://www.rfc-editor.org/rfc/rfc6716#section-4.4) makes packet-loss concealment optional and allows decoders to use any reasonable PLC algorithm. This implementation is therefore RFC-compliant, but it is not intended to reproduce the RFC reference implementation or libopus sample-for-sample.

The implementation uses the state already maintained by this decoder:

- SILK voiced frames continue a decaying pitch-period waveform; unvoiced frames use decaying history-shaped noise
- CELT frames synthesize energy-shaped spectral noise through the existing CELT synthesis, postfilter, and overlap state
- hybrid frames combine the concealed SILK and CELT layers

## Gap from the RFC reference implementation

- CELT concealment does not implement the reference pitch-period repetition and windowed overlap procedure; it uses energy-shaped spectral noise instead
- SILK concealment does not implement the reference LPC extrapolation path; it uses simpler pitch continuation or history-shaped noise with attenuation and pitch drift
- output is not bit-exact with the reference implementation or libopus
- the public API intentionally handles one 20 ms signed-16-bit frame per call rather than exposing the reference implementation's broader PLC controls

These differences affect concealment quality and output shape, not Opus bitstream conformance.

## Validation

- `go test ./... -covermode=atomic`
- `go vet ./...`
- `golangci-lint run`
- Linux/i386 test binaries compile for the root and SILK packages
- targeted tests cover repeated voiced and unvoiced SILK loss, stereo/mid-only paths, all public PLC validation branches, CELT redundancy selection, and channel mapping
