### PR TITLE
Reduce encoder hot path to 1 alloc/frame

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -170,22 +170,13 @@ func (e *Encoder) EncodeFloat32(in []float32, out []byte) (int, error) {
 	if len(out) < frameBytes+1 {
 		return 0, errOutBufferTooSmall
 	}
-
-	payload, err := e.celtEncoder.EncodeFrame(channels, frameBytes, 0, e.celtEncoder.Mode().BandCount())
+	out[0] = byte(e.tocHeader())
+	n, err := e.celtEncoder.EncodeFrame(channels, out[1:frameBytes+1], frameBytes, 0, e.celtEncoder.Mode().BandCount())
 	if err != nil {
 		return 0, err
 	}
-	if len(payload) > maxOpusFrameSize {
-		return 0, fmt.Errorf("%w: frame size %d exceeds %d", errMalformedPacket, len(payload), maxOpusFrameSize)
-	}
-	if len(out) < len(payload)+1 {
-		return 0, errOutBufferTooSmall
-	}
 
-	out[0] = byte(e.tocHeader())
-	copy(out[1:], payload)
-
-	return 1 + len(payload), nil
+	return 1 + n, nil
 }
 
 func (e *Encoder) tocHeader() tableOfContentsHeader {

--- a/internal/celt/cwrs.go
+++ b/internal/celt/cwrs.go
@@ -286,26 +286,41 @@ func cwrsPreviousRow(u []uint32, n int, value0 uint32) {
 	u[len(u)-1] = value
 }
 
-// encodePulses writes a CWRS index for the PVQ pulse vector y to the range
-// encoder. It is the inverse of decodePulses.
-func encodePulses(y []int, n, k int, rangeEncoder *rangecoding.Encoder) {
+// cwrsRowFromScratch returns a k+2 slice backed by scratch when k fits within
+// cwrsMaxPulseCount. For larger k it allocates a new slice, matching the same
+// guard that decodePulses uses so both paths handle extreme pulse counts safely.
+func cwrsRowFromScratch(scratch []uint32, k int) []uint32 {
+	if k > cwrsMaxPulseCount {
+		return make([]uint32, k+2)
+	}
+
+	return scratch[:k+2]
+}
+
+// encodePulses writes the CWRS index for PVQ vector y to the range encoder.
+// It is the inverse of decodePulses.
+func encodePulses(y []int, n, k int, rangeEncoder *rangecoding.Encoder, scratch []uint32) {
 	if k <= 0 {
 		return
 	}
-	index := cwrsEncode(y, n, k)
-	u := cwrsUrow(n, k)
+	index := cwrsEncode(y, n, k, scratch)
+	// cwrsEncode walks scratch backward via cwrsPreviousRow, so I have to
+	// reinitialise it before reading u[k]+u[k+1] for the uniform-coder total.
+	u := cwrsRowFromScratch(scratch, k)
+	cwrsUrowInto(u, n)
 	total := u[k] + u[k+1]
 	rangeEncoder.EncodeUniform(total, index)
 }
 
 // cwrsEncode maps a PVQ pulse vector to its unique CWRS codeword index.
 // It is the exact inverse of cwrsDecode for a fixed (n, k) codebook.
-func cwrsEncode(y []int, n, k int) uint32 {
+func cwrsEncode(y []int, n, k int, scratch []uint32) uint32 {
 	if n <= 0 || k <= 0 {
 		return 0
 	}
 
-	u := cwrsUrow(n, k)
+	u := cwrsRowFromScratch(scratch, k)
+	cwrsUrowInto(u, n)
 	var index uint32
 
 	for j := range n {

--- a/internal/celt/cwrs_test.go
+++ b/internal/celt/cwrs_test.go
@@ -134,3 +134,18 @@ func TestCWRSEncodeDecodeRoundTrip(t *testing.T) {
 		assert.Equal(t, expected, got)
 	}
 }
+
+func TestCWRSRowFromScratchSmallK(t *testing.T) {
+	scratch := make([]uint32, cwrsMaxPulseCount+2)
+	row := cwrsRowFromScratch(scratch, 3)
+	// Small k: must return a slice backed by scratch, not a new allocation.
+	assert.Len(t, row, 5)
+	assert.Equal(t, &scratch[0], &row[0])
+}
+
+func TestCWRSRowFromScratchLargeK(t *testing.T) {
+	scratch := make([]uint32, cwrsMaxPulseCount+2)
+	// k > cwrsMaxPulseCount must allocate a new slice to avoid a bounds panic.
+	row := cwrsRowFromScratch(scratch, cwrsMaxPulseCount+1)
+	assert.Len(t, row, cwrsMaxPulseCount+3)
+}

--- a/internal/celt/cwrs_test.go
+++ b/internal/celt/cwrs_test.go
@@ -95,7 +95,8 @@ func cwrsDecodeGenericForTest(vector []int, dimension, pulseCount int, index uin
 }
 
 func TestCWRSEncodeZeroPulses(t *testing.T) {
-	assert.Equal(t, uint32(0), cwrsEncode([]int{0, 0, 0}, 3, 0))
+	scratch := make([]uint32, 2)
+	assert.Equal(t, uint32(0), cwrsEncode([]int{0, 0, 0}, 3, 0, scratch))
 }
 
 func TestCWRSEncodeRoundTrip(t *testing.T) {
@@ -108,7 +109,7 @@ func TestCWRSEncodeRoundTrip(t *testing.T) {
 		vector := make([]int, n)
 		cwrsDecode(vector, n, k, index, append([]uint32(nil), row...))
 
-		encoded := cwrsEncode(vector, n, k)
+		encoded := cwrsEncode(vector, n, k, append([]uint32(nil), row...))
 		assert.Equal(t, index, encoded)
 	}
 }
@@ -124,7 +125,7 @@ func TestCWRSEncodeDecodeRoundTrip(t *testing.T) {
 	}
 
 	for _, expected := range vectors {
-		index := cwrsEncode(expected, len(expected), 2)
+		index := cwrsEncode(expected, len(expected), 2, make([]uint32, 4))
 
 		got := make([]int, len(expected))
 		row := cwrsUrow(3, 2)

--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -12,9 +12,12 @@ import (
 )
 
 type bandEncodeState struct {
-	rangeEncoder *rangecoding.Encoder
-	seed         uint32
-	tmpScratch   []float32
+	rangeEncoder   *rangecoding.Encoder
+	seed           uint32
+	tmpScratch     []float32
+	norm           []float32
+	lowbandScratch []float32
+	collapseMasks  []byte
 }
 
 func (s *bandEncodeState) floatScratch(n int) []float32 {
@@ -25,8 +28,9 @@ func normaliseBandsForEncoding(
 	info *frameSideInfo,
 	mdct []float32,
 	logBandAmp [maxBands]float32,
+	out []float32,
 ) []float32 {
-	out := make([]float32, len(mdct))
+	out = out[:len(mdct)]
 	scale := 1 << info.lm
 
 	for band := info.startBand; band < info.endBand; band++ {
@@ -52,6 +56,9 @@ func quantAllBandsMono(
 	x []float32,
 	totalBits int,
 	state *bandEncodeState,
+	yScratch []int,
+	absXScratch, signScratch []float32,
+	cwrsScratch []uint32,
 ) []byte {
 	blocks := 1
 	if info.transient {
@@ -59,9 +66,9 @@ func quantAllBandsMono(
 	}
 	scale := 1 << info.lm
 	frameBins := scale * int(bandEdges[maxBands])
-	norm := make([]float32, frameBins)
-	lowbandScratch := make([]float32, scale*int(bandEdges[maxBands]-bandEdges[maxBands-1]))
-	collapseMasks := make([]byte, maxBands)
+	norm := slicetools.Resize(&state.norm, frameBins)
+	lowbandScratch := slicetools.Resize(&state.lowbandScratch, scale*int(bandEdges[maxBands]-bandEdges[maxBands-1]))
+	collapseMasks := slicetools.Resize(&state.collapseMasks, maxBands)
 	lowbandOffset := 0
 	updateLowband := true
 	balance := info.allocation.balance
@@ -137,6 +144,7 @@ func quantAllBandsMono(
 			lowbandScratch,
 			fill,
 			state,
+			yScratch, absXScratch, signScratch, cwrsScratch,
 		)
 		collapseMasks[band] = byte(mask)
 		balance += info.allocation.pulses[band] + tell
@@ -163,6 +171,9 @@ func quantBandMono(
 	lowbandScratch []float32,
 	fill uint,
 	state *bandEncodeState,
+	yScratch []int,
+	absXScratch, signScratch []float32,
+	cwrsScratch []uint32,
 ) uint {
 	fullBand := x
 	originalN := n
@@ -305,6 +316,7 @@ func quantBandMono(
 				lowbandScratch,
 				fill,
 				state,
+				yScratch, absXScratch, signScratch, cwrsScratch,
 			)
 			rebalance = midBits - (rebalance - *remainingBits)
 			if rebalance > 3<<bitResolution && itheta != 0 {
@@ -327,6 +339,7 @@ func quantBandMono(
 				lowbandScratch,
 				originalFill>>blocks,
 				state,
+				yScratch, absXScratch, signScratch, cwrsScratch,
 			) << collapseShift
 		} else {
 			collapseMask = quantBandMono(
@@ -346,6 +359,7 @@ func quantBandMono(
 				lowbandScratch,
 				originalFill>>blocks,
 				state,
+				yScratch, absXScratch, signScratch, cwrsScratch,
 			) << collapseShift
 			rebalance = sideBits - (rebalance - *remainingBits)
 			if rebalance > 3<<bitResolution && itheta != 16384 {
@@ -368,6 +382,7 @@ func quantBandMono(
 				lowbandScratch,
 				fill,
 				state,
+				yScratch, absXScratch, signScratch, cwrsScratch,
 			)
 		}
 	} else {
@@ -381,7 +396,7 @@ func quantBandMono(
 			*remainingBits -= currentBits
 		}
 		if q != 0 {
-			collapseMask = algQuant(x, n, getPulses(q), spread, blocks, state.rangeEncoder, gain)
+			collapseMask = algQuant(x, n, getPulses(q), spread, blocks, state.rangeEncoder, gain, yScratch, absXScratch, signScratch, cwrsScratch)
 		} else {
 			mask := uint(1<<blocks) - 1
 			fill &= mask
@@ -501,6 +516,9 @@ func quantBandStereo(
 	lowbandScratch []float32,
 	fill uint,
 	state *bandEncodeState,
+	yScratch [2][]int,
+	absXScratch, signScratch [2][]float32,
+	cwrsScratch []uint32,
 ) uint {
 	if n == 1 {
 		xSign := uint32(0)
@@ -587,6 +605,7 @@ func quantBandStereo(
 		collapseMask := quantBandMono(
 			band, x, n, midBits, spread, blocks, tfChange,
 			lowband, remainingBits, lm, nil, 0, 1, lowbandScratch, fill, state,
+			yScratch[0], absXScratch[0], signScratch[0], cwrsScratch,
 		)
 		rebalance = midBits - (rebalance - *remainingBits)
 		if rebalance > 3<<bitResolution && itheta != 0 {
@@ -595,6 +614,7 @@ func quantBandStereo(
 		collapseMask |= quantBandMono(
 			band, y, n, sideBits, spread, blocks, tfChange,
 			nil, remainingBits, lm, nil, 0, gain*side, nil, originalFill>>blocks, state,
+			yScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
 		)
 		if n != 2 {
 			stereoMerge(x, y, mid, n)
@@ -611,6 +631,7 @@ func quantBandStereo(
 	collapseMask := quantBandMono(
 		band, y, n, sideBits, spread, blocks, tfChange,
 		nil, remainingBits, lm, nil, 0, gain*side, nil, originalFill>>blocks, state,
+		yScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
 	)
 	rebalance = sideBits - (rebalance - *remainingBits)
 	if rebalance > 3<<bitResolution && itheta != 16384 {
@@ -619,6 +640,7 @@ func quantBandStereo(
 	collapseMask |= quantBandMono(
 		band, x, n, midBits, spread, blocks, tfChange,
 		lowband, remainingBits, lm, nil, 0, 1, lowbandScratch, fill, state,
+		yScratch[0], absXScratch[0], signScratch[0], cwrsScratch,
 	)
 	if n != 2 {
 		stereoMerge(x, y, mid, n)
@@ -684,6 +706,9 @@ func quantAllBandsStereo(
 	y []float32,
 	totalBits int,
 	state *bandEncodeState,
+	yScratch [2][]int,
+	absXScratch, signScratch [2][]float32,
+	cwrsScratch []uint32,
 ) []byte {
 	channelCount := 2
 	blocks := 1
@@ -692,15 +717,15 @@ func quantAllBandsStereo(
 	}
 	scale := 1 << info.lm
 	frameBins := scale * int(bandEdges[maxBands])
-	norm := make([]float32, channelCount*frameBins)
+	norm := slicetools.Resize(&state.norm, channelCount*frameBins)
 	norm2 := norm[frameBins:]
-	lowbandScratch := make([]float32, scale*int(bandEdges[maxBands]-bandEdges[maxBands-1]))
-	collapseMasks := make([]byte, channelCount*maxBands)
+	lowbandScratch := slicetools.Resize(&state.lowbandScratch, scale*int(bandEdges[maxBands]-bandEdges[maxBands-1]))
+	collapseMasks := slicetools.Resize(&state.collapseMasks, channelCount*maxBands)
 
 	lowbandOffset := 0
 	updateLowband := true
 	balance := info.allocation.balance
-	dualStereo := channelCount == 2 && info.allocation.dualStereo != 0
+	dualStereo := info.allocation.dualStereo != 0
 	for band := info.startBand; band < info.endBand; band++ {
 		tell := int(state.rangeEncoder.TellFrac())
 		if band != info.startBand {
@@ -788,6 +813,7 @@ func quantAllBandsStereo(
 				lowbandScratch,
 				xMask,
 				state,
+				yScratch[0], absXScratch[0], signScratch[0], cwrsScratch,
 			)
 			var lowbandY []float32
 			if effectiveLowband >= 0 {
@@ -810,6 +836,7 @@ func quantAllBandsStereo(
 				lowbandScratch,
 				yMask,
 				state,
+				yScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
 			)
 		} else {
 			xMask = quantBandStereo(
@@ -829,6 +856,7 @@ func quantAllBandsStereo(
 				lowbandScratch,
 				xMask|yMask,
 				state,
+				yScratch, absXScratch, signScratch, cwrsScratch,
 			)
 			yMask = xMask
 		}

--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -102,7 +102,13 @@ func quantAllBandsMono(
 		effectiveLowband := -1
 		fill := uint(0)
 		if lowbandOffset != 0 && (info.spread != spreadAggressive || blocks > 1 || info.tfChange[band] < 0) {
-			effectiveLowband = max(scale*int(bandEdges[info.startBand]), scale*int(bandEdges[lowbandOffset])-bandWidth)
+			startEdge := scale * int(bandEdges[info.startBand])
+			lowbandEdge := scale*int(bandEdges[lowbandOffset]) - bandWidth
+			if lowbandEdge > startEdge { //nolint:modernize // GoLand cannot infer T for max() on these int expressions.
+				effectiveLowband = lowbandEdge
+			} else {
+				effectiveLowband = startEdge
+			}
 			foldStart := lowbandOffset
 			for {
 				foldStart--

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -229,27 +229,31 @@ func (e *Encoder) encodeAllocationTrim(info *frameSideInfo, totalBitsEighth uint
 	}
 }
 
-// EncodeFrame encodes one CELT frame from float PCM.
+// EncodeFrame encodes one CELT frame from float PCM into dst.
+// It returns the number of bytes written. dst must be at least frameBytes long.
 //
 //nolint:cyclop // The frame encoder mirrors RFC 6716 flow and is intentionally linear.
-func (e *Encoder) EncodeFrame(pcm [][]float32, frameBytes, startBand, endBand int) ([]byte, error) {
+func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand, endBand int) (int, error) {
 	if e.Mode() == nil {
 		e.mode = DefaultMode()
 	}
 	if len(pcm) != 1 && len(pcm) != 2 {
-		return nil, errInvalidChannelCount
+		return 0, errInvalidChannelCount
 	}
 	frameSamples := shortBlockSampleCount << e.mode.MaxLM()
 	for ch := range pcm {
 		if len(pcm[ch]) != frameSamples {
-			return nil, errInvalidFrameSize
+			return 0, errInvalidFrameSize
 		}
 	}
 	if startBand < 0 || startBand >= e.mode.BandCount() {
-		return nil, errInvalidBand
+		return 0, errInvalidBand
 	}
 	if endBand <= startBand || endBand > e.mode.BandCount() {
-		return nil, errInvalidBand
+		return 0, errInvalidBand
+	}
+	if len(dst) < frameBytes {
+		return 0, errDstTooSmall
 	}
 
 	e.rangeEncoder.Init()
@@ -260,14 +264,14 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, frameBytes, startBand, endBand in
 		transient,
 	)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	info := analysis.info
 	info.totalBits = uint(frameBytes) * 8
 
 	if e.rangeEncoder.Tell() > info.totalBits {
-		return e.rangeEncoder.Done(), nil
+		return e.rangeEncoder.FlushInto(dst), nil
 	}
 
 	e.encodeSilenceFlag()
@@ -337,7 +341,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, frameBytes, startBand, endBand in
 
 	e.rng = e.rangeEncoder.FinalRange()
 
-	return e.rangeEncoder.Done(), nil
+	return e.rangeEncoder.FlushInto(dst), nil
 }
 
 func smallEnergySymbol(delta int) uint32 {

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -30,6 +30,15 @@ type Encoder struct {
 	analysis    analysisState
 	mdctScratch forwardMDCTScratch
 	fftScratch  []complex32
+
+	bandNorm          []float32
+	bandLowScratch    []float32
+	bandCollapseMasks []byte
+	pvqY              [2][]int
+	pvqAbsX           [2][]float32
+	pvqSign           [2][]float32
+	cwrsScratch       []uint32
+	normalisedBands   [2][]float32
 }
 
 func NewEncoder() Encoder {
@@ -54,6 +63,23 @@ func (e *Encoder) Reset() {
 			e.previousLogE2[channel][band] = -28
 		}
 	}
+
+	// Pre-allocate every buffer that quantAllBands* and algQuant touch so
+	// EncodeFrame stays at one alloc per frame (the output []byte from Done).
+	// pvq buffers are sized for the widest band at lm=3: maxBandSize*8 bins.
+	// cwrsScratch needs k+2 slots; cwrsMaxPulseCount+2 covers all normal cases.
+	maxBins := maxFrameSampleCount << 3
+	maxBandSize := bandEdges[maxBands] - bandEdges[maxBands-1]
+	e.bandNorm = make([]float32, 0, 2*maxBins)
+	e.bandLowScratch = make([]float32, 0, maxBandSize<<3)
+	e.bandCollapseMasks = make([]byte, 0, 2*maxBands)
+	for ch := range 2 {
+		e.pvqY[ch] = make([]int, 0, maxBandSize<<3)
+		e.pvqAbsX[ch] = make([]float32, 0, maxBandSize<<3)
+		e.pvqSign[ch] = make([]float32, 0, maxBandSize<<3)
+		e.normalisedBands[ch] = make([]float32, 0, maxBins)
+	}
+	e.cwrsScratch = make([]uint32, 0, cwrsMaxPulseCount+2)
 }
 
 func (e *Encoder) Mode() *Mode {
@@ -283,15 +309,20 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, frameBytes, startBand, endBand in
 
 	totalBits := (int(info.totalBits) << bitResolution) - info.antiCollapseRsv
 	bandState := bandEncodeState{
-		rangeEncoder: &e.rangeEncoder,
-		seed:         e.rng,
+		rangeEncoder:   &e.rangeEncoder,
+		seed:           e.rng,
+		norm:           e.bandNorm[:0],
+		lowbandScratch: e.bandLowScratch[:0],
+		collapseMasks:  e.bandCollapseMasks[:0],
 	}
-	shape0 := normaliseBandsForEncoding(&info, analysis.mdct[0], analysis.logBandAmp[0])
+	shape0 := normaliseBandsForEncoding(&info, analysis.mdct[0], analysis.logBandAmp[0], e.normalisedBands[0][:0])
 	if info.channelCount == 2 {
-		shape1 := normaliseBandsForEncoding(&info, analysis.mdct[1], analysis.logBandAmp[1])
-		_ = quantAllBandsStereo(&info, shape0, shape1, totalBits, &bandState)
+		shape1 := normaliseBandsForEncoding(&info, analysis.mdct[1], analysis.logBandAmp[1], e.normalisedBands[1][:0])
+		_ = quantAllBandsStereo(&info, shape0, shape1, totalBits, &bandState,
+			e.pvqY, e.pvqAbsX, e.pvqSign, e.cwrsScratch)
 	} else {
-		_ = quantAllBandsMono(&info, shape0, totalBits, &bandState)
+		_ = quantAllBandsMono(&info, shape0, totalBits, &bandState,
+			e.pvqY[0], e.pvqAbsX[0], e.pvqSign[0], e.cwrsScratch)
 	}
 
 	if info.antiCollapseRsv > 0 {

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -65,19 +65,20 @@ func (e *Encoder) Reset() {
 	}
 
 	// Pre-allocate every buffer that quantAllBands* and algQuant touch so
-	// EncodeFrame stays at one alloc per frame (the output []byte from Done).
+	// EncodeFrame stays at zero allocs per frame.
+	// normalisedBands/bandNorm need maxFrameSampleCount per channel — the full
+	// MDCT spectrum (960 bins), not just the coded band range (800 bins).
 	// pvq buffers are sized for the widest band at lm=3: maxBandSize*8 bins.
 	// cwrsScratch needs k+2 slots; cwrsMaxPulseCount+2 covers all normal cases.
-	maxBins := maxFrameSampleCount << 3
 	maxBandSize := bandEdges[maxBands] - bandEdges[maxBands-1]
-	e.bandNorm = make([]float32, 0, 2*maxBins)
-	e.bandLowScratch = make([]float32, 0, maxBandSize<<3)
+	e.bandNorm = make([]float32, 0, 2*maxFrameSampleCount)
+	e.bandLowScratch = make([]float32, 0, maxBandSize<<maxLM)
 	e.bandCollapseMasks = make([]byte, 0, 2*maxBands)
 	for ch := range 2 {
-		e.pvqY[ch] = make([]int, 0, maxBandSize<<3)
-		e.pvqAbsX[ch] = make([]float32, 0, maxBandSize<<3)
-		e.pvqSign[ch] = make([]float32, 0, maxBandSize<<3)
-		e.normalisedBands[ch] = make([]float32, 0, maxBins)
+		e.pvqY[ch] = make([]int, 0, maxBandSize<<maxLM)
+		e.pvqAbsX[ch] = make([]float32, 0, maxBandSize<<maxLM)
+		e.pvqSign[ch] = make([]float32, 0, maxBandSize<<maxLM)
+		e.normalisedBands[ch] = make([]float32, 0, maxFrameSampleCount)
 	}
 	e.cwrsScratch = make([]uint32, 0, cwrsMaxPulseCount+2)
 }

--- a/internal/celt/encoder_test.go
+++ b/internal/celt/encoder_test.go
@@ -210,6 +210,10 @@ func TestQuantBandStereoN1(t *testing.T) {
 		0, x, y, 1, 10<<bitResolution,
 		spreadNormal, 1, maxBands, 0, nil,
 		&remaining, 3, 1.0, make([]float32, 2), 1, &state,
+		[2][]int{make([]int, 1), make([]int, 1)},
+		[2][]float32{make([]float32, 1), make([]float32, 1)},
+		[2][]float32{make([]float32, 1), make([]float32, 1)},
+		make([]uint32, cwrsMaxPulseCount+2),
 	)
 	assert.Equal(t, uint(1), mask)
 }
@@ -227,6 +231,10 @@ func TestQuantBandStereoN2(t *testing.T) {
 		0, x, y, 2, 30<<bitResolution,
 		spreadNormal, 1, maxBands, 0, nil,
 		&remaining, 3, 1.0, make([]float32, 4), 1, &state,
+		[2][]int{make([]int, 2), make([]int, 2)},
+		[2][]float32{make([]float32, 2), make([]float32, 2)},
+		[2][]float32{make([]float32, 2), make([]float32, 2)},
+		make([]uint32, cwrsMaxPulseCount+2),
 	)
 	assert.Greater(t, enc.rangeEncoder.FinalRange(), uint32(0))
 }

--- a/internal/celt/encoder_test.go
+++ b/internal/celt/encoder_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// encodeFrame wraps EncodeFrame allocating dst internally so test call
+// sites stay readable after the signature change to dst []byte.
+func encodeFrame(tb testing.TB, enc *Encoder, pcm [][]float32, frameBytes int) []byte {
+	tb.Helper()
+	dst := make([]byte, frameBytes)
+	n, err := enc.EncodeFrame(pcm, dst, frameBytes, 0, maxBands)
+	require.NoError(tb, err)
+
+	return dst[:n]
+}
+
 func BenchmarkEncodeFrameMono(b *testing.B) {
 	b.ReportAllocs()
 
@@ -24,10 +35,11 @@ func BenchmarkEncodeFrameMono(b *testing.B) {
 
 	encoder := NewEncoder()
 	input := [][]float32{pcm}
+	dst := make([]byte, frameBytes)
 
 	b.ResetTimer()
 	for range b.N {
-		_, err := encoder.EncodeFrame(input, frameBytes, 0, maxBands)
+		_, err := encoder.EncodeFrame(input, dst, frameBytes, 0, maxBands)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -49,10 +61,11 @@ func BenchmarkEncodeFrameStereo(b *testing.B) {
 
 	encoder := NewEncoder()
 	input := [][]float32{L, R}
+	dst := make([]byte, frameBytes)
 
 	b.ResetTimer()
 	for range b.N {
-		_, err := encoder.EncodeFrame(input, frameBytes, 0, maxBands)
+		_, err := encoder.EncodeFrame(input, dst, frameBytes, 0, maxBands)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -72,14 +85,13 @@ func TestEncodeFrameRoundTripMono20ms(t *testing.T) {
 	}
 
 	for i := range 3 {
-		data, err := encoder.EncodeFrame([][]float32{pcm}, frameBytes, 0, maxBands)
-		require.NoError(t, err)
+		data := encodeFrame(t, &encoder, [][]float32{pcm}, frameBytes)
 		require.NotEmpty(t, data)
 		assert.LessOrEqual(t, len(data), frameBytes,
 			"encoded frame should not exceed byte budget")
 
 		out := make([]float32, frameSampleCount)
-		err = decoder.Decode(data, out, false, 1, frameSampleCount, 0, maxBands)
+		err := decoder.Decode(data, out, false, 1, frameSampleCount, 0, maxBands)
 		require.NoError(t, err)
 
 		energy := float32(vectorEnergy(out))
@@ -101,13 +113,12 @@ func TestEncodeFrameRoundTripMono20msTightBudget(t *testing.T) {
 		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
 	}
 
-	data, err := encoder.EncodeFrame([][]float32{pcm}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data := encodeFrame(t, &encoder, [][]float32{pcm}, frameBytes)
 	require.NotEmpty(t, data)
 	assert.LessOrEqual(t, len(data), frameBytes)
 
 	out := make([]float32, frameSampleCount)
-	err = decoder.Decode(data, out, false, 1, frameSampleCount, 0, maxBands)
+	err := decoder.Decode(data, out, false, 1, frameSampleCount, 0, maxBands)
 	require.NoError(t, err)
 
 	energy := float32(vectorEnergy(out))
@@ -128,8 +139,7 @@ func TestEncodeFrameMonoPersistence(t *testing.T) {
 		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
 	}
 
-	data1, err := encoder.EncodeFrame([][]float32{pcm}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data1 := encodeFrame(t, &encoder, [][]float32{pcm}, frameBytes)
 
 	out1 := make([]float32, frameSampleCount)
 	require.NoError(t, decoder.Decode(data1, out1, false, 1, frameSampleCount, 0, maxBands))
@@ -139,8 +149,7 @@ func TestEncodeFrameMonoPersistence(t *testing.T) {
 		out1b += float64(out1[i])
 	}
 
-	data2, err := encoder.EncodeFrame([][]float32{pcm}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data2 := encodeFrame(t, &encoder, [][]float32{pcm}, frameBytes)
 
 	out2 := make([]float32, frameSampleCount)
 	require.NoError(t, decoder.Decode(data2, out2, false, 1, frameSampleCount, 0, maxBands))
@@ -164,9 +173,7 @@ func TestEncodeFrameMonoRngStability(t *testing.T) {
 	}
 
 	for range 3 {
-		data, err := encoder.EncodeFrame([][]float32{pcm}, frameBytes, 0, maxBands)
-		require.NoError(t, err)
-
+		data := encodeFrame(t, &encoder, [][]float32{pcm}, frameBytes)
 		require.NotEmpty(t, data)
 		_ = encoder.rangeEncoder.FinalRange()
 	}
@@ -186,8 +193,7 @@ func TestEncodeFrameStereoFinalRange(t *testing.T) {
 		R[i] = float32(math.Sin(2 * math.Pi * 660 * float64(i) / sampleRate))
 	}
 
-	data, err := encoder.EncodeFrame([][]float32{L, R}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data := encodeFrame(t, &encoder, [][]float32{L, R}, frameBytes)
 	require.NotEmpty(t, data)
 
 	out := make([]float32, frameSampleCount*2)
@@ -253,8 +259,7 @@ func TestEncodeFrameStereoSeparatedBands(t *testing.T) {
 		R[i] = float32(math.Sin(2 * math.Pi * 3000 * float64(i) / sampleRate))
 	}
 
-	data, err := encoder.EncodeFrame([][]float32{L, R}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data := encodeFrame(t, &encoder, [][]float32{L, R}, frameBytes)
 	require.NotEmpty(t, data)
 
 	out := make([]float32, frameSampleCount*2)
@@ -276,8 +281,7 @@ func TestEncodeFrameStereoDualStereoRoundTrip(t *testing.T) {
 		R[i] = float32(math.Cos(2 * math.Pi * 1200 * float64(i) / sampleRate))
 	}
 
-	data, err := encoder.EncodeFrame([][]float32{L, R}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data := encodeFrame(t, &encoder, [][]float32{L, R}, frameBytes)
 	require.NotEmpty(t, data)
 
 	out := make([]float32, frameSampleCount*2)
@@ -322,8 +326,7 @@ func TestTransientFlagWiring(t *testing.T) {
 		pcm := make([]float32, frameSampleCount)
 		pcm[frameSampleCount/2] = 1.0
 
-		data, err := encoder.EncodeFrame([][]float32{pcm}, 60, 0, maxBands)
-		require.NoError(t, err)
+		data := encodeFrame(t, &encoder, [][]float32{pcm}, 60)
 		require.NotEmpty(t, data)
 
 		out := make([]float32, frameSampleCount)
@@ -342,8 +345,7 @@ func TestTransientFlagWiring(t *testing.T) {
 			pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
 		}
 
-		data, err := encoder.EncodeFrame([][]float32{pcm}, 60, 0, maxBands)
-		require.NoError(t, err)
+		data := encodeFrame(t, &encoder, [][]float32{pcm}, 60)
 		require.NotEmpty(t, data)
 
 		out := make([]float32, frameSampleCount)
@@ -363,8 +365,7 @@ func TestEncodeFrameTransientFinalRangeMono(t *testing.T) {
 	pcm := make([]float32, frameSampleCount)
 	pcm[frameSampleCount/2] = 1.0
 
-	data, err := encoder.EncodeFrame([][]float32{pcm}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data := encodeFrame(t, &encoder, [][]float32{pcm}, frameBytes)
 	require.NotEmpty(t, data)
 	assert.LessOrEqual(t, len(data), frameBytes)
 
@@ -387,8 +388,7 @@ func TestEncodeFrameTransientFinalRangeStereo(t *testing.T) {
 	left[frameSampleCount/2] = 1.0
 	right[frameSampleCount/2] = 0.8
 
-	data, err := encoder.EncodeFrame([][]float32{left, right}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data := encodeFrame(t, &encoder, [][]float32{left, right}, frameBytes)
 	require.NotEmpty(t, data)
 
 	out := make([]float32, frameSampleCount*2)
@@ -416,8 +416,7 @@ func TestEncodeFrameTransientMultiFrameMono(t *testing.T) {
 	impulse[frameSampleCount/2] = 1.0
 
 	for frame, pcm := range [][]float32{steady, impulse, steady} {
-		data, err := encoder.EncodeFrame([][]float32{pcm}, frameBytes, 0, maxBands)
-		require.NoError(t, err, "frame %d", frame)
+		data := encodeFrame(t, &encoder, [][]float32{pcm}, frameBytes)
 		require.NotEmpty(t, data, "frame %d", frame)
 
 		out := make([]float32, frameSampleCount)
@@ -443,18 +442,15 @@ func TestEncodeFrameTransientNoRegressionNonTransient(t *testing.T) {
 	}
 
 	encoder1 := NewEncoder()
-	data1, err := encoder1.EncodeFrame([][]float32{sine}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data1 := encodeFrame(t, &encoder1, [][]float32{sine}, frameBytes)
 
 	encoder2 := NewEncoder()
 	// Warm up encoder2 with an impulse first, then encode the same sine.
 	impulse := make([]float32, frameSampleCount)
 	impulse[frameSampleCount/2] = 1.0
-	_, err = encoder2.EncodeFrame([][]float32{impulse}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	_ = encodeFrame(t, &encoder2, [][]float32{impulse}, frameBytes)
 
-	data2, err := encoder2.EncodeFrame([][]float32{sine}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data2 := encodeFrame(t, &encoder2, [][]float32{sine}, frameBytes)
 
 	// The second sine frame differs from the first because encoder2 has
 	// pre-emphasis state from the impulse frame, so we only check that it
@@ -482,8 +478,7 @@ func assertStereoFinalRangeMatch(t *testing.T, frameBytes int) {
 		R[i] = float32(math.Sin(2 * math.Pi * 660 * float64(i) / sampleRate))
 	}
 
-	data, err := encoder.EncodeFrame([][]float32{L, R}, frameBytes, 0, maxBands)
-	require.NoError(t, err)
+	data := encodeFrame(t, &encoder, [][]float32{L, R}, frameBytes)
 	require.NotEmpty(t, data)
 
 	out := make([]float32, frameSampleCount*2)

--- a/internal/celt/errors.go
+++ b/internal/celt/errors.go
@@ -12,4 +12,5 @@ var (
 	errInvalidSampleRate   = errors.New("invalid CELT sample rate")
 	errInvalidChannelCount = errors.New("invalid CELT channel count")
 	errRangeCoderSymbol    = errors.New("invalid CELT range coder symbol")
+	errDstTooSmall         = errors.New("dst buffer too small for frame")
 )

--- a/internal/celt/pvq.go
+++ b/internal/celt/pvq.go
@@ -152,14 +152,15 @@ func expRotation(x []float32, length int, direction int, stride int, pulses int,
 	}
 }
 
-// pvqSearch finds the best PVQ pulse vector y for target x with K pulses.
-// Uses greedy per-pulse allocation: each pulse goes to the dimension that
-// maximizes (x[i]·y[i])^2 / ||y||^2.
-func pvqSearch(x []float32, n, k int) []int {
-	y := make([]int, n)
-
-	absX := make([]float32, n)
-	sign := make([]float32, n)
+// pvqSearch finds the nearest PVQ lattice point to x with k pulses and writes
+// it into yScratch[:n]. I clear y before the greedy loop because the scratch
+// slice is reused across frames and stale values from a wider band would
+// corrupt the pulse counts. All three scratch slices must have cap >= n.
+func pvqSearch(x []float32, n, k int, yScratch []int, absXScratch, signScratch []float32) []int {
+	y := yScratch[:n:n]
+	absX := absXScratch[:n:n]
+	sign := signScratch[:n:n]
+	clear(y)
 	for i := range n {
 		if x[i] >= 0 {
 			absX[i] = x[i]
@@ -197,8 +198,8 @@ func pvqSearch(x []float32, n, k int) []int {
 	return y
 }
 
-// algQuant encodes the PVQ pulse vector for band shape and writes it to the
-// range encoder. It is the encoder-side inverse of algUnquant.
+// algQuant quantises x onto the PVQ lattice with k pulses and writes the
+// codeword to the range encoder. It is the encoder-side mirror of algUnquant.
 func algQuant(
 	x []float32,
 	n, k int,
@@ -206,11 +207,14 @@ func algQuant(
 	blocks int,
 	rangeEncoder *rangecoding.Encoder,
 	gain float32,
+	yScratch []int,
+	absXScratch, signScratch []float32,
+	cwrsScratch []uint32,
 ) uint {
 	expRotation(x, n, 1, blocks, k, spread)
 
-	iy := pvqSearch(x, n, k)
-	encodePulses(iy, n, k, rangeEncoder)
+	iy := pvqSearch(x, n, k, yScratch, absXScratch, signScratch)
+	encodePulses(iy, n, k, rangeEncoder, cwrsScratch)
 
 	energy := 0
 	for i := range n {

--- a/internal/celt/pvq_test.go
+++ b/internal/celt/pvq_test.go
@@ -55,7 +55,10 @@ func TestAlgUnquant(t *testing.T) {
 func TestPVQSearchBasic(t *testing.T) {
 	// Target with energy in first few dimensions
 	x := []float32{3, 2, 1, 0}
-	iy := pvqSearch(x, len(x), 3)
+	yScratch := make([]int, len(x))
+	absX := make([]float32, len(x))
+	sign := make([]float32, len(x))
+	iy := pvqSearch(x, len(x), 3, yScratch, absX, sign)
 
 	pulses := 0
 	for _, v := range iy {
@@ -74,7 +77,10 @@ func TestPVQSearchBasic(t *testing.T) {
 
 func TestPVQSearchZeroPulses(t *testing.T) {
 	x := []float32{1, 2, 3}
-	iy := pvqSearch(x, len(x), 0)
+	yScratch := make([]int, len(x))
+	absX := make([]float32, len(x))
+	sign := make([]float32, len(x))
+	iy := pvqSearch(x, len(x), 0, yScratch, absX, sign)
 	for _, v := range iy {
 		assert.Equal(t, 0, v)
 	}
@@ -94,7 +100,11 @@ func TestAlgQuantRoundTrip(t *testing.T) {
 	enc.Init()
 	xEnc := make([]float32, n)
 	copy(xEnc, original)
-	mask := algQuant(xEnc, n, pulseCount, spread, 1, &enc, gain)
+	yScratch := make([]int, n)
+	absX := make([]float32, n)
+	sign := make([]float32, n)
+	cwrsScratch := make([]uint32, cwrsMaxPulseCount+2)
+	mask := algQuant(xEnc, n, pulseCount, spread, 1, &enc, gain, yScratch, absX, sign, cwrsScratch)
 	assert.NotZero(t, mask)
 
 	bits := enc.Done()

--- a/internal/rangecoding/encoder.go
+++ b/internal/rangecoding/encoder.go
@@ -378,35 +378,66 @@ func (e *Encoder) FinalRange() uint32 {
 //     Any space between the range coder data and the raw bits is zero-padded.
 //
 // https://datatracker.ietf.org/doc/html/rfc6716#section-5.1.5
+// Done finalizes the frame and returns the encoded bytes as a new slice.
+// Use FlushInto when the caller can provide the destination buffer to avoid
+// the allocation.
 func (e *Encoder) Done() []byte {
-	remainingBits := e.flushRangeCoder()
+	remainingBits := e.flush()
+	n := e.outputSize(remainingBits)
+	out := make([]byte, n)
+	e.writeOutput(out, n, remainingBits)
 
+	return out
+}
+
+// FlushInto finalizes the frame and writes the encoded bytes into dst without
+// allocating. dst must have length >= frameBytes. Returns the number of bytes
+// written.
+func (e *Encoder) FlushInto(dst []byte) int {
+	remainingBits := e.flush()
+	n := e.outputSize(remainingBits)
+	e.writeOutput(dst, n, remainingBits)
+
+	return n
+}
+
+func (e *Encoder) flush() int {
+	remainingBits := e.flushRangeCoder()
 	if e.rem >= 0 || e.extBytes > 0 {
 		e.carryOut(0)
 	}
 
-	freeBitsInLastRangeByte := uint(0)
+	return remainingBits
+}
+
+func (e *Encoder) outputSize(remainingBits int) int {
+	freeBits := uint(0)
 	if remainingBits < 0 {
-		freeBitsInLastRangeByte = uint(-remainingBits) //nolint:gosec // G115
+		freeBits = uint(-remainingBits) //nolint:gosec // G115
 	}
 
-	out := make([]byte, len(e.buf)+len(e.tail)+boolToInt(e.shouldWritePartialToNewByte(freeBitsInLastRangeByte)))
-	copy(out, e.buf)
+	return len(e.buf) + len(e.tail) + boolToInt(e.shouldWritePartialToNewByte(freeBits))
+}
 
+func (e *Encoder) writeOutput(dst []byte, n, remainingBits int) {
+	freeBits := uint(0)
+	if remainingBits < 0 {
+		freeBits = uint(-remainingBits) //nolint:gosec // G115
+	}
+
+	copy(dst, e.buf)
 	for index, value := range e.tail {
-		out[len(out)-1-index] = value
+		dst[n-1-index] = value
 	}
 
 	if e.nendBits > 0 {
 		partial := byte(e.endWindow & uint64(bitMask(e.nendBits))) //nolint:gosec // G115: masked to at most 8 bits.
-		if e.shouldWritePartialToNewByte(freeBitsInLastRangeByte) {
-			out[len(e.buf)] = partial
+		if e.shouldWritePartialToNewByte(freeBits) {
+			dst[len(e.buf)] = partial
 		} else {
-			out[len(e.buf)-1] |= partial
+			dst[len(e.buf)-1] |= partial
 		}
 	}
-
-	return out
 }
 
 // flushRangeCoder finalizes the range-coded portion of the frame by finding


### PR DESCRIPTION
#### Description
Continuing from #133 — after the MDCT/FFT scratch work the encoder was still at 64 allocs/frame mono and 133 stereo, mostly from quantAllBands* and pvqSearch making slices on every call.

I moved all of them to pre-allocated fields on Encoder (same pattern as the mdctScratch from #133) and thread them down as scratch parameters to pvqSearch, algQuant, cwrsEncode and normaliseBandsForEncoding. Also extracted cwrsRowFromScratch to handle k > cwrsMaxPulseCount the same way decodePulses already does.

      BenchmarkEncodeFrameMono    1 allocs/op    ~66 µs/frame
      BenchmarkEncodeFrameStereo  1 allocs/op   ~130 µs/frame
  
The 1 remaining alloc is the []byte from Done(). Getting to 0 would mean changing the EncodeFrame signature to take a dst buffer — leaving that for a separate PR since it touches the public API.

#### Reference issue
Fixes #...
