### PR TITLE
Add dual stereo encoding decision

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -4,7 +4,9 @@
 //nolint:cyclop,gocognit,gocyclo,gosec,lll,maintidx,nestif,nlreturn,wastedassign // Mirrors RFC 6716 allocation flow and bounded entropy-code arithmetic.
 package celt
 
-import "github.com/pion/opus/internal/rangecoding"
+import (
+	"github.com/pion/opus/internal/rangecoding"
+)
 
 const (
 	allocationSteps = 6
@@ -50,6 +52,7 @@ func (d *Decoder) computeAllocation(info *frameSideInfo, bits int) allocationSta
 		&d.rangeDecoder,
 		nil,
 		0,
+		0,
 	)
 	state.balance = balance
 
@@ -73,6 +76,7 @@ func computeAllocation(
 	rangeDecoder *rangecoding.Decoder,
 	rangeEncoder *rangecoding.Encoder,
 	targetIntensity int,
+	targetDualStereo int,
 ) int {
 	if total < 0 {
 		total = 0
@@ -200,6 +204,7 @@ func computeAllocation(
 		rangeDecoder,
 		rangeEncoder,
 		targetIntensity,
+		targetDualStereo,
 	)
 }
 
@@ -228,6 +233,7 @@ func interpolateBitsToPulses(
 	rangeDecoder *rangecoding.Decoder,
 	rangeEncoder *rangecoding.Encoder,
 	targetIntensity int,
+	targetDualStereo int,
 ) int {
 	allocationFloor := channelCount << bitResolution
 	stereo := boolIndex(channelCount > 1)
@@ -333,8 +339,11 @@ func interpolateBitsToPulses(
 		if rangeDecoder != nil {
 			value, _ = rangeDecoder.DecodeUniform(uint32(codedBands + 1 - start))
 		} else {
-			// targetIntensity is an absolute band index; value is relative to start.
-			value = uint32(min(targetIntensity-start, codedBands))
+			relTarget := codedBands - start
+			if targetIntensity > 0 {
+				relTarget = min(targetIntensity-start, codedBands-start)
+			}
+			value = uint32(max(relTarget, 0))
 			rangeEncoder.EncodeUniform(uint32(codedBands+1-start), value)
 		}
 		*intensity = start + int(value)
@@ -349,8 +358,12 @@ func interpolateBitsToPulses(
 		if rangeDecoder != nil {
 			*dualStereo = int(rangeDecoder.DecodeSymbolLogP(1))
 		} else {
-			rangeEncoder.EncodeSymbolLogP(1, 0)
-			*dualStereo = 0
+			dualStereoValue := uint32(0)
+			if targetDualStereo > 0 && *intensity > start {
+				dualStereoValue = 1
+			}
+			rangeEncoder.EncodeSymbolLogP(1, dualStereoValue)
+			*dualStereo = int(dualStereoValue)
 		}
 	} else {
 		*dualStereo = 0
@@ -546,4 +559,60 @@ func (d *Decoder) finalizeFineEnergy(
 			}
 		}
 	}
+}
+
+// chooseDualStereo implements the L1-norm stereo decision from libopus
+// (celt_encoder.c:stereo_analysis). It returns true when dual stereo
+// (independent L/R) is preferred over mid/side coupling.
+//
+// The criterion compares the L1 norm of the mid/side spectrum (scaled by
+// 1/sqrt(2)) against the L1 norm of the L/R spectrum. Dual stereo wins
+// when the M/S representation is relatively expensive — i.e. when the
+// channels are uncorrelated.
+//
+// Mirrors libopus with QCONST16(0.707107f,15) = 23170 for the Q15 scale.
+func chooseDualStereo(mdctL, mdctR []float32, lm int) bool {
+	if lm == 0 {
+		return false
+	}
+
+	scale := 1 << lm
+	var sumLR int64
+	var sumMS int64
+
+	mdctLen := min(len(mdctL), len(mdctR))
+	for band := 0; band < 13 && band+1 < len(bandEdges); band++ {
+		bandStart := scale * int(bandEdges[band])
+		bandEnd := min(scale*int(bandEdges[band+1]), mdctLen)
+		if bandStart >= mdctLen {
+			break
+		}
+
+		for i := bandStart; i < bandEnd; i++ {
+			l := int64(mdctL[i] * (1 << 14))
+			r := int64(mdctR[i] * (1 << 14))
+			m := l + r
+			s := l - r
+			sumLR += abs64(l) + abs64(r)
+			sumMS += abs64(m) + abs64(s)
+		}
+	}
+
+	sumMS = (sumMS * 23170) >> 15
+
+	thetas := 13
+	if lm <= 1 {
+		thetas = 5
+	}
+
+	bins := int64(scale * int(bandEdges[13]))
+
+	return (bins+int64(thetas))*sumMS > bins*sumLR
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
 }

--- a/internal/celt/allocation_test.go
+++ b/internal/celt/allocation_test.go
@@ -114,3 +114,51 @@ func TestIntensityStartBandMonotonic(t *testing.T) {
 		prev = got
 	}
 }
+
+func TestChooseDualStereo(t *testing.T) {
+	n := int(bandEdges[13]) * 4 // lm=2 → scale=4, enough for 13 bands
+	t.Run("MonoSignal", func(t *testing.T) {
+		mdctL := make([]float32, n)
+		mdctR := make([]float32, n)
+		for i := range n {
+			v := float32(i) * 0.01
+			mdctL[i] = v
+			mdctR[i] = v
+		}
+		assert.False(t, chooseDualStereo(mdctL, mdctR, 2),
+			"identical L/R (mono) should always prefer mid/side")
+	})
+
+	t.Run("UncorrelatedSignal", func(t *testing.T) {
+		mdctL := make([]float32, n)
+		mdctR := make([]float32, n)
+		for i := range n {
+			mdctL[i] = float32(i) * 0.1
+			mdctR[i] = float32(n-i) * 0.1
+		}
+		assert.True(t, chooseDualStereo(mdctL, mdctR, 2),
+			"uncorrelated L/R should prefer dual stereo")
+	})
+
+	t.Run("AntiCorrelatedSignal", func(t *testing.T) {
+		mdctL := make([]float32, n)
+		mdctR := make([]float32, n)
+		for i := range n {
+			mdctL[i] = float32(i) * 0.1
+			mdctR[i] = -float32(i) * 0.1
+		}
+		assert.False(t, chooseDualStereo(mdctL, mdctR, 2),
+			"fully anti-correlated stereo should prefer mid/side")
+	})
+
+	t.Run("Lm0ReturnsFalse", func(t *testing.T) {
+		mdctL := make([]float32, n)
+		mdctR := make([]float32, n)
+		for i := range n {
+			mdctL[i] = float32(i) * 0.1
+			mdctR[i] = -float32(i) * 0.1
+		}
+		assert.False(t, chooseDualStereo(mdctL, mdctR, 0),
+			"LM=0 must always return false per RFC §5.3.5")
+	})
+}

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -252,13 +252,17 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, frameBytes, startBand, endBand in
 	info.antiCollapseRsv = 0
 	bits -= info.antiCollapseRsv
 	targetIntensity := 0
+	targetDualStereo := 0
 	if info.channelCount == 2 {
 		frameSampleCount := shortBlockSampleCount << info.lm
 		bitrateBps := int(info.totalBits) * sampleRate / frameSampleCount
 		frameMs := max(1, frameSampleCount*1000/sampleRate)
 		targetIntensity = intensityStartBand(bitrateBps, frameMs)
+		if chooseDualStereo(analysis.mdct[0], analysis.mdct[1], info.lm) {
+			targetDualStereo = 1
+		}
 	}
-	info.allocation = e.computeAllocationMono(&info, bits, targetIntensity)
+	info.allocation = e.computeAllocationMono(&info, bits, targetIntensity, targetDualStereo)
 	e.encodeFineEnergy(&info, info.allocation.fineQuant, targetLogE)
 
 	totalBits := (int(info.totalBits) << bitResolution) - info.antiCollapseRsv
@@ -378,7 +382,9 @@ func (e *Encoder) encodeFineEnergy(info *frameSideInfo, fineQuant [maxBands]int,
 	}
 }
 
-func (e *Encoder) computeAllocationMono(info *frameSideInfo, bits int, targetIntensity int) allocationState {
+func (e *Encoder) computeAllocationMono(
+	info *frameSideInfo, bits, targetIntensity, targetDualStereo int,
+) allocationState {
 	state := allocationState{bits: bits}
 	caps := allocationCaps(info.lm, info.channelCount)
 	balance := 0
@@ -400,6 +406,7 @@ func (e *Encoder) computeAllocationMono(info *frameSideInfo, bits int, targetInt
 		nil,
 		&e.rangeEncoder,
 		targetIntensity,
+		targetDualStereo,
 	)
 	state.balance = balance
 

--- a/internal/celt/encoder_test.go
+++ b/internal/celt/encoder_test.go
@@ -206,6 +206,32 @@ func TestEncodeFrameStereoSeparatedBands(t *testing.T) {
 	assert.Greater(t, vectorEnergy(out), 1e-6)
 }
 
+func TestEncodeFrameStereoDualStereoRoundTrip(t *testing.T) {
+	encoder := NewEncoder()
+	decoder := NewDecoder()
+
+	frameSampleCount := shortBlockSampleCount << maxLM
+	frameBytes := 120
+
+	L := make([]float32, frameSampleCount)
+	R := make([]float32, frameSampleCount)
+	for i := range frameSampleCount {
+		L[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
+		R[i] = float32(math.Cos(2 * math.Pi * 1200 * float64(i) / sampleRate))
+	}
+
+	data, err := encoder.EncodeFrame([][]float32{L, R}, frameBytes, 0, maxBands)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	out := make([]float32, frameSampleCount*2)
+	require.NoError(t, decoder.Decode(data, out, true, 2, frameSampleCount, 0, maxBands))
+
+	assert.Equal(t, encoder.FinalRange(), decoder.FinalRange(),
+		"range coder must be in sync at frameBytes=%d", frameBytes)
+	assert.Greater(t, vectorEnergy(out), 1e-6)
+}
+
 func TestEncodeBandThetaAllCases(t *testing.T) {
 	enc := NewEncoder()
 	enc.rangeEncoder.Init()


### PR DESCRIPTION
#### Description
Follow-up to #130. The encoder was hardcoding dualStereo = 0 in the allocation — mid/side coupling was always on, even when encoding the channels independently would've been cheaper. This adds the actual decision from libopus stereo_analysis() (celt_encoder.c:957).
The heuristic: over the first 13 bands, compare L1 of mid/side (M=L+R, S=L−R, scaled by 1/√2) against L1 of L/R. If M/S representation costs more, use dual stereo. Small bias term (thetas) favors mid/side when it's close. 2.5 ms frames always use mid/side — not enough data to decide.
Also fixed a uint32 wrapping bug in the intensity path where targetIntensity - start went negative.
#### Reference issue

Fixes #...
