### PR TITLE
Add pitch detection and post-filter bitstream encoding

### DIFF
--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -4,7 +4,11 @@
 //nolint:gosec // G115/G602: integer conversions are bounded by CELT frame and band sizes.
 package celt
 
-import "github.com/pion/opus/internal/rangecoding"
+import (
+	"math/bits"
+
+	"github.com/pion/opus/internal/rangecoding"
+)
 
 // Encoder encodes PCM audio into CELT-only Opus frames.
 //
@@ -141,10 +145,33 @@ func (e *Encoder) encodeSilenceFlag() {
 	}
 }
 
-// encodePostFilter writes the disabled RFC 6716 post-filter symbol.
+// encodePostFilter writes the RFC 6716 Table 56 post-filter symbols.
 func (e *Encoder) encodePostFilter(info *frameSideInfo) {
-	if info.startBand == 0 && e.rangeEncoder.Tell()+16 <= info.totalBits {
+	if info.startBand != 0 || e.rangeEncoder.Tell()+16 > info.totalBits {
+		return
+	}
+	if !info.postFilter.enabled {
 		e.rangeEncoder.EncodeSymbolLogP(1, 0)
+
+		return
+	}
+
+	e.rangeEncoder.EncodeSymbolLogP(1, 1)
+
+	// Encode period as octave + fine pitch (RFC 6716 §4.3.7.1).
+	// pitch_index = period + 1 is split into octave = floor(log2) - 4
+	// and fine = pitch_index - (16 << octave), matching libopus
+	// celt_encoder.c lines 2055-2058.
+	period1 := uint32(info.postFilter.period + 1)
+	octave := uint(bits.Len32(period1) - 5)
+	e.rangeEncoder.EncodeUniform(6, uint32(octave))
+	fine := period1 - (16 << octave)
+	e.rangeEncoder.EncodeRawBits(4+octave, fine)
+
+	e.rangeEncoder.EncodeRawBits(3, uint32(info.postFilter.qq))
+
+	if e.rangeEncoder.Tell()+2 <= info.totalBits {
+		e.rangeEncoder.EncodeSymbolWithICDF(icdfTapset, uint32(info.postFilter.tapset))
 	}
 }
 
@@ -344,12 +371,12 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	e.encodeAllocationTrim(&info, totalBitsEighth)
 
 	tellFrac := int(e.rangeEncoder.TellFrac())
-	bits := (int(info.totalBits) << bitResolution) - tellFrac - 1
+	shapeBits := (int(info.totalBits) << bitResolution) - tellFrac - 1
 	info.antiCollapseRsv = 0
-	if info.transient && info.lm >= 2 && bits >= (info.lm+2)<<bitResolution {
+	if info.transient && info.lm >= 2 && shapeBits >= (info.lm+2)<<bitResolution {
 		info.antiCollapseRsv = 1 << bitResolution
 	}
-	bits -= info.antiCollapseRsv
+	shapeBits -= info.antiCollapseRsv
 	targetIntensity := 0
 	targetDualStereo := 0
 	if info.channelCount == 2 {
@@ -373,7 +400,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 			targetDualStereo = 1
 		}
 	}
-	info.allocation = e.computeAllocationMono(&info, bits, targetIntensity, targetDualStereo)
+	info.allocation = e.computeAllocationMono(&info, shapeBits, targetIntensity, targetDualStereo)
 	e.encodeFineEnergy(&info, info.allocation.fineQuant, targetLogE)
 
 	totalBits := (int(info.totalBits) << bitResolution) - info.antiCollapseRsv

--- a/internal/celt/frame.go
+++ b/internal/celt/frame.go
@@ -62,6 +62,7 @@ type postFilter struct {
 	period  int
 	gain    float32
 	tapset  int
+	qq      int
 }
 
 // decodeFrameSideInfo consumes the initial CELT symbols through the allocation
@@ -230,6 +231,7 @@ func (d *Decoder) decodePostFilter(info *frameSideInfo) error {
 		octave:  int(octave),
 		period:  (postFilterPitchBase << octave) + int(rawPeriod) - 1,
 		gain:    postFilterGainStep * float32(rawGain+1),
+		qq:      int(rawGain),
 	}
 
 	if d.rangeDecoder.Tell()+2 <= info.totalBits {

--- a/internal/celt/pitch.go
+++ b/internal/celt/pitch.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//nolint:gosec // G602: slice indices are bounded by combFilterMinPeriod/MaxPeriod and len(pcm).
+package celt
+
+import "math"
+
+// detectPitch finds the dominant pitch period via normalized autocorrelation
+// over [combFilterMinPeriod, combFilterMaxPeriod-2] (RFC 6716 §4.3.7.1 range).
+// Normalizing by sqrt(energyCurrent*lagEnergy) avoids the bias toward short lags.
+//
+// Simpler than libopus pitch_downsample + pitch_search (no LPC whitening,
+// no 4x decimation) — enough for clear tonal signals. libopus: celt/pitch.c.
+//
+//nolint:cyclop
+func detectPitch(pcm []float32) (period int, gain float32) {
+	period = combFilterMinPeriod
+	gain = 0
+
+	sampleCount := len(pcm)
+	if sampleCount < combFilterMinPeriod+1 {
+		return period, gain
+	}
+
+	maxPeriod := min(combFilterMaxPeriod-2, sampleCount-1)
+
+	// Energy of the current segment pcm[lag..n-1] at lag=combFilterMinPeriod.
+	var energyCurrent float64
+	for i := combFilterMinPeriod; i < sampleCount; i++ {
+		energyCurrent += float64(pcm[i]) * float64(pcm[i])
+	}
+
+	// Energy of the lagged segment pcm[0..n-1-lag] at lag=combFilterMinPeriod.
+	var lagEnergy float64
+	for i := 0; i < sampleCount-combFilterMinPeriod; i++ {
+		lagEnergy += float64(pcm[i]) * float64(pcm[i])
+	}
+
+	bestGain := 0.0
+	bestPeriod := combFilterMinPeriod
+
+	for lag := combFilterMinPeriod; lag <= maxPeriod; lag++ {
+		if energyCurrent > 1e-30 && lagEnergy > 1e-30 {
+			var xcorr float64
+			for i := lag; i < sampleCount; i++ {
+				xcorr += float64(pcm[i]) * float64(pcm[i-lag])
+			}
+
+			normGain := xcorr / math.Sqrt(energyCurrent*lagEnergy)
+			if normGain > bestGain {
+				bestGain = normGain
+				bestPeriod = lag
+			}
+		}
+
+		// Shrink both windows by one sample for the next period.
+		if lag < maxPeriod {
+			energyCurrent -= float64(pcm[lag]) * float64(pcm[lag])
+			if energyCurrent < 0 {
+				energyCurrent = 0
+			}
+			idx := sampleCount - lag - 1
+			lagEnergy -= float64(pcm[idx]) * float64(pcm[idx])
+			if lagEnergy < 0 {
+				lagEnergy = 0
+			}
+		}
+	}
+
+	if bestGain < 0 {
+		bestGain = 0
+	}
+
+	return bestPeriod, float32(bestGain)
+}
+
+// quantizePitchGain maps gain to the 3-bit RFC 6716 Table 56 grid.
+// Mirrors libopus run_prefilter (celt_encoder.c lines 1532-1538).
+func quantizePitchGain(gain float32) (qq int, quantized float32) {
+	// qg = floor(gain*32/3 + 0.5) - 1, clamped to [0, 7].
+	qq = int(float64(gain)*32.0/3.0+0.5) - 1
+	qq = max(0, min(7, qq))
+	quantized = postFilterGainStep * float32(qq+1)
+
+	return qq, quantized
+}

--- a/internal/celt/pitch_test.go
+++ b/internal/celt/pitch_test.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateSine(freq float64, sampleRate, numSamples int) []float32 {
+	samples := make([]float32, numSamples)
+	for i := range samples {
+		samples[i] = float32(math.Sin(2 * math.Pi * freq * float64(i) / float64(sampleRate)))
+	}
+
+	return samples
+}
+
+func TestDetectPitchSine200Hz(t *testing.T) {
+	// 200 Hz at 48 kHz → period 240 samples.
+	pcm := generateSine(200, 48000, 960)
+	period, gain := detectPitch(pcm)
+
+	assert.InDelta(t, 240, period, 2, "period should be ~240 samples")
+	assert.Greater(t, gain, float32(0.8), "gain should be high for pure tone")
+}
+
+func TestDetectPitchSine150Hz(t *testing.T) {
+	// 150 Hz at 48 kHz → period 320 samples.
+	pcm := generateSine(150, 48000, 960)
+	period, gain := detectPitch(pcm)
+
+	assert.InDelta(t, 320, period, 2, "period should be ~320 samples")
+	assert.Greater(t, gain, float32(0.8), "gain should be high for pure tone")
+}
+
+func TestDetectPitchSilence(t *testing.T) {
+	pcm := make([]float32, 960)
+	period, gain := detectPitch(pcm)
+
+	assert.Equal(t, combFilterMinPeriod, period)
+	assert.Zero(t, gain)
+}
+
+func TestDetectPitchShortInput(t *testing.T) {
+	pcm := make([]float32, 10)
+	period, gain := detectPitch(pcm)
+
+	assert.Equal(t, combFilterMinPeriod, period)
+	assert.Zero(t, gain)
+}
+
+func TestQuantizePitchGain(t *testing.T) {
+	cases := []struct {
+		gain      float32
+		wantQg    int
+		wantQuant float32
+	}{
+		{0.0, 0, postFilterGainStep * 1},
+		{0.1, 0, postFilterGainStep * 1},
+		{0.2, 1, postFilterGainStep * 2},
+		{0.5, 4, postFilterGainStep * 5},
+		{0.9, 7, postFilterGainStep * 8},
+		{1.0, 7, postFilterGainStep * 8},
+	}
+	for _, tc := range cases {
+		qg, quantized := quantizePitchGain(tc.gain)
+		assert.Equal(t, tc.wantQg, qg, "qg for gain %f", tc.gain)
+		assert.Equal(t, tc.wantQuant, quantized, "quantized for gain %f", tc.gain)
+	}
+}
+
+func TestEncodePostFilterDisabledByteIdentical(t *testing.T) {
+	// The disabled path must produce the same bitstream as before PR 7.5a.
+	enc := NewEncoder()
+	enc.rangeEncoder.Init()
+	info := frameSideInfo{startBand: 0, totalBits: 256}
+	enc.encodePostFilter(&info)
+	data := enc.rangeEncoder.Done()
+
+	// Single bit logp=1 symbol=0 → exactly one byte with the disabled flag.
+	dec := NewDecoder()
+	dec.rangeDecoder.Init(data)
+	info2 := frameSideInfo{startBand: 0, totalBits: 256}
+	err := dec.decodePostFilter(&info2)
+
+	require.NoError(t, err)
+	assert.False(t, info2.postFilter.enabled)
+}
+
+func TestEncodePostFilterRoundTrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		period int
+		qg     int
+		tapset int
+	}{
+		{"octave0 period15", 15, 0, 0},
+		{"octave1 period40", 40, 3, 1},
+		{"octave3 period240", 240, 5, 2},
+		{"octave5 period700", 700, 7, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := NewEncoder()
+			enc.rangeEncoder.Init()
+			info := frameSideInfo{
+				startBand: 0,
+				totalBits: 256,
+				postFilter: postFilter{
+					enabled: true,
+					period:  tc.period,
+					qq:      tc.qg,
+					tapset:  tc.tapset,
+				},
+			}
+			enc.encodePostFilter(&info)
+			data := enc.rangeEncoder.Done()
+
+			dec := NewDecoder()
+			dec.rangeDecoder.Init(data)
+			info2 := frameSideInfo{startBand: 0, totalBits: 256}
+			err := dec.decodePostFilter(&info2)
+
+			require.NoError(t, err)
+			assert.True(t, info2.postFilter.enabled)
+			assert.Equal(t, tc.period, info2.postFilter.period, "period mismatch")
+			assert.Equal(t, tc.qg, info2.postFilter.qq, "qg mismatch")
+			assert.Equal(t, tc.tapset, info2.postFilter.tapset, "tapset mismatch")
+			assert.Equal(t, postFilterGainStep*float32(tc.qg+1), info2.postFilter.gain, "gain mismatch")
+			assert.Equal(t, enc.rangeEncoder.FinalRange(), dec.rangeDecoder.FinalRange(),
+				"FinalRange must match after post-filter encode/decode")
+		})
+	}
+}
+
+func TestEncodePostFilterSkipsWhenStartBandNotZero(t *testing.T) {
+	enc := NewEncoder()
+	enc.rangeEncoder.Init()
+	info := frameSideInfo{
+		startBand:  17,
+		totalBits:  256,
+		postFilter: postFilter{enabled: true, period: 240, qq: 3, tapset: 1},
+	}
+	enc.encodePostFilter(&info)
+
+	// Nothing should have been written — Tell stays at 1 (post-Init).
+	assert.Equal(t, uint(1), enc.rangeEncoder.Tell())
+}


### PR DESCRIPTION
#### Description
Implements `detectPitch` (normalized autocorrelation over the RFC 6716 §4.3.7.1 period range) and extends `encodePostFilter` to write the actual post-filter parameters instead of always writing "disabled".

`detectPitch` is simpler than libopus `pitch_downsample + pitch_search` — no LPC whitening, no 4x decimation. Good enough for clear tonal signals where the pre-filter matters. The bitstream encoding (octave + fine period + 3-bit gain + tapset) is bit-exact with `decodePostFilter`, verified with round-trip tests across octaves 0–5.

The encoder still writes `enabled=false` for every frame — the decision logic and pre-filter application come in the next PR.

#### Reference issue
Fixes #...
