### PR TITLE
Add adaptive spreading and intensity hysteresis

### DIFF
--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -245,6 +245,59 @@ func computeBandLogAmp(freq []float32, lm int, startBand int, endBand int) [maxB
 	return logAmp
 }
 
+// spreadingDecision computes the spread level for one frame from the MDCT
+// spectrum and updates the inter-frame average in prevAvg.
+//
+// The metric is the mean of (1 - bandMean/bandPeak) across coded bands.
+// A band where one bin dominates gives a value near 1 (tonal); a band with
+// uniform energy gives a value near 0 (noise-like). This is the floating-point
+// equivalent of the per-band CDF step inside libopus spreading_decision
+// (celt_encoder.c), using a uniform band weight since the tonality-based
+// spread_weight is disabled in libopus production.
+func spreadingDecision(mdct []float32, lm, startBand, endBand int, prevAvg *float32, prevDecision int) int {
+	scale := 1 << lm
+	var sum float32
+	nBands := 0
+
+	for band := startBand; band < endBand; band++ {
+		lo := scale * int(bandEdges[band])
+		hi := scale * int(bandEdges[band+1])
+		n := hi - lo
+		if n < 2 {
+			continue
+		}
+
+		var energy, maxE float32
+		for i := lo; i < hi; i++ {
+			e := mdct[i] * mdct[i]
+			energy += e
+			if e > maxE {
+				maxE = e
+			}
+		}
+
+		mean := energy / float32(n)
+		if mean < 1e-30 || maxE < 1e-30 {
+			continue
+		}
+
+		// 0 when all bins are equal (noise), near 1 when one bin dominates (tonal).
+		sum += 1 - mean/maxE
+		nBands++
+	}
+
+	if nBands == 0 {
+		return prevDecision
+	}
+
+	avg := sum / float32(nBands)
+	// Recursive inter-frame average damps single-frame spikes.
+	avg = 0.5 * (avg + *prevAvg)
+	*prevAvg = avg
+
+	return hysteresisDecision(avg, prevDecision, [3]float32{0.15, 0.40, 0.65})
+}
+
 // applyDCBlock applies a first-order IIR high-pass at dcBlockCutoffHz to
 // remove DC bias. mem must persist across frames. Not normative — encoder-only
 // pre-processing (libopus dc_reject, src/opus_encoder.c:479-507).

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -11,6 +11,132 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSpreadingDecisionTonalSignal(t *testing.T) {
+	// A spectrum with one dominant bin per band should read as tonal (high metric)
+	// and produce at least NORMAL spreading after warmup.
+	lm := maxLM
+	scale := 1 << lm
+	mdct := make([]float32, scale*int(bandEdges[maxBands]))
+
+	for band := range maxBands {
+		lo := scale * int(bandEdges[band])
+		hi := scale * int(bandEdges[band+1])
+		if hi > lo {
+			// put all energy in the first bin of each band
+			mdct[lo] = 1.0
+		}
+	}
+
+	var prevAvg float32
+	prev := defaultSpreadDecision
+	var decision int
+	for range 8 {
+		decision = spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, prev)
+		prev = decision
+	}
+	assert.GreaterOrEqual(t, decision, spreadNormal,
+		"spike-per-band spectrum should reach at least NORMAL after warmup (got %d)", decision)
+}
+
+func TestSpreadingDecisionNoiseSignal(t *testing.T) {
+	// A flat spectrum (uniform energy per bin) is noise-like and should settle
+	// at NONE or LIGHT after warmup.
+	lm := maxLM
+	scale := 1 << lm
+	mdct := make([]float32, scale*int(bandEdges[maxBands]))
+	for i := range mdct {
+		mdct[i] = 0.01
+	}
+
+	var prevAvg float32
+	prev := defaultSpreadDecision
+	var decision int
+	for range 8 {
+		decision = spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, prev)
+		prev = decision
+	}
+	assert.LessOrEqual(t, decision, spreadLight,
+		"uniform-energy spectrum should settle at NONE or LIGHT after warmup (got %d)", decision)
+}
+
+func TestSpreadingDecisionRecursiveAvg(t *testing.T) {
+	// Two independent runs of N frames should produce the same avg value as a
+	// single run of 2N frames because the recursive average is stateless
+	// between calls.
+	lm := maxLM
+	scale := 1 << lm
+	mdct := make([]float32, scale*int(bandEdges[maxBands]))
+	for i := range mdct {
+		mdct[i] = 0.1 * float32(i%7+1)
+	}
+
+	var avgA float32
+	prevA := defaultSpreadDecision
+	for range 4 {
+		prevA = spreadingDecision(mdct, lm, 0, maxBands, &avgA, prevA)
+	}
+
+	var avgB float32
+	prevB := defaultSpreadDecision
+	for range 8 {
+		prevB = spreadingDecision(mdct, lm, 0, maxBands, &avgB, prevB)
+	}
+
+	// After more frames the avg should converge further; after 8 frames it
+	// must not be identical to after 4.
+	assert.NotEqual(t, avgA, avgB, "recursive average should differ after different frame counts")
+}
+
+func TestSpreadingDecisionSilentFrame(t *testing.T) {
+	lm := maxLM
+	mdct := make([]float32, (1<<lm)*int(bandEdges[maxBands]))
+	var prevAvg float32
+	// All zero input: should return prevDecision unchanged.
+	got := spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, spreadNormal)
+	assert.Equal(t, spreadNormal, got, "silent frame should return prevDecision")
+}
+
+func TestAnalyzeFrameAdaptiveSpread(t *testing.T) {
+	// A pure sine and white-noise-like PCM should produce different spread
+	// decisions, which changes the encoded symbol and therefore the FinalRange.
+	enc1 := NewEncoder()
+	enc2 := NewEncoder()
+	frameSampleCount := shortBlockSampleCount << maxLM
+	frameBytes := 60
+
+	sine := make([]float32, frameSampleCount)
+	for i := range sine {
+		sine[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / float64(sampleRate)))
+	}
+
+	// Approximate white noise via a deterministic sequence spread across all
+	// frequencies — alternate sign at a prime-ish period so the MDCT sees
+	// roughly uniform energy rather than a tonal spike.
+	noise := make([]float32, frameSampleCount)
+	for i := range noise {
+		if i%7 < 4 {
+			noise[i] = 0.1
+		} else {
+			noise[i] = -0.1
+		}
+	}
+
+	// Warm both encoders up for several frames so the recursive average settles.
+	const warmup = 5
+	dstSine := make([]byte, frameBytes)
+	dstNoise := make([]byte, frameBytes)
+	for range warmup {
+		_, err := enc1.EncodeFrame([][]float32{sine}, dstSine, frameBytes, 0, maxBands)
+		require.NoError(t, err)
+		_, err = enc2.EncodeFrame([][]float32{noise}, dstNoise, frameBytes, 0, maxBands)
+		require.NoError(t, err)
+	}
+
+	assert.NotEqual(t, enc1.FinalRange(), enc2.FinalRange(),
+		"sine and noise should produce different spread decisions after warmup "+
+			"(sine=%x, noise=%x)", enc1.FinalRange(), enc2.FinalRange())
+}
+
 func TestDetectTransientSteadySine(t *testing.T) {
 	state := newAnalysisState()
 	pcm := make([]float32, 960)

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -39,6 +39,10 @@ type Encoder struct {
 	pvqSign           [2][]float32
 	cwrsScratch       []uint32
 	normalisedBands   [2][]float32
+
+	prevSpreadAvg      float32
+	prevSpreadDecision int
+	prevIntensityBand  int
 }
 
 func NewEncoder() Encoder {
@@ -81,6 +85,10 @@ func (e *Encoder) Reset() {
 		e.normalisedBands[ch] = make([]float32, 0, maxFrameSampleCount)
 	}
 	e.cwrsScratch = make([]uint32, 0, cwrsMaxPulseCount+2)
+
+	e.prevSpreadAvg = 0
+	e.prevSpreadDecision = defaultSpreadDecision
+	e.prevIntensityBand = 0
 }
 
 func (e *Encoder) Mode() *Mode {
@@ -287,6 +295,11 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	e.encodeCoarseEnergy(&info, targetLogE)
 
 	e.encodeTimeFrequencyChanges(&info)
+	info.spread = spreadingDecision(
+		analysis.mdct[0], info.lm, info.startBand, info.endBand,
+		&e.prevSpreadAvg, e.prevSpreadDecision,
+	)
+	e.prevSpreadDecision = info.spread
 	e.encodeSpread(&info)
 	totalBitsEighth := e.encodeDynamicAllocation(&info)
 	e.encodeAllocationTrim(&info, totalBitsEighth)
@@ -304,7 +317,19 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 		frameSampleCount := shortBlockSampleCount << info.lm
 		bitrateBps := int(info.totalBits) * sampleRate / frameSampleCount
 		frameMs := max(1, frameSampleCount*1000/sampleRate)
-		targetIntensity = intensityStartBand(bitrateBps, frameMs)
+		raw := intensityStartBand(bitrateBps, frameMs)
+		if e.prevIntensityBand == 0 {
+			e.prevIntensityBand = raw
+		}
+		// ±1 dead band: require two consecutive frames to confirm a direction
+		// change, matching the hysteresis pattern in libopus CELTEncoder.
+		if raw > e.prevIntensityBand+1 {
+			raw = e.prevIntensityBand + 1
+		} else if raw < e.prevIntensityBand-1 {
+			raw = e.prevIntensityBand - 1
+		}
+		e.prevIntensityBand = raw
+		targetIntensity = raw
 		if chooseDualStereo(analysis.mdct[0], analysis.mdct[1], info.lm) {
 			targetDualStereo = 1
 		}

--- a/internal/celt/hysteresis.go
+++ b/internal/celt/hysteresis.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+// hysteresisDecision maps val in [0, 1] to a 0–3 decision level using
+// thresholds as the three crossing points.
+//
+// The bias term mirrors the libopus pattern in spreading_decision
+// (celt_encoder.c): when prevDecision is high, val is biased down, so the
+// signal must be clearly tonal to stay aggressive; when prevDecision is low,
+// val is biased up, so a mildly tonal burst stays active for an extra frame.
+// This damps chattering around threshold crossings without needing per-caller
+// dead-band logic.
+func hysteresisDecision(val float32, prevDecision int, thresholds [3]float32) int {
+	// bias ∈ [0, hystMag]: largest when prev was NONE (0), zero when AGGRESSIVE (3).
+	const hystMag = 0.04
+	biased := val + float32(3-prevDecision)/3*hystMag
+	switch {
+	case biased > thresholds[2]:
+		return spreadAggressive
+	case biased > thresholds[1]:
+		return spreadNormal
+	case biased > thresholds[0]:
+		return spreadLight
+	default:
+		return spreadNone
+	}
+}

--- a/internal/celt/hysteresis_test.go
+++ b/internal/celt/hysteresis_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHysteresisDecisionThresholds(t *testing.T) {
+	thresholds := [3]float32{0.15, 0.40, 0.65}
+
+	// Clearly below all thresholds → NONE regardless of prev.
+	assert.Equal(t, spreadNone, hysteresisDecision(0.0, spreadNormal, thresholds))
+	// Clearly above all thresholds → AGGRESSIVE regardless of prev.
+	assert.Equal(t, spreadAggressive, hysteresisDecision(1.0, spreadNone, thresholds))
+	// Middle → NORMAL when prev is NORMAL.
+	assert.Equal(t, spreadNormal, hysteresisDecision(0.50, spreadNormal, thresholds))
+}
+
+func TestHysteresisDecisionBias(t *testing.T) {
+	thresholds := [3]float32{0.15, 0.40, 0.65}
+
+	// Near the 0.15 boundary (val=0.12): with prevDecision=NONE the upward
+	// bias should push it into spreadLight; with prevDecision=AGGRESSIVE it stays NONE.
+	near := float32(0.12)
+	assert.Equal(t, spreadLight, hysteresisDecision(near, spreadNone, thresholds),
+		"upward bias from NONE should cross into LIGHT at val=%.2f", near)
+	assert.Equal(t, spreadNone, hysteresisDecision(near, spreadAggressive, thresholds),
+		"no bias from AGGRESSIVE should leave val=%.2f as NONE", near)
+}
+
+func TestHysteresisDecisionNoBias(t *testing.T) {
+	thresholds := [3]float32{0.15, 0.40, 0.65}
+
+	// prevDecision=AGGRESSIVE adds zero bias; prevDecision=NONE adds full hystMag.
+	aggressive := hysteresisDecision(0.63, spreadAggressive, thresholds)
+	none := hysteresisDecision(0.63, spreadNone, thresholds)
+	// 0.63 + 0 = 0.63 < 0.65 → NORMAL; 0.63 + 0.04 = 0.67 > 0.65 → AGGRESSIVE
+	assert.Equal(t, spreadNormal, aggressive)
+	assert.Equal(t, spreadAggressive, none)
+}


### PR DESCRIPTION
#### Description
The encoder was hardcoding spread=NORMAL every frame. This PR makes it actually look at the MDCT spectrum and decide how much spreading the PVQ needs.

Added `spreadingDecision()` which computes a peak-to-mean energy ratio per band — tonal signals (one bin dominates) score high, noise-like signals score low. The result feeds a recursive inter-frame average and then `hysteresisDecision()` to avoid chattering at threshold crossings. Same idea as libopus `spreading_decision` in celt_encoder.c but in float32 with a uniform band weight, since the tonality-based weight is disabled in libopus production anyway.

Also added a ±1 dead band for the intensity stereo start band so it can only move one step per frame instead of jumping around.

#### Reference issue
Fixes #...
