### PR TITLE
Reduce per-frame allocations in the MDCT/FFT encode path

### DIFF
--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -12,6 +12,8 @@ const preemphasisCoefficient = 0.85000610
 type analysisState struct {
 	prevPCM        [2][]float32
 	preemphasisMem [2]float32
+	preScratch     [2][]float32
+	mdctInput      [2][]float32
 }
 
 type analysisResult struct {
@@ -21,17 +23,31 @@ type analysisResult struct {
 }
 
 func newAnalysisState() analysisState {
-	return analysisState{
+	maxFrame := shortBlockSampleCount << maxLM
+	state := analysisState{
 		prevPCM: [2][]float32{
 			make([]float32, shortBlockSampleCount),
 			make([]float32, shortBlockSampleCount),
 		},
+		preScratch: [2][]float32{
+			make([]float32, maxFrame),
+			make([]float32, maxFrame),
+		},
+		mdctInput: [2][]float32{
+			make([]float32, shortBlockSampleCount+maxFrame),
+			make([]float32, shortBlockSampleCount+maxFrame),
+		},
 	}
+
+	return state
 }
 
 // analyzeFrame applies pre-emphasis, builds the MDCT overlap window, runs the
 // forward MDCT, and returns per-band log amplitude for each input channel.
-func analyzeFrame(mode *Mode, pcm [][]float32, startBand, endBand int, state *analysisState) (analysisResult, error) {
+func analyzeFrame(
+	mode *Mode, pcm [][]float32, startBand, endBand int,
+	state *analysisState, mdctScratch *forwardMDCTScratch, fftScratch *[]complex32,
+) (analysisResult, error) {
 	lm, err := mode.LMForFrameSampleCount(len(pcm[0]))
 	if err != nil {
 		return analysisResult{}, err
@@ -50,14 +66,14 @@ func analyzeFrame(mode *Mode, pcm [][]float32, startBand, endBand int, state *an
 	}
 
 	for ch := range pcm {
-		pre := make([]float32, len(pcm[ch]))
+		pre := state.preScratch[ch][:len(pcm[ch])]
 		applyPreemphasis(pcm[ch], pre, &state.preemphasisMem[ch])
 
-		mdctInput := make([]float32, shortBlockSampleCount+len(pre))
+		mdctInput := state.mdctInput[ch][:shortBlockSampleCount+len(pre)]
 		copy(mdctInput, state.prevPCM[ch])
 		copy(mdctInput[shortBlockSampleCount:], pre)
 
-		res.mdct[ch] = forwardMDCT(mdctInput)
+		res.mdct[ch] = forwardMDCTWithScratch(mdctInput, ch, mdctScratch, fftScratch)
 		if res.mdct[ch] == nil {
 			return analysisResult{}, errInvalidFrameSize
 		}

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -27,7 +27,9 @@ type Encoder struct {
 	previousLogE1 [2][maxBands]float32
 	previousLogE2 [2][maxBands]float32
 
-	analysis analysisState
+	analysis    analysisState
+	mdctScratch forwardMDCTScratch
+	fftScratch  []complex32
 }
 
 func NewEncoder() Encoder {
@@ -219,7 +221,9 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, frameBytes, startBand, endBand in
 
 	e.rangeEncoder.Init()
 
-	analysis, err := analyzeFrame(e.mode, pcm, startBand, endBand, &e.analysis)
+	analysis, err := analyzeFrame(
+		e.mode, pcm, startBand, endBand, &e.analysis, &e.mdctScratch, &e.fftScratch,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/celt/encoder_test.go
+++ b/internal/celt/encoder_test.go
@@ -11,6 +11,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func BenchmarkEncodeFrameMono(b *testing.B) {
+	b.ReportAllocs()
+
+	frameSampleCount := shortBlockSampleCount << maxLM
+	frameBytes := 60
+
+	pcm := make([]float32, frameSampleCount)
+	for i := range pcm {
+		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
+	}
+
+	encoder := NewEncoder()
+	input := [][]float32{pcm}
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := encoder.EncodeFrame(input, frameBytes, 0, maxBands)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeFrameStereo(b *testing.B) {
+	b.ReportAllocs()
+
+	frameSampleCount := shortBlockSampleCount << maxLM
+	frameBytes := 120
+
+	L := make([]float32, frameSampleCount)
+	R := make([]float32, frameSampleCount)
+	for i := range frameSampleCount {
+		L[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
+		R[i] = float32(math.Sin(2 * math.Pi * 660 * float64(i) / sampleRate))
+	}
+
+	encoder := NewEncoder()
+	input := [][]float32{L, R}
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := encoder.EncodeFrame(input, frameBytes, 0, maxBands)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestEncodeFrameRoundTripMono20ms(t *testing.T) {
 	encoder := NewEncoder()
 	decoder := NewDecoder()

--- a/internal/celt/fft.go
+++ b/internal/celt/fft.go
@@ -83,7 +83,7 @@ func newFFTPlan(n int) *fftPlan {
 }
 
 //nolint:cyclop // Cooley-Tukey mixed-radix FFT: three passes + un-permute.
-func fft(in []complex32) {
+func fftWithScratch(in []complex32, scratch *[]complex32) {
 	n := len(in)
 	if n <= 1 {
 		return
@@ -97,16 +97,19 @@ func fft(in []complex32) {
 		return
 	}
 
-	scratch := make([]complex32, n+plan.odd)
+	if cap(*scratch) < n+plan.odd {
+		*scratch = make([]complex32, n+plan.odd)
+	}
+	scratchBuf := (*scratch)[:n+plan.odd]
 
 	for col := range plan.pow2 {
-		colBuf := scratch[col*plan.odd : (col+1)*plan.odd]
+		colBuf := scratchBuf[col*plan.odd : (col+1)*plan.odd]
 		for row := range plan.odd {
 			colBuf[row] = in[row*plan.pow2+col]
 		}
-		directDFT(colBuf, scratch[n:], plan.directTwiddles, plan.odd)
+		directDFT(colBuf, scratchBuf[n:], plan.directTwiddles, plan.odd)
 		for row := range plan.odd {
-			in[row*plan.pow2+col] = scratch[n+row]
+			in[row*plan.pow2+col] = scratchBuf[n+row]
 		}
 	}
 
@@ -129,10 +132,16 @@ func fft(in []complex32) {
 		for k2 := range plan.pow2 {
 			p := k1*plan.pow2 + k2
 			q := k1 + k2*plan.odd
-			scratch[q] = in[p]
+			scratchBuf[q] = in[p]
 		}
 	}
-	copy(in, scratch[:n])
+	copy(in, scratchBuf[:n])
+}
+
+//nolint:cyclop // Cooley-Tukey mixed-radix FFT: three passes + un-permute.
+func fft(in []complex32) {
+	var scratch []complex32
+	fftWithScratch(in, &scratch)
 }
 
 func fftRadix2(in []complex32, plan *fftPlan) {

--- a/internal/celt/mdct.go
+++ b/internal/celt/mdct.go
@@ -3,11 +3,27 @@
 
 package celt
 
+type forwardMDCTScratch struct {
+	deshuffled  [2][]float32
+	postRotated [2][]float32
+	fftOut      [2][]complex32
+	preRotated  [2][]complex32
+	freq        [2][]float32
+}
+
 // forwardComplexDFT computes the forward complex DFT via fft and 1/N scaling.
 func forwardComplexDFT(in []complex32) []complex32 {
+	scratch := []complex32(nil)
+
+	return forwardComplexDFTWithScratch(in, &scratch)
+}
+
+// forwardComplexDFTWithScratch reuses the supplied scratch buffer for the
+// intermediate FFT allocation.
+func forwardComplexDFTWithScratch(in []complex32, scratch *[]complex32) []complex32 {
 	out := make([]complex32, len(in))
 	copy(out, in)
-	fft(out)
+	fftWithScratch(out, scratch)
 	n := float32(len(out))
 	for i := range out {
 		out[i].r /= n
@@ -106,4 +122,103 @@ func undoMDCTShear(a, b, sine float32) (float32, float32) {
 	denominator := 1 + sine*sine
 
 	return (a + b*sine) / denominator, (b - a*sine) / denominator
+}
+
+func ensureMDCTScratch(scratch *forwardMDCTScratch, n2 int) {
+	for ch := range scratch.deshuffled {
+		if cap(scratch.deshuffled[ch]) < n2 {
+			scratch.deshuffled[ch] = make([]float32, n2)
+			scratch.postRotated[ch] = make([]float32, n2)
+			scratch.freq[ch] = make([]float32, n2)
+		}
+		if cap(scratch.fftOut[ch]) < n2/2 {
+			scratch.fftOut[ch] = make([]complex32, n2/2)
+			scratch.preRotated[ch] = make([]complex32, n2/2)
+		}
+		scratch.deshuffled[ch] = scratch.deshuffled[ch][:n2]
+		scratch.postRotated[ch] = scratch.postRotated[ch][:n2]
+		scratch.freq[ch] = scratch.freq[ch][:n2]
+		scratch.fftOut[ch] = scratch.fftOut[ch][:n2/2]
+		scratch.preRotated[ch] = scratch.preRotated[ch][:n2/2]
+	}
+}
+
+//nolint:cyclop // Mirrors the RFC 6716 Section 4.3.7 IMDCT structure step-for-step.
+func forwardMDCTWithScratch(
+	time []float32, channel int, scratch *forwardMDCTScratch, fftScratch *[]complex32,
+) []float32 {
+	overlap := shortBlockSampleCount
+	if len(time) <= overlap {
+		return nil
+	}
+
+	frameSampleCount := len(time) - overlap
+	if frameSampleCount <= 0 || frameSampleCount%2 != 0 {
+		return nil
+	}
+
+	n2 := frameSampleCount
+	n := 2 * n2
+	n4 := n >> 2
+	leftPlain := n4 - overlap/2
+	plan := inverseTransformPlanForFrameSampleCount(frameSampleCount)
+
+	ensureMDCTScratch(scratch, n2)
+	deshuffled := scratch.deshuffled[channel]
+	postRotated := scratch.postRotated[channel]
+	fftOut := scratch.fftOut[channel]
+	freq := scratch.freq[channel]
+
+	for i := 0; i < overlap/2; i++ {
+		windowValue := celtWindow(i)
+		deshuffled[overlap/2-1-i] = -time[i] * windowValue
+	}
+
+	for i := range leftPlain {
+		deshuffled[n4+i] = time[n4+overlap/2+i]
+	}
+
+	for i := 0; i < overlap/2; i++ {
+		windowValue := celtWindow(i)
+		deshuffled[n2-overlap/2+i] = time[n2+overlap-1-i] * windowValue
+	}
+
+	for i := range n4 {
+		postRotated[2*i] = -deshuffled[2*i]
+		postRotated[n2-1-2*i] = deshuffled[2*i+1]
+	}
+
+	for i := range n4 {
+		yr, yi := undoMDCTShear(postRotated[2*i], postRotated[2*i+1], plan.sine)
+		cosine := plan.rotateCos[i]
+		sineQuarter := plan.rotateSinQuarter[i]
+
+		fftOut[i] = complex32{
+			r: yr*cosine + yi*sineQuarter,
+			i: yi*cosine - yr*sineQuarter,
+		}
+	}
+
+	// Copy fftOut into the preRotated scratch buffer and run the FFT in-place
+	// to avoid a per-frame heap allocation.
+	preRotated := scratch.preRotated[channel]
+	copy(preRotated, fftOut)
+	fftWithScratch(preRotated, fftScratch)
+	scale := 1 / float32(len(preRotated))
+	for i := range preRotated {
+		preRotated[i].r *= scale
+		preRotated[i].i *= scale
+	}
+
+	for i, value := range preRotated {
+		yr, yi := undoMDCTShear(value.r, value.i, plan.sine)
+		cosine := plan.rotateCos[i]
+		sineQuarter := plan.rotateSinQuarter[i]
+		xp1 := sineQuarter*yr - cosine*yi
+		xp2 := -cosine*yr - sineQuarter*yi
+		freq[2*i] = xp1
+		freq[n2-1-2*i] = xp2
+	}
+
+	return freq
 }


### PR DESCRIPTION
#### Description
Follow-up to #127. After the twiddle cache landed, profiling showed the biggest remaining alloc sources were in analyzeFrame: two heap allocations per channel per frame (pre-emphasis buffer and MDCT overlap window), plus five more inside forwardMDCT itself (deshuffled, postRotated, fftOut, preRotated, freq). All of those are the same size every frame so theres no reason to keep allocating them.
  
This moves them into scratch buffers that live on the Encoder struct and get reused across frames. The FFT scratch (the mixed-radix work buffer) goes the same way.
  
Benchmarks on my machine (i3-9100F, 20ms frames, internal/celt):
 
- mono:   ~73 allocs/frame → 64,  ~22 KB/frame → 14.7 KB,  ~75 µs → ~70 µs
- stereo: ~151 allocs/frame → 133, ~43 KB/frame → 26.8 KB, ~127 µs → ~135 µs

The remaining 64/133 allocs are in encode_bands, pvq and cwrs — those need a bigger refactor that touches the same files as the transient detection PR, so Im leaving them for a separate pass after that lands.

Also adds BenchmarkEncodeFrameMono and BenchmarkEncodeFrameStereo with
-benchmem so regressions dont slip through silently going forward.

#### Reference issue
Fixes #...
