### PR TITLE
Add dynamic band boosts via dynalloc analysis

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -16,6 +16,10 @@ const (
 	fineOffset      = 21
 )
 
+// lsbDepth is the assumed bit depth of the input PCM. libopus uses 24 for
+// float input and 16 for int16. pion always receives float32, so 24.
+const lsbDepth = 24
+
 type allocationState struct {
 	pulses       [maxBands]int // Shape budget in 1/8-bit units; PVQ converts this to a pulse count later.
 	fineQuant    [maxBands]int
@@ -727,3 +731,323 @@ func min32(a, b float32) float32 {
 }
 
 func sqrtf(x float32) float32 { return float32(math.Sqrt(float64(x))) }
+
+// medianOf3 returns the median of three float32 values. Port of libopus
+// celt_encoder.c:median_of_3.
+func medianOf3(vals [3]float32) float32 {
+	if vals[0] > vals[1] {
+		if vals[1] > vals[2] {
+			return vals[1]
+		} else if vals[0] > vals[2] {
+			return vals[2]
+		}
+
+		return vals[0]
+	}
+
+	if vals[0] > vals[2] {
+		return vals[0]
+	} else if vals[1] > vals[2] {
+		return vals[2]
+	}
+
+	return vals[1]
+}
+
+// medianOf5 returns the median of five float32 values. Port of libopus
+// celt_encoder.c:median_of_5.
+func medianOf5(vals [5]float32) float32 {
+	lo0, hi0 := vals[0], vals[1]
+	if lo0 > hi0 {
+		lo0, hi0 = hi0, lo0
+	}
+	mid := vals[2]
+	lo1, hi1 := vals[3], vals[4]
+	if lo1 > hi1 {
+		lo1, hi1 = hi1, lo1
+	}
+	if lo0 > lo1 {
+		_, hi0, lo1, hi1 = lo1, hi1, lo0, hi0
+	}
+	if mid > hi0 {
+		if hi0 < lo1 {
+			return min32(mid, lo1)
+		}
+
+		return min32(hi1, hi0)
+	}
+	if mid < lo1 {
+		return min32(hi0, lo1)
+	}
+
+	return min32(mid, hi1)
+}
+
+// dynallocAnalysis computes per-band boost offsets and spread weights.
+// Mirrors libopus celt_encoder.c:dynalloc_analysis.
+//
+// pion's logBandAmp = 0.5*log2(energy)-energyMeans; libopus bandLogE =
+// log2(energy). We convert internally so the follower thresholds match.
+func dynallocAnalysis(
+	logBandAmp [2][maxBands]float32,
+	prevLogBandAmp [2][maxBands]float32,
+	lm, startBand, endBand, channelCount int,
+	effectiveBytes int,
+	isTransient bool,
+) (offsets [maxBands]int, spreadWeight [maxBands]int) {
+	var noiseFloor [maxBands]float32
+	for band := range endBand {
+		logN := float32(logN400[band]) / 8.0 // log2(band width)
+		noiseFloor[band] = 0.0625*logN +
+			0.5 + float32(9-lsbDepth) -
+			energyMeans[band] +
+			0.0062*float32((band+5)*(band+5))
+	}
+
+	var bandLogE [2][maxBands]float32
+	for ch := range channelCount {
+		for band := range endBand {
+			bandLogE[ch][band] = 2.0 * (logBandAmp[ch][band] + energyMeans[band])
+		}
+	}
+
+	maxDepth := float32(-31.9)
+	for ch := range channelCount {
+		for band := range endBand {
+			depth := bandLogE[ch][band] - noiseFloor[band]
+			if depth > maxDepth {
+				maxDepth = depth
+			}
+		}
+	}
+
+	{
+		var mask, sig [maxBands]float32
+		for band := range endBand {
+			mask[band] = bandLogE[0][band] - noiseFloor[band]
+			if channelCount == 2 {
+				d1 := bandLogE[1][band] - noiseFloor[band]
+				if d1 > mask[band] {
+					mask[band] = d1
+				}
+			}
+			sig[band] = mask[band]
+		}
+		// Forward: -6 dB/Bark → -0.996 log2.
+		for band := 1; band < endBand; band++ {
+			if mask[band-1]-0.996 > mask[band] {
+				mask[band] = mask[band-1] - 0.996
+			}
+		}
+		// Backward: -9 dB/Bark → -1.495 log2.
+		for band := endBand - 2; band >= 0; band-- {
+			if mask[band+1]-1.495 > mask[band] {
+				mask[band] = mask[band+1] - 1.495
+			}
+		}
+		// SMR → shift → spread_weight = 32 >> shift.
+		for band := range endBand {
+			masked := max32(0, maxDepth-12.0)
+			if mask[band] > masked {
+				masked = mask[band]
+			}
+			smr := sig[band] - masked
+			shift := 0
+			if smr < 0 {
+				shift = int(-smr + 0.5)
+			}
+			if shift > 5 {
+				shift = 5
+			}
+			if shift < 0 {
+				shift = 0
+			}
+			spreadWeight[band] = 32 >> shift
+		}
+	}
+
+	if effectiveBytes < 30+5*lm {
+		return offsets, spreadWeight
+	}
+
+	// follower tracks the previous frame's spectrum (bandLogE2 in libopus).
+	var follower [2][maxBands]float32
+	for ch := range channelCount {
+		var bandLogE3 [maxBands]float32
+		for band := range endBand {
+			bandLogE3[band] = 2.0 * (prevLogBandAmp[ch][band] + energyMeans[band])
+		}
+
+		// For LM==0, first 8 bands have 1 bin → unreliable. Take max with
+		// current bandLogE so at least 2 "bins" of context are used.
+		if lm == 0 {
+			for band := 0; band < endBand && band < 8; band++ {
+				if bandLogE[ch][band] > bandLogE3[band] {
+					bandLogE3[band] = bandLogE[ch][band]
+				}
+			}
+		}
+
+		follow := &follower[ch]
+		follow[0] = bandLogE3[0]
+		last := 0
+		for band := 1; band < endBand; band++ {
+			if bandLogE3[band] > bandLogE3[band-1]+0.5 {
+				last = band
+			}
+			prev := follow[band-1] + 1.5
+			follow[band] = bandLogE3[band]
+			if prev < follow[band] {
+				follow[band] = prev
+			}
+		}
+		for band := last - 1; band > 0; band-- {
+			next := follow[band+1] + 2.0
+			if next < follow[band] {
+				follow[band] = next
+			}
+			if bandLogE3[band] < follow[band] {
+				follow[band] = bandLogE3[band]
+			}
+		}
+
+		// Median filter with 1.0 dB offset (≈ 0.166 log2) to avoid
+		// triggering on smooth spectral tilts.
+		const offset = 1.0
+		for band := 2; band < endBand-2; band++ {
+			m := medianOf5([5]float32{
+				bandLogE3[band-2], bandLogE3[band-1], bandLogE3[band],
+				bandLogE3[band+1], bandLogE3[band+2],
+			}) - offset
+			if m > follow[band] {
+				follow[band] = m
+			}
+		}
+
+		if endBand >= 3 {
+			tmp := medianOf3([3]float32{bandLogE3[0], bandLogE3[1], bandLogE3[2]}) - offset
+			if tmp > follow[0] {
+				follow[0] = tmp
+			}
+			if tmp > follow[1] {
+				follow[1] = tmp
+			}
+			tmp = medianOf3([3]float32{
+				bandLogE3[endBand-3], bandLogE3[endBand-2], bandLogE3[endBand-1],
+			}) - offset
+			if tmp > follow[endBand-2] {
+				follow[endBand-2] = tmp
+			}
+			if tmp > follow[endBand-1] {
+				follow[endBand-1] = tmp
+			}
+		}
+
+		for band := range endBand {
+			if noiseFloor[band] > follow[band] {
+				follow[band] = noiseFloor[band]
+			}
+		}
+	}
+
+	var combined [maxBands]float32
+	if channelCount == 2 {
+		for band := startBand; band < endBand; band++ {
+			if follower[1][band] < follower[0][band]-4.0 {
+				follower[1][band] = follower[0][band] - 4.0
+			}
+			if follower[0][band] < follower[1][band]-4.0 {
+				follower[0][band] = follower[1][band] - 4.0
+			}
+			d0 := bandLogE[0][band] - follower[0][band]
+			if d0 < 0 {
+				d0 = 0
+			}
+			d1 := bandLogE[1][band] - follower[1][band]
+			if d1 < 0 {
+				d1 = 0
+			}
+			combined[band] = 0.5 * (d0 + d1)
+		}
+	} else {
+		for band := startBand; band < endBand; band++ {
+			d := bandLogE[0][band] - follower[0][band]
+			if d < 0 {
+				d = 0
+			}
+			combined[band] = d
+		}
+	}
+
+	// Halve non-transient frames (CBR path); boost low bands, reduce high.
+	if !isTransient {
+		for band := startBand; band < endBand; band++ {
+			combined[band] *= 0.5
+		}
+	}
+	for band := startBand; band < endBand; band++ {
+		if band < 8 {
+			combined[band] *= 2
+		}
+		if band >= 12 {
+			combined[band] *= 0.5
+		}
+	}
+
+	// Extra boost for band 0 at very high bitrate.
+	if effectiveBytes > 320 {
+		extra := float32(0.001) * float32(effectiveBytes-320)
+		if extra > 1.5 {
+			extra = 1.5
+		}
+		combined[0] += extra
+	}
+
+	// Cap at 4.0 log2 (≈ 24 dB) then divide by 8 to match libopus boost scale.
+	totBoostBits := 0
+	boostCap := 2 * effectiveBytes / 3 * 8 * 8 // 2/3 of budget in 1/8-bit units
+	for band := startBand; band < endBand; band++ {
+		if combined[band] > 4.0 {
+			combined[band] = 4.0
+		}
+		scaled := combined[band] / 8.0
+		width := channelCount * (int(bandEdges[band+1] - bandEdges[band])) << lm
+
+		var boost int
+		var boostBits int
+		switch {
+		case width < 6:
+			boost = int(scaled)
+			boostBits = boost * width << bitResolution
+		case width > 48:
+			boost = int(scaled * 8)
+			boostBits = (boost * width << bitResolution) / 8
+		default:
+			boost = int(scaled * float32(width) / 6.0)
+			boostBits = boost * 6 << bitResolution
+		}
+
+		if totBoostBits+boostBits > boostCap {
+			// Clamp to remaining budget.
+			remaining := max(0, boostCap-totBoostBits)
+			// convert remaining bits back to boost quanta
+			switch {
+			case width < 6:
+				boost = remaining >> bitResolution / max(1, width)
+			case width > 48:
+				boost = remaining << 3 / max(1, width) >> bitResolution
+			default:
+				boost = remaining >> bitResolution / 6
+			}
+			if boost < 0 {
+				boost = 0
+			}
+			boostBits = remaining
+		}
+
+		offsets[band] = boost
+		totBoostBits += boostBits
+	}
+
+	return offsets, spreadWeight
+}

--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -248,13 +248,17 @@ func computeBandLogAmp(freq []float32, lm int, startBand int, endBand int) [maxB
 // spreadingDecision computes the spread level for one frame from the MDCT
 // spectrum and updates the inter-frame average in prevAvg.
 //
-// The metric is the mean of (1 - bandMean/bandPeak) across coded bands.
-// A band where one bin dominates gives a value near 1 (tonal); a band with
-// uniform energy gives a value near 0 (noise-like). This is the floating-point
+// The metric is the weighted mean of (1 - bandMean/bandPeak) across coded
+// bands, where spreadWeight[band] controls each band's contribution. A band
+// where one bin dominates gives a value near 1 (tonal); a band with uniform
+// energy gives a value near 0 (noise-like). This is the floating-point
 // equivalent of the per-band CDF step inside libopus spreading_decision
-// (celt_encoder.c), using a uniform band weight since the tonality-based
-// spread_weight is disabled in libopus production.
-func spreadingDecision(mdct []float32, lm, startBand, endBand int, prevAvg *float32, prevDecision int) int {
+// (celt_encoder.c). spreadWeight comes from dynallocAnalysis masking model.
+func spreadingDecision(
+	mdct []float32, lm, startBand, endBand int,
+	prevAvg *float32, prevDecision int,
+	spreadWeight [maxBands]int,
+) int {
 	scale := 1 << lm
 	var sum float32
 	nBands := 0
@@ -264,6 +268,11 @@ func spreadingDecision(mdct []float32, lm, startBand, endBand int, prevAvg *floa
 		hi := scale * int(bandEdges[band+1])
 		n := hi - lo
 		if n < 2 {
+			continue
+		}
+
+		weight := spreadWeight[band]
+		if weight == 0 {
 			continue
 		}
 
@@ -282,8 +291,9 @@ func spreadingDecision(mdct []float32, lm, startBand, endBand int, prevAvg *floa
 		}
 
 		// 0 when all bins are equal (noise), near 1 when one bin dominates (tonal).
-		sum += 1 - mean/maxE
-		nBands++
+		tonality := 1 - mean/maxE
+		sum += tonality * float32(weight)
+		nBands += weight
 	}
 
 	if nBands == 0 {

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -534,7 +534,7 @@ func TestMedianOf5(t *testing.T) {
 func uniformSpreadWeight() [maxBands]int {
 	var w [maxBands]int
 	for i := range w {
-		w[i] = 32
+		w[i] = 32 //nolint:gosec // G602: i from range.
 	}
 
 	return w

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -31,7 +31,7 @@ func TestSpreadingDecisionTonalSignal(t *testing.T) {
 	prev := defaultSpreadDecision
 	var decision int
 	for range 8 {
-		decision = spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, prev)
+		decision = spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, prev, uniformSpreadWeight())
 		prev = decision
 	}
 	assert.GreaterOrEqual(t, decision, spreadNormal,
@@ -52,7 +52,7 @@ func TestSpreadingDecisionNoiseSignal(t *testing.T) {
 	prev := defaultSpreadDecision
 	var decision int
 	for range 8 {
-		decision = spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, prev)
+		decision = spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, prev, uniformSpreadWeight())
 		prev = decision
 	}
 	assert.LessOrEqual(t, decision, spreadLight,
@@ -73,13 +73,13 @@ func TestSpreadingDecisionRecursiveAvg(t *testing.T) {
 	var avgA float32
 	prevA := defaultSpreadDecision
 	for range 4 {
-		prevA = spreadingDecision(mdct, lm, 0, maxBands, &avgA, prevA)
+		prevA = spreadingDecision(mdct, lm, 0, maxBands, &avgA, prevA, uniformSpreadWeight())
 	}
 
 	var avgB float32
 	prevB := defaultSpreadDecision
 	for range 8 {
-		prevB = spreadingDecision(mdct, lm, 0, maxBands, &avgB, prevB)
+		prevB = spreadingDecision(mdct, lm, 0, maxBands, &avgB, prevB, uniformSpreadWeight())
 	}
 
 	// After more frames the avg should converge further; after 8 frames it
@@ -92,7 +92,7 @@ func TestSpreadingDecisionSilentFrame(t *testing.T) {
 	mdct := make([]float32, (1<<lm)*int(bandEdges[maxBands]))
 	var prevAvg float32
 	// All zero input: should return prevDecision unchanged.
-	got := spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, spreadNormal)
+	got := spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, spreadNormal, uniformSpreadWeight())
 	assert.Equal(t, spreadNormal, got, "silent frame should return prevDecision")
 }
 
@@ -392,7 +392,7 @@ func TestChooseAllocationTrimStereoCorrelated(t *testing.T) {
 
 // makeFlatLogBandAmp returns a per-band log amplitude array with every band
 // set to v. Used to feed chooseAllocationTrim a spectrally flat input.
-func makeFlatLogBandAmp(v float32) [maxBands]float32 {
+func makeFlatLogBandAmp(v float32) [maxBands]float32 { //nolint:unparam // v is kept for future tests
 	var out [maxBands]float32
 	for i := range out {
 		out[i] = v //nolint:gosec // G602: i is always in bounds, sourced from range out.
@@ -457,4 +457,85 @@ func makeNoiseMDCT(seed uint32) []float32 {
 	}
 
 	return mdct
+}
+
+func TestDynallocFlatSpectrumNoBoost(t *testing.T) {
+	// Flat spectrum → no isolated peaks → all offsets zero.
+	logBandAmp := makeFlatLogBandAmp(0.0)
+	prev := makeFlatLogBandAmp(0.0)
+	offsets, _ := dynallocAnalysis(
+		[2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][maxBands]float32{prev, prev},
+		maxLM, 0, maxBands, 1, 120, false,
+	)
+	for band := range maxBands {
+		assert.Equal(t, 0, offsets[band], "flat spectrum band %d should get no boost", band)
+	}
+}
+
+func TestDynallocIsolatedPeakGetsBoost(t *testing.T) {
+	// Isolated peak in band 10 → that band gets boost.
+	logBandAmp := makeFlatLogBandAmp(0.0)
+	logBandAmp[10] = 10.0
+	prev := makeFlatLogBandAmp(0.0)
+	offsets, _ := dynallocAnalysis(
+		[2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][maxBands]float32{prev, prev},
+		maxLM, 0, maxBands, 1, 120, false,
+	)
+	assert.Greater(t, offsets[10], 0, "isolated peak should get boost")
+}
+
+func TestDynallocSpreadWeightMaskedBandReduced(t *testing.T) {
+	// Strong peak in band 15 → neighboring bands are masked → lower weight.
+	logBandAmp := makeFlatLogBandAmp(0.0)
+	logBandAmp[15] = 20.0
+	prev := makeFlatLogBandAmp(0.0)
+	_, spreadWeight := dynallocAnalysis(
+		[2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][maxBands]float32{prev, prev},
+		maxLM, 0, maxBands, 1, 120, false,
+	)
+	// Bands far from the peak should have reduced weight.
+	assert.Less(t, spreadWeight[5], 32, "band far from peak should have reduced weight")
+}
+
+func TestDynallocLowBitrateGated(t *testing.T) {
+	// Below 30+5*LM bytes → dynalloc disabled, all offsets zero.
+	logBandAmp := makeFlatLogBandAmp(0.0)
+	logBandAmp[10] = 10.0
+	prev := makeFlatLogBandAmp(0.0)
+	offsets, _ := dynallocAnalysis(
+		[2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][maxBands]float32{prev, prev},
+		maxLM, 0, maxBands, 1, 10, false, // 10 bytes < 30+15=45
+	)
+	for band := range maxBands {
+		assert.Equal(t, 0, offsets[band], "low bitrate should gate dynalloc")
+	}
+}
+
+func TestMedianOf3(t *testing.T) {
+	assert.Equal(t, float32(2), medianOf3([3]float32{1, 2, 3}))
+	assert.Equal(t, float32(2), medianOf3([3]float32{3, 1, 2}))
+	assert.Equal(t, float32(2), medianOf3([3]float32{2, 3, 1}))
+	assert.Equal(t, float32(1), medianOf3([3]float32{1, 1, 1}))
+}
+
+func TestMedianOf5(t *testing.T) {
+	assert.Equal(t, float32(3), medianOf5([5]float32{1, 2, 3, 4, 5}))
+	assert.Equal(t, float32(3), medianOf5([5]float32{5, 4, 3, 2, 1}))
+	assert.Equal(t, float32(3), medianOf5([5]float32{3, 1, 4, 5, 2}))
+	assert.Equal(t, float32(2), medianOf5([5]float32{2, 2, 2, 2, 2}))
+}
+
+// uniformSpreadWeight returns a weight array where every band has weight 32
+// (no masking). This matches the pre-7c behavior of spreadingDecision.
+func uniformSpreadWeight() [maxBands]int {
+	var w [maxBands]int
+	for i := range w {
+		w[i] = 32
+	}
+
+	return w
 }

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -43,6 +43,7 @@ type Encoder struct {
 	prevSpreadAvg      float32
 	prevSpreadDecision int
 	prevIntensityBand  int
+	prevLogBandAmp     [2][maxBands]float32
 }
 
 func NewEncoder() Encoder {
@@ -210,22 +211,44 @@ func (e *Encoder) encodeSpread(info *frameSideInfo) {
 	}
 }
 
-// encodeDynamicAllocation mirrors decodeDynamicAllocation by emitting a zero
-// boost flag per band while budget allows. The decoder reads one flag per
-// band per RFC 6716 Section 4.3.3, so the encoder must emit the matching
-// flags in the same order to keep the range coder in sync — even when no
-// boost is applied.
-func (e *Encoder) encodeDynamicAllocation(info *frameSideInfo) uint {
+// encodeDynamicAllocation mirrors decodeDynamicAllocation by emitting boost
+// flags per band. offsets[band] is the number of boost quanta computed by
+// dynallocAnalysis; the encoder writes one flag per quantum, stopping when
+// the flag is 0 or the budget is exhausted. The decoder reads the same
+// sequence (RFC 6716 Section 4.3.3), so the two must stay in lockstep.
+func (e *Encoder) encodeDynamicAllocation(info *frameSideInfo, offsets [maxBands]int) uint {
 	totalBitsEighth := info.totalBits << bitResolution
+	caps := allocationCaps(info.lm, info.channelCount)
 	dynamicAllocationLogP := initialDynamicAllocationLogP
 	tellFrac := e.rangeEncoder.TellFrac()
 
 	for band := info.startBand; band < info.endBand; band++ {
-		if tellFrac+uint(dynamicAllocationLogP<<bitResolution) < totalBitsEighth {
-			e.rangeEncoder.EncodeSymbolLogP(uint(dynamicAllocationLogP), 0)
+		width := info.channelCount * (int(bandEdges[band+1]-bandEdges[band]) << info.lm)
+		quanta := min(width<<bitResolution, max(allocationTrimBitCost<<bitResolution, width))
+		quantaBits := uint(quanta)
+		loopLogP := dynamicAllocationLogP
+		boost := 0
+
+		for j := 0; tellFrac+uint(loopLogP<<bitResolution) < totalBitsEighth && boost < caps[band]; j++ {
+			flag := j < offsets[band]
+			e.rangeEncoder.EncodeSymbolLogP(uint(loopLogP), uint32(boolIndex(flag)))
 			tellFrac = e.rangeEncoder.TellFrac()
+			if !flag {
+				break
+			}
+			boost += quanta
+			if quantaBits >= totalBitsEighth {
+				totalBitsEighth = 0
+			} else {
+				totalBitsEighth -= quantaBits
+			}
+			loopLogP = 1
 		}
-		info.bandBoost[band] = 0
+
+		info.bandBoost[band] = boost
+		if boost > 0 {
+			dynamicAllocationLogP = max(minDynamicAllocationLogP, dynamicAllocationLogP-1)
+		}
 	}
 
 	return totalBitsEighth
@@ -295,13 +318,23 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	e.encodeCoarseEnergy(&info, targetLogE)
 
 	e.encodeTimeFrequencyChanges(&info)
+	// Compute dynalloc offsets and spread_weight BEFORE the spread decision,
+	// because spread_weight feeds spreadingDecision (libopus computes
+	// dynalloc_analysis before spreading_decision).
+	effectiveBytes := frameBytes
+	offsets, spreadWeight := dynallocAnalysis(
+		analysis.logBandAmp, e.prevLogBandAmp,
+		info.lm, info.startBand, info.endBand, info.channelCount,
+		effectiveBytes, info.transient,
+	)
+
 	info.spread = spreadingDecision(
 		analysis.mdct[0], info.lm, info.startBand, info.endBand,
-		&e.prevSpreadAvg, e.prevSpreadDecision,
+		&e.prevSpreadAvg, e.prevSpreadDecision, spreadWeight,
 	)
 	e.prevSpreadDecision = info.spread
 	e.encodeSpread(&info)
-	totalBitsEighth := e.encodeDynamicAllocation(&info)
+	totalBitsEighth := e.encodeDynamicAllocation(&info, offsets)
 	info.allocationTrim = chooseAllocationTrim(
 		analysis.logBandAmp,
 		analysis.mdct,
@@ -371,6 +404,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	bitsLeft := int(info.totalBits) - int(e.rangeEncoder.Tell())
 	e.finalizeFineEnergy(&info, info.allocation.fineQuant, info.allocation.finePriority, targetLogE, bitsLeft)
 
+	e.prevLogBandAmp = analysis.logBandAmp
 	e.rng = e.rangeEncoder.FinalRange()
 
 	return e.rangeEncoder.FlushInto(dst), nil


### PR DESCRIPTION
#### Description
Until now `encodeDynamicAllocation` always wrote zero boost flags, so the decoder never got extra bits for any band. This adds the actual analysis.

`dynallocAnalysis()` ports libopus `dynalloc_analysis` (celt_encoder.c). It builds a "follower" from the previous frame's spectrum, runs a median filter to avoid false positives on gradual tilts, and converts per-band excess into boost quanta. Bands that stick out above neighbors get more bits allocated.
  
As a side effect it also computes per-band spread weights from a simple masking model (forward/backward Bark spreading), which `spreadingDecision` now uses instead of the uniform weight=32 from PR #138.
  
One annoying bit: pion's `logBandAmp` is `0.5*log2(energy) - energyMeans`, not `log2(energy)` like libopus. Added the conversion internally so the follower thresholds don't need adjusting.

#### Reference issue
Fixes #...
