### PR TITLE
Add adaptive allocation trim based on spectral tilt

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -5,6 +5,8 @@
 package celt
 
 import (
+	"math"
+
 	"github.com/pion/opus/internal/rangecoding"
 )
 
@@ -610,9 +612,118 @@ func chooseDualStereo(mdctL, mdctR []float32, lm int) bool {
 	return (bins+int64(thetas))*sumMS > bins*sumLR
 }
 
+// chooseAllocationTrim returns the allocation trim [0,10] based on bitrate,
+// inter-channel correlation, and spectral tilt. Mirrors libopus
+// celt_encoder.c:alloc_trim_analysis. Components that depend on unported
+// modules (surround_trim, tf_estimate, tonality_slope) contribute zero.
+//
+// pion's logBandAmp is 0.5*log2(energy)-energyMeans, while libopus's bandLogE
+// is log2(energy). The 0.5 factor is corrected with *2 in the tilt formula;
+// the energyMeans offset cancels in the weighted difference.
+func chooseAllocationTrim(
+	logBandAmp [2][maxBands]float32,
+	mdct [2][]float32,
+	channelCount, lm, endBand int,
+	totalBits uint,
+) int {
+	frameSampleCount := shortBlockSampleCount << lm
+	equivRate := int(totalBits) * sampleRate / frameSampleCount
+
+	// bitrate base, trim=5 default, 4 at low bitrate, interpolated 64-80kbps.
+	trim := float32(5.0)
+	if equivRate < 64000 {
+		trim = 4.0
+	} else if equivRate < 80000 {
+		frac := float32(equivRate-64000) / 1024
+		trim = 4.0 + float32(1.0/16.0)*frac
+	}
+
+	// --- Stereo correlation: average |cosine similarity| over first 8 bands.
+	// libopus uses inner product of normalised bands; we use cosine similarity
+	// of raw MDCT (scale-invariant, same result). Correlated channels →
+	// logXC < 0 → trim decreases → more bits to lows.
+	if channelCount == 2 {
+		scale := 1 << lm
+		var corrSum float32
+		for band := 0; band < 8 && band < endBand; band++ {
+			start := scale * int(bandEdges[band])
+			end := scale * int(bandEdges[band+1])
+			var dot, l2, r2 float32
+			for i := start; i < end; i++ {
+				dot += mdct[0][i] * mdct[1][i]
+				l2 += mdct[0][i] * mdct[0][i]
+				r2 += mdct[1][i] * mdct[1][i]
+			}
+			if l2 > 1e-30 && r2 > 1e-30 {
+				corrSum += abs32(dot) / sqrtf(l2*r2)
+			}
+		}
+		avgCorr := corrSum / 8.0
+		if avgCorr > 1.0 {
+			avgCorr = 1.0
+		}
+		logXC := float32(math.Log2(1.001 - float64(avgCorr*avgCorr)))
+		trim += max32(-4.0, 0.75*logXC)
+	}
+
+	// --- Spectral tilt: weighted sum of bandLogE.
+	// (2+2*i-end) is negative for low bands, positive for high.
+	// Positive diff (high-freq heavy) → trim decreases → more bits to highs.
+	// pion's logBandAmp is 0.5*log2(energy)-energyMeans (relative to the
+	// per-band mean); libopus's bandLogE is log2(energy) in absolute dB. The
+	// *2 cancels the 0.5 factor; *6.02 converts log2 to dB to match libopus's
+	// Q7 domain. libopus adds a +16 dB offset (QCONST32(1.f, DB_SHIFT-5)) to
+	// center the clamp around typical absolute bandLogE values; pion's
+	// mean-relative domain is already centered at 0, so the offset is dropped.
+	const dbPerLog2 = 6.0206 // 20/log2(10)
+	var diff float32
+	for ch := range channelCount {
+		for i := range endBand {
+			diff += logBandAmp[ch][i] * 2.0 * dbPerLog2 * float32(2+2*i-endBand)
+		}
+	}
+	diff /= float32(channelCount * (endBand - 1))
+	tiltContrib := diff * 4.0 / 6.0
+	tiltContrib = max32(-2.0, min32(2.0, tiltContrib))
+	trim -= tiltContrib
+
+	// Round and clamp to [0, 10].
+	trimIndex := int(trim + 0.5)
+	if trimIndex < 0 {
+		trimIndex = 0
+	} else if trimIndex > 10 {
+		trimIndex = 10
+	}
+	return trimIndex
+}
+
 func abs64(x int64) int64 {
 	if x < 0 {
 		return -x
 	}
 	return x
 }
+
+func abs32(x float32) float32 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func max32(a, b float32) float32 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min32(a, b float32) float32 {
+	if a < b {
+		return a
+	}
+
+	return b
+}
+
+func sqrtf(x float32) float32 { return float32(math.Sqrt(float64(x))) }

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -109,9 +109,8 @@ func TestAnalyzeFrameAdaptiveSpread(t *testing.T) {
 		sine[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / float64(sampleRate)))
 	}
 
-	// Approximate white noise via a deterministic sequence spread across all
-	// frequencies — alternate sign at a prime-ish period so the MDCT sees
-	// roughly uniform energy rather than a tonal spike.
+	// A square wave at period 7 (~6.8 kHz) has its energy spread across many
+	// harmonics, giving a flatter MDCT spectrum than the 440 Hz sine.
 	noise := make([]float32, frameSampleCount)
 	for i := range noise {
 		if i%7 < 4 {
@@ -339,4 +338,123 @@ func TestAnalyzeFrameAppliesDCBlock(t *testing.T) {
 	assert.NotEqual(t, enc1.FinalRange(), enc2.FinalRange(),
 		"DC block should change the encoder output (sine=%x, withOffset=%x)",
 		enc1.FinalRange(), enc2.FinalRange())
+}
+
+func TestChooseAllocationTrimDefault(t *testing.T) {
+	// Espectro plano a 128kbps → trim cerca de 5 (default).
+	logBandAmp := makeFlatLogBandAmp(0.0) // todas las bandas iguales
+	mdct := makeFlatMDCT(1.0)
+	trim := chooseAllocationTrim(
+		[2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50,
+	)
+	assert.InDelta(t, 5, trim, 1, "flat spectrum at 128kbps should stay near default")
+}
+
+func TestChooseAllocationTrimLowBitrate(t *testing.T) {
+	// A 32kbps → base trim=4 (no 5).
+	logBandAmp := makeFlatLogBandAmp(0.0)
+	mdct := makeFlatMDCT(1.0)
+	trim := chooseAllocationTrim(
+		[2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 32*8*50,
+	)
+	assert.LessOrEqual(t, trim, 5, "low bitrate should bias trim downward")
+}
+
+func TestChooseAllocationTrimSpectralTilt(t *testing.T) {
+	// Low-heavy spectrum → diff < 0 → trim -= negative → trim increases
+	// (trim > 5 biases bits toward low bands). High-heavy → opposite.
+	lowHeavy := makeTiltedLogBandAmp(-1.0)  // bandas bajas con más energía
+	highHeavy := makeTiltedLogBandAmp(+1.0) // bandas altas con más energía
+	mdct := makeFlatMDCT(1.0)
+	trimLow := chooseAllocationTrim([2][maxBands]float32{lowHeavy, lowHeavy},
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50)
+	trimHigh := chooseAllocationTrim([2][maxBands]float32{highHeavy, highHeavy},
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50)
+	assert.Greater(t, trimLow, trimHigh, "low-heavy spectrum should bias trim upward (more bits to lows)")
+}
+
+func TestChooseAllocationTrimStereoCorrelated(t *testing.T) {
+	// L=R (correlated) → trim disminuye.
+	logBandAmp := makeFlatLogBandAmp(0.0)
+	mdct := makeSineMDCT(440) // mismo contenido en ambos canales
+	trimCorr := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][]float32{mdct, mdct}, 2, maxLM, maxBands, 128*8*50)
+
+	// L y R decorrelated → trim sin ajuste stereo.
+	mdctR := makeNoiseMDCT(42)
+	trimDecorr := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][]float32{mdct, mdctR}, 2, maxLM, maxBands, 128*8*50)
+
+	assert.Less(t, trimCorr, trimDecorr, "correlated stereo should have lower trim than decorrelated")
+}
+
+// makeFlatLogBandAmp returns a per-band log amplitude array with every band
+// set to v. Used to feed chooseAllocationTrim a spectrally flat input.
+func makeFlatLogBandAmp(v float32) [maxBands]float32 {
+	var out [maxBands]float32
+	for i := range out {
+		out[i] = v
+	}
+
+	return out
+}
+
+// makeTiltedLogBandAmp returns a per-band log amplitude with a linear tilt
+// across bands. slope > 0 favors high bands, slope < 0 favors lows.
+func makeTiltedLogBandAmp(slope float32) [maxBands]float32 {
+	var out [maxBands]float32
+	for i := range out {
+		out[i] = slope * (float32(i) - float32(maxBands-1)/2.0)
+	}
+
+	return out
+}
+
+// makeFlatMDCT returns an MDCT spectrum of the full frame with every bin set
+// to v. Cosine similarity between two identical flat spectra is 1.0.
+func makeFlatMDCT(v float32) []float32 {
+	mdct := make([]float32, (1<<maxLM)*int(bandEdges[maxBands]))
+	for i := range mdct {
+		mdct[i] = v
+	}
+
+	return mdct
+}
+
+// makeSineMDCT returns an MDCT spectrum with a peak at the band closest to
+// freqHz. Bins outside that band are small but non-zero so the spectrum is
+// not degenerate. Two calls with the same freqHz produce identical spectra,
+// so cosine similarity is 1.0 (perfectly correlated).
+func makeSineMDCT(freqHz float32) []float32 {
+	scale := 1 << maxLM
+	mdct := make([]float32, scale*int(bandEdges[maxBands]))
+	binHz := float32(sampleRate) / float32(2*scale*int(bandEdges[maxBands]))
+	targetBin := max(0, int(freqHz/binHz))
+	if targetBin >= len(mdct) {
+		targetBin = len(mdct) - 1
+	}
+	for i := range mdct {
+		mdct[i] = 0.01
+	}
+	mdct[targetBin] = 1.0
+
+	return mdct
+}
+
+// makeNoiseMDCT returns a deterministic pseudo-random MDCT spectrum seeded by
+// seed. Different seeds produce decorrelated spectra.
+func makeNoiseMDCT(seed uint32) []float32 {
+	scale := 1 << maxLM
+	mdct := make([]float32, scale*int(bandEdges[maxBands]))
+	state := seed
+	for i := range mdct {
+		// Linear congruential generator (same constants as libopus celt_lcg_rand).
+		state = 1664525*state + 1013904223
+		// Map to [-1, 1]. int32 conversion is safe: state is a full-cycle LCG.
+		mdct[i] = float32(int32(state)) / float32(1<<31) //nolint:gosec // G115: intentional bit cast
+	}
+
+	return mdct
 }

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -406,7 +406,7 @@ func makeFlatLogBandAmp(v float32) [maxBands]float32 {
 func makeTiltedLogBandAmp(slope float32) [maxBands]float32 {
 	var out [maxBands]float32
 	for i := range out {
-		out[i] = slope * (float32(i) - float32(maxBands-1)/2.0) //nolint:gosec // G602: i is always in bounds, sourced from range out.
+		out[i] = slope * (float32(i) - float32(maxBands-1)/2.0) //nolint:gosec // G602: i from range.
 	}
 
 	return out

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -395,7 +395,7 @@ func TestChooseAllocationTrimStereoCorrelated(t *testing.T) {
 func makeFlatLogBandAmp(v float32) [maxBands]float32 {
 	var out [maxBands]float32
 	for i := range out {
-		out[i] = v
+		out[i] = v //nolint:gosec // G602: i is always in bounds, sourced from range out.
 	}
 
 	return out
@@ -406,7 +406,7 @@ func makeFlatLogBandAmp(v float32) [maxBands]float32 {
 func makeTiltedLogBandAmp(slope float32) [maxBands]float32 {
 	var out [maxBands]float32
 	for i := range out {
-		out[i] = slope * (float32(i) - float32(maxBands-1)/2.0)
+		out[i] = slope * (float32(i) - float32(maxBands-1)/2.0) //nolint:gosec // G602: i is always in bounds, sourced from range out.
 	}
 
 	return out

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -302,6 +302,12 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	e.prevSpreadDecision = info.spread
 	e.encodeSpread(&info)
 	totalBitsEighth := e.encodeDynamicAllocation(&info)
+	info.allocationTrim = chooseAllocationTrim(
+		analysis.logBandAmp,
+		analysis.mdct,
+		info.channelCount, info.lm, info.endBand,
+		info.totalBits,
+	)
 	e.encodeAllocationTrim(&info, totalBitsEighth)
 
 	tellFrac := int(e.rangeEncoder.TellFrac())

--- a/internal/celt/hysteresis.go
+++ b/internal/celt/hysteresis.go
@@ -6,12 +6,10 @@ package celt
 // hysteresisDecision maps val in [0, 1] to a 0–3 decision level using
 // thresholds as the three crossing points.
 //
-// The bias term mirrors the libopus pattern in spreading_decision
-// (celt_encoder.c): when prevDecision is high, val is biased down, so the
-// signal must be clearly tonal to stay aggressive; when prevDecision is low,
-// val is biased up, so a mildly tonal burst stays active for an extra frame.
-// This damps chattering around threshold crossings without needing per-caller
-// dead-band logic.
+// A small upward bias is added when prevDecision is low (NONE → +hystMag) and
+// removed when it is high (AGGRESSIVE → 0). This mirrors the libopus pattern
+// in spreading_decision (celt_encoder.c) and prevents chattering: a borderline
+// tonal signal that crossed into LIGHT stays there for at least one extra frame.
 func hysteresisDecision(val float32, prevDecision int, thresholds [3]float32) int {
 	// bias ∈ [0, hystMag]: largest when prev was NONE (0), zero when AGGRESSIVE (3).
 	const hystMag = 0.04


### PR DESCRIPTION
#### Description
The encoder was always using allocationTrim=5 (the neutral default). This PR computes it from the actual signal so the bit allocator can shift bits toward low or high frequency bands depending on what the frame needs.

Added `chooseAllocationTrim()` which mirrors `alloc_trim_analysis` in libopus (celt_encoder.c). It considers three things:

- **Bitrate**: at low bitrate (< 64 kbps) starts from 4 instead of 5
- **Stereo correlation**: if L and R are correlated, fewer bits go to highs
- **Spectral tilt**: measures whether the frame is bass-heavy or treble-heavy via a weighted sum of bandLogE, then shifts trim up or down accordingly

One tricky bit: pion's `logBandAmp` is `0.5*log2(energy) - energyMeans` while libopus uses `log2(energy)` in absolute dB. The tilt formula compensates with a ×2 on the log value and a ×6.02 dB/log2 conversion; the `energyMeans` offset cancels in the weighted difference since the weights sum to zero.

Parts that libopus computes from unported modules (`tonality_slope`, `tf_estimate`, `surround_trim`) contribute zero here — left for later PRs.

#### Reference issue
Fixes #...
