### PR TITLE
Add encoder quality regression harness

### DIFF
--- a/.github/scripts/lib-opus-reference.sh
+++ b/.github/scripts/lib-opus-reference.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+# SPDX-License-Identifier: MIT
+#
+# Shared helpers for working with the RFC 6716 reference implementation.
+# Source this file; do not execute it directly.
+
+_OPUS_RFC6716_URL="${RFC6716_URL:-https://www.rfc-editor.org/rfc/rfc6716.txt}"
+# RFC 6716 Appendix A.1 publishes this SHA-1 for opus-rfc6716.tar.gz.
+readonly _OPUS_RFC6716_SOURCE_SHA1="86a927223e73d2476646a1b933fcd3fffb6ecc8c"
+_OPUS_RFC8251_PATCH_URL="${RFC8251_PATCH_URL:-https://www.ietf.org/proceedings/98/slides/materials-98-codec-opus-update-00.patch}"
+# RFC 8251 Section 1 publishes this SHA-1 for the properly formatted patch.
+readonly _OPUS_RFC8251_PATCH_SHA1="029e3aa88fc342c91e67a21e7bfbc9458661cd5f"
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+download() {
+    local url="$1"
+    local out="$2"
+    curl --fail --location --show-error --silent "${url}" --output "${out}"
+}
+
+verify_sha1() {
+    local want="$1"
+    local path="$2"
+    if command -v sha1sum >/dev/null 2>&1; then
+        printf "%s  %s\n" "${want}" "${path}" | sha1sum -c -
+    else
+        printf "%s  %s\n" "${want}" "${path}" | shasum -a 1 -c -
+    fi
+}
+
+base64_decode() {
+    if base64 --help 2>&1 | grep -q -- "--decode"; then
+        base64 --decode
+    else
+        base64 -D
+    fi
+}
+
+# prepare_reference_source downloads the RFC 6716 C source, verifies its
+# SHA-1 (RFC 6716 Appendix A.1), applies the RFC 8251 decoder patch, and
+# unpacks the tree into <reference_dir>.  After this call the directory is
+# ready for `make opus_demo opus_compare`.
+#
+# Usage: prepare_reference_source <work_dir> <reference_dir>
+prepare_reference_source() {
+    local work_dir="$1"
+    local reference_dir="$2"
+
+    local rfc_path="$work_dir/rfc6716.txt"
+    local archive_path="$work_dir/opus-rfc6716.tar.gz"
+    local patch_path="$work_dir/rfc8251.patch"
+
+    echo "Downloading RFC 6716..."
+    download "${_OPUS_RFC6716_URL}" "${rfc_path}"
+
+    echo "Extracting reference source..."
+    grep '^   ###' "${rfc_path}" | sed -e 's/...###//' | base64_decode >"${archive_path}"
+    verify_sha1 "${_OPUS_RFC6716_SOURCE_SHA1}" "${archive_path}"
+    mkdir -p "${reference_dir}"
+    tar -xzf "${archive_path}" -C "${reference_dir}" --strip-components=1
+
+    echo "Applying RFC 8251 decoder patch..."
+    download "${_OPUS_RFC8251_PATCH_URL}" "${patch_path}"
+    verify_sha1 "${_OPUS_RFC8251_PATCH_SHA1}" "${patch_path}"
+    patch -d "${reference_dir}" -p1 <"${patch_path}"
+}

--- a/.github/scripts/run-encoder-quality.sh
+++ b/.github/scripts/run-encoder-quality.sh
@@ -16,12 +16,15 @@ trap 'rm -rf "${WORK_DIR}"' EXIT
 result_file="${OPUS_QUALITY_RESULT:-${WORK_DIR}/encoder-quality.md}"
 mkdir -p "$(dirname "${result_file}")"
 
+markdown_file="${WORK_DIR}/quality-tables.md"
+
 # --- Tier 1: SNR regression (pure Go, no external tools) ---
 echo "=== Tier 1: SNR regression ==="
 cd "${REPO_DIR}"
 tier1_log="${WORK_DIR}/tier1.log"
 set +e
-go test -v -run TestEncoderQuality -count=1 . 2>&1 | tee "${tier1_log}"
+OPUS_QUALITY_MARKDOWN="${markdown_file}" \
+    go test -v -run TestEncoderQuality -count=1 . 2>&1 | tee "${tier1_log}"
 tier1_exit=${PIPESTATUS[0]}
 set -e
 echo ""
@@ -40,36 +43,46 @@ prepare_reference_source "${WORK_DIR}" "${reference_dir}"
 
 tier2_log="${WORK_DIR}/tier2.log"
 set +e
-OPUS_RFC6716_REFERENCE="${reference_dir}" \
+OPUS_QUALITY_MARKDOWN="${markdown_file}" \
+    OPUS_RFC6716_REFERENCE="${reference_dir}" \
     go test -v -tags conformance -run TestEncoderQualityVsReference -count=1 . 2>&1 | tee "${tier2_log}"
 tier2_exit=${PIPESTATUS[0]}
 set -e
 echo ""
 
 # --- Report ---
+status_text="pass"
+if [ "${tier1_exit}" -ne 0 ] || [ "${tier2_exit}" -ne 0 ]; then
+    status_text="fail (informational)"
+fi
+
 {
     echo "<!-- opus-encoder-quality -->"
     echo "## Encoder Quality Report"
-    echo ""
-    echo "### Tier 1: SNR (pion encode → pion decode)"
-    echo ""
+    echo
+    echo "**Status:** ${status_text}"
+    echo
+    if [ -s "${markdown_file}" ]; then
+        cat "${markdown_file}"
+    else
+        echo "No quality tables generated."
+    fi
+    echo
+    echo "<details><summary>Run output</summary>"
+    echo
+    echo '```text'
+    tail -n 200 "${tier1_log}"
+    [ -s "${tier2_log}" ] && tail -n 200 "${tier2_log}"
     echo '```'
-    grep -E "signal=|baseline=|--- PASS|--- FAIL" "${tier1_log}" 2>/dev/null \
-        | sed 's/^    [^:]*:[0-9]*: //' \
-        || echo "(no output)"
-    echo '```'
-    echo ""
-    echo "### Tier 2: opus_compare (vs RFC 6716 reference)"
-    echo ""
-    echo '```'
-    grep -E "pion quality=|libopus quality=|--- PASS|--- FAIL|--- SKIP" "${tier2_log}" 2>/dev/null \
-        | sed 's/^    [^:]*:[0-9]*: //' \
-        || echo "(no output)"
-    echo '```'
-    echo ""
+    echo "</details>"
+    echo
     echo "---"
     echo "*Baseline: \`testdata/encoder-quality-baseline.json\`*"
 } >"${result_file}"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    cat "${result_file}" >>"${GITHUB_STEP_SUMMARY}"
+fi
 
 if [ "${tier1_exit}" -ne 0 ] || [ "${tier2_exit}" -ne 0 ]; then
     echo "FAILED: tier1=${tier1_exit} tier2=${tier2_exit}"

--- a/.github/scripts/run-encoder-quality.sh
+++ b/.github/scripts/run-encoder-quality.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=lib-opus-reference.sh
+source "${SCRIPT_DIR}/lib-opus-reference.sh"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+result_file="${OPUS_QUALITY_RESULT:-${WORK_DIR}/encoder-quality.md}"
+mkdir -p "$(dirname "${result_file}")"
+
+# --- Tier 1: SNR regression (pure Go, no external tools) ---
+echo "=== Tier 1: SNR regression ==="
+cd "${REPO_DIR}"
+tier1_log="${WORK_DIR}/tier1.log"
+set +e
+go test -v -run TestEncoderQuality -count=1 . 2>&1 | tee "${tier1_log}"
+tier1_exit=${PIPESTATUS[0]}
+set -e
+echo ""
+
+# --- Tier 2: opus_compare vs reference ---
+echo "=== Tier 2: opus_compare ==="
+require_command base64
+require_command curl
+require_command make
+require_command patch
+require_command sed
+require_command tar
+
+reference_dir="${WORK_DIR}/reference"
+prepare_reference_source "${WORK_DIR}" "${reference_dir}"
+
+tier2_log="${WORK_DIR}/tier2.log"
+set +e
+OPUS_RFC6716_REFERENCE="${reference_dir}" \
+    go test -v -tags conformance -run TestEncoderQualityVsReference -count=1 . 2>&1 | tee "${tier2_log}"
+tier2_exit=${PIPESTATUS[0]}
+set -e
+echo ""
+
+# --- Report ---
+{
+    echo "<!-- opus-encoder-quality -->"
+    echo "## Encoder Quality Report"
+    echo ""
+    echo "### Tier 1: SNR (pion encode → pion decode)"
+    echo ""
+    echo '```'
+    grep -E "signal=|baseline=|--- PASS|--- FAIL" "${tier1_log}" 2>/dev/null || echo "(no output)"
+    echo '```'
+    echo ""
+    echo "### Tier 2: opus_compare (vs RFC 6716 reference)"
+    echo ""
+    echo '```'
+    grep -E "quality=|weighted_error=|--- PASS|--- FAIL|--- SKIP" "${tier2_log}" 2>/dev/null || echo "(no output)"
+    echo '```'
+    echo ""
+    echo "---"
+    echo "*Baseline: \`testdata/encoder-quality-baseline.json\`*"
+} >"${result_file}"
+
+if [ "${tier1_exit}" -ne 0 ] || [ "${tier2_exit}" -ne 0 ]; then
+    echo "FAILED: tier1=${tier1_exit} tier2=${tier2_exit}"
+    exit 1
+fi
+
+echo "All quality checks passed."

--- a/.github/scripts/run-encoder-quality.sh
+++ b/.github/scripts/run-encoder-quality.sh
@@ -54,13 +54,17 @@ echo ""
     echo "### Tier 1: SNR (pion encode → pion decode)"
     echo ""
     echo '```'
-    grep -E "signal=|baseline=|--- PASS|--- FAIL" "${tier1_log}" 2>/dev/null || echo "(no output)"
+    grep -E "signal=|baseline=|--- PASS|--- FAIL" "${tier1_log}" 2>/dev/null \
+        | sed 's/^    [^:]*:[0-9]*: //' \
+        || echo "(no output)"
     echo '```'
     echo ""
     echo "### Tier 2: opus_compare (vs RFC 6716 reference)"
     echo ""
     echo '```'
-    grep -E "quality=|weighted_error=|--- PASS|--- FAIL|--- SKIP" "${tier2_log}" 2>/dev/null || echo "(no output)"
+    grep -E "pion quality=|libopus quality=|--- PASS|--- FAIL|--- SKIP" "${tier2_log}" 2>/dev/null \
+        | sed 's/^    [^:]*:[0-9]*: //' \
+        || echo "(no output)"
     echo '```'
     echo ""
     echo "---"

--- a/.github/scripts/run-rfc6716-conformance.sh
+++ b/.github/scripts/run-rfc6716-conformance.sh
@@ -5,12 +5,10 @@
 
 set -euo pipefail
 
-readonly RFC6716_URL="${RFC6716_URL:-https://www.rfc-editor.org/rfc/rfc6716.txt}"
-# RFC 6716 Appendix A.1 publishes this SHA-1 for opus-rfc6716.tar.gz.
-readonly RFC6716_SOURCE_SHA1="86a927223e73d2476646a1b933fcd3fffb6ecc8c"
-readonly RFC8251_PATCH_URL="${RFC8251_PATCH_URL:-https://www.ietf.org/proceedings/98/slides/materials-98-codec-opus-update-00.patch}"
-# RFC 8251 Section 1 publishes this SHA-1 for the properly formatted patch.
-readonly RFC8251_PATCH_SHA1="029e3aa88fc342c91e67a21e7bfbc9458661cd5f"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-opus-reference.sh
+source "${SCRIPT_DIR}/lib-opus-reference.sh"
+
 readonly RFC6716_VECTORS_URL="${RFC6716_VECTORS_URL:-https://opus-codec.org/static/testvectors/opus_testvectors.tar.gz}"
 readonly RFC8251_VECTORS_URL="${RFC8251_VECTORS_URL:-https://opus-codec.org/static/testvectors/opus_testvectors-rfc8251.tar.gz}"
 
@@ -20,116 +18,71 @@ log_file="${work_dir}/go-test.log"
 matrix_file="${work_dir}/conformance-matrix.md"
 
 write_early_failure_comment() {
-  local status="$1"
+    local status="$1"
 
-  mkdir -p "$(dirname "${result_file}")"
-  {
-    echo "<!-- opus-rfc-conformance -->"
-    echo "## RFC 6716 / 8251 conformation"
-    echo
-    echo "**Status:** fail"
-    echo
-    echo "The conformance action failed before the test matrix was available."
-    echo
-    echo "Exit status: \`${status}\`"
-    if [ -f "${log_file}" ]; then
-      echo
-      echo "<details><summary>Run output</summary>"
-      echo
-      echo '```text'
-      tail -n 200 "${log_file}"
-      echo '```'
-      echo "</details>"
-    fi
-  } >"${result_file}"
+    mkdir -p "$(dirname "${result_file}")"
+    {
+        echo "<!-- opus-rfc-conformance -->"
+        echo "## RFC 6716 / 8251 conformation"
+        echo
+        echo "**Status:** fail"
+        echo
+        echo "The conformance action failed before the test matrix was available."
+        echo
+        echo "Exit status: \`${status}\`"
+        if [ -f "${log_file}" ]; then
+            echo
+            echo "<details><summary>Run output</summary>"
+            echo
+            echo '```text'
+            tail -n 200 "${log_file}"
+            echo '```'
+            echo "</details>"
+        fi
+    } >"${result_file}"
 }
 
 on_exit() {
-  local status="$1"
+    local status="$1"
 
-  if [ "${status}" -ne 0 ] && [ ! -s "${result_file}" ]; then
-    write_early_failure_comment "${status}"
-  fi
+    if [ "${status}" -ne 0 ] && [ ! -s "${result_file}" ]; then
+        write_early_failure_comment "${status}"
+    fi
 }
 trap 'on_exit "$?"' EXIT
 
-require_command() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    echo "missing required command: $1" >&2
-    exit 1
-  fi
-}
-
-download() {
-  local url="$1"
-  local out="$2"
-
-  curl --fail --location --show-error --silent "${url}" --output "${out}"
-}
-
-verify_sha1() {
-  local want="$1"
-  local path="$2"
-
-  if command -v sha1sum >/dev/null 2>&1; then
-    printf "%s  %s\n" "${want}" "${path}" | sha1sum -c -
-  else
-    printf "%s  %s\n" "${want}" "${path}" | shasum -a 1 -c -
-  fi
-}
-
 verify_sha1_manifest() {
-  local dir="$1"
+    local dir="$1"
 
-  if command -v sha1sum >/dev/null 2>&1; then
-    (cd "${dir}" && sha1sum -c -)
-  else
-    (cd "${dir}" && shasum -a 1 -c -)
-  fi
-}
-
-base64_decode() {
-  if base64 --help 2>&1 | grep -q -- "--decode"; then
-    base64 --decode
-  else
-    base64 -D
-  fi
-}
-
-extract_reference_source() {
-  local rfc_path="$1"
-  local archive_path="$2"
-  local reference_dir="$3"
-
-  grep '^   ###' "${rfc_path}" | sed -e 's/...###//' | base64_decode >"${archive_path}"
-  verify_sha1 "${RFC6716_SOURCE_SHA1}" "${archive_path}"
-
-  mkdir -p "${reference_dir}"
-  tar -xzf "${archive_path}" -C "${reference_dir}" --strip-components=1
+    if command -v sha1sum >/dev/null 2>&1; then
+        (cd "${dir}" && sha1sum -c -)
+    else
+        (cd "${dir}" && shasum -a 1 -c -)
+    fi
 }
 
 extract_vector_archive() {
-  local archive_path="$1"
-  local dest_dir="$2"
-  local expected_count="$3"
-  local tmp_dir
-  local found_count
+    local archive_path="$1"
+    local dest_dir="$2"
+    local expected_count="$3"
+    local tmp_dir
+    local found_count
 
-  tmp_dir="$(mktemp -d "${work_dir}/vectors.XXXXXX")"
-  mkdir -p "${dest_dir}"
-  tar -xzf "${archive_path}" -C "${tmp_dir}"
-  find "${tmp_dir}" -type f \( -name 'testvector*.bit' -o -name 'testvector*.dec' \) -exec cp {} "${dest_dir}" \;
+    tmp_dir="$(mktemp -d "${work_dir}/vectors.XXXXXX")"
+    mkdir -p "${dest_dir}"
+    tar -xzf "${archive_path}" -C "${tmp_dir}"
+    find "${tmp_dir}" -type f \( -name 'testvector*.bit' -o -name 'testvector*.dec' \) -exec cp {} "${dest_dir}" \;
 
-  found_count="$(find "${dest_dir}" -type f | wc -l | tr -d ' ')"
-  if [ "${found_count}" != "${expected_count}" ]; then
-    echo "expected ${expected_count} vector files in ${dest_dir}, found ${found_count}" >&2
-    exit 1
-  fi
+    found_count="$(find "${dest_dir}" -type f | wc -l | tr -d ' ')"
+    if [ "${found_count}" != "${expected_count}" ]; then
+        echo "expected ${expected_count} vector files in ${dest_dir}, found ${found_count}" >&2
+        exit 1
+    fi
 }
 
 verify_rfc6716_vector_sha1s() {
-  # RFC 6716 Appendix A.4 publishes SHA-1 hashes for the extracted vector files.
-  verify_sha1_manifest "$1" <<'EOF'
+    # RFC 6716 Appendix A.4 publishes SHA-1 hashes for the extracted vector files.
+    verify_sha1_manifest "$1" <<'EOF'
 e49b2862ceec7324790ed8019eb9744596d5be01  testvector01.bit
 b809795ae1bcd606049d76de4ad24236257135e0  testvector02.bit
 e0c4ecaeab44d35a2f5b6575cd996848e5ee2acc  testvector03.bit
@@ -158,8 +111,8 @@ EOF
 }
 
 verify_rfc8251_vector_sha1s() {
-  # RFC 8251 Section 11 publishes SHA-1 hashes for the extracted vector files.
-  verify_sha1_manifest "$1" <<'EOF'
+    # RFC 8251 Section 11 publishes SHA-1 hashes for the extracted vector files.
+    verify_sha1_manifest "$1" <<'EOF'
 e49b2862ceec7324790ed8019eb9744596d5be01  testvector01.bit
 b809795ae1bcd606049d76de4ad24236257135e0  testvector02.bit
 e0c4ecaeab44d35a2f5b6575cd996848e5ee2acc  testvector03.bit
@@ -200,93 +153,83 @@ EOF
 }
 
 write_result_comment() {
-  local status="$1"
-  local status_text="pass"
+    local status="$1"
+    local status_text="pass"
 
-  if [ "${status}" -ne 0 ]; then
-    status_text="fail (informational)"
-  fi
-
-  {
-    echo "<!-- opus-rfc-conformance -->"
-    echo "## RFC 6716 / 8251 conformation"
-    echo
-    echo "**Status:** ${status_text}"
-    echo
-    echo "The action extracts the RFC 6716 reference implementation, applies the RFC 8251 decoder update patch, and then builds the patched reference tools."
     if [ "${status}" -ne 0 ]; then
-      echo
-      echo "This check is informational while CELT support is incomplete; the workflow still reports success."
+        status_text="fail (informational)"
     fi
-    echo
-    if [ -s "${matrix_file}" ]; then
-      cat "${matrix_file}"
-    else
-      echo "The conformance run did not produce a result matrix."
-    fi
-    echo
-    echo "<details><summary>Run output</summary>"
-    echo
-    echo '```text'
-    tail -n 200 "${log_file}"
-    echo '```'
-    echo "</details>"
-  } >"${result_file}"
 
-  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-    cat "${result_file}" >>"${GITHUB_STEP_SUMMARY}"
-  fi
+    {
+        echo "<!-- opus-rfc-conformance -->"
+        echo "## RFC 6716 / 8251 conformation"
+        echo
+        echo "**Status:** ${status_text}"
+        echo
+        echo "The action extracts the RFC 6716 reference implementation, applies the RFC 8251 decoder update patch, and then builds the patched reference tools."
+        if [ "${status}" -ne 0 ]; then
+            echo
+            echo "This check is informational while CELT support is incomplete; the workflow still reports success."
+        fi
+        echo
+        if [ -s "${matrix_file}" ]; then
+            cat "${matrix_file}"
+        else
+            echo "The conformance run did not produce a result matrix."
+        fi
+        echo
+        echo "<details><summary>Run output</summary>"
+        echo
+        echo '```text'
+        tail -n 200 "${log_file}"
+        echo '```'
+        echo "</details>"
+    } >"${result_file}"
+
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        cat "${result_file}" >>"${GITHUB_STEP_SUMMARY}"
+    fi
 }
 
 main() {
-  require_command base64
-  require_command curl
-  require_command find
-  require_command go
-  require_command make
-  require_command patch
-  require_command sed
-  require_command tar
+    require_command base64
+    require_command curl
+    require_command find
+    require_command go
+    require_command make
+    require_command patch
+    require_command sed
+    require_command tar
 
-  rm -rf "${work_dir}"
-  mkdir -p "${work_dir}"
+    rm -rf "${work_dir}"
+    mkdir -p "${work_dir}"
 
-  local rfc_path="${work_dir}/rfc6716.txt"
-  local source_archive="${work_dir}/opus-rfc6716.tar.gz"
-  local patch_path="${work_dir}/rfc8251.patch"
-  local reference_dir="${work_dir}/reference"
-  local vector_dir="${work_dir}/testvectors"
-  local rfc6716_vectors="${work_dir}/opus_testvectors.tar.gz"
-  local rfc8251_vectors="${work_dir}/opus_testvectors-rfc8251.tar.gz"
+    prepare_reference_source "${work_dir}" "${work_dir}/reference"
 
-  download "${RFC6716_URL}" "${rfc_path}"
-  extract_reference_source "${rfc_path}" "${source_archive}" "${reference_dir}"
+    local vector_dir="${work_dir}/testvectors"
+    local rfc6716_vectors="${work_dir}/opus_testvectors.tar.gz"
+    local rfc8251_vectors="${work_dir}/opus_testvectors-rfc8251.tar.gz"
 
-  download "${RFC8251_PATCH_URL}" "${patch_path}"
-  verify_sha1 "${RFC8251_PATCH_SHA1}" "${patch_path}"
-  echo "Applying RFC 8251 decoder update patch to the RFC 6716 reference implementation"
-  patch -d "${reference_dir}" -p1 <"${patch_path}"
+    download "${RFC6716_VECTORS_URL}" "${rfc6716_vectors}"
+    extract_vector_archive "${rfc6716_vectors}" "${vector_dir}/rfc6716" 24
+    verify_rfc6716_vector_sha1s "${vector_dir}/rfc6716"
 
-  download "${RFC6716_VECTORS_URL}" "${rfc6716_vectors}"
-  extract_vector_archive "${rfc6716_vectors}" "${vector_dir}/rfc6716" 24
-  verify_rfc6716_vector_sha1s "${vector_dir}/rfc6716"
+    download "${RFC8251_VECTORS_URL}" "${rfc8251_vectors}"
+    extract_vector_archive "${rfc8251_vectors}" "${vector_dir}/rfc8251" 36
+    verify_rfc8251_vector_sha1s "${vector_dir}/rfc8251"
 
-  download "${RFC8251_VECTORS_URL}" "${rfc8251_vectors}"
-  extract_vector_archive "${rfc8251_vectors}" "${vector_dir}/rfc8251" 36
-  verify_rfc8251_vector_sha1s "${vector_dir}/rfc8251"
+    export OPUS_RFC6716_REFERENCE="${work_dir}/reference"
+    export OPUS_RFC6716_TESTVECTORS="${vector_dir}"
+    export OPUS_CONFORMANCE_MARKDOWN="${matrix_file}"
 
-  export OPUS_RFC6716_REFERENCE="${reference_dir}"
-  export OPUS_RFC6716_TESTVECTORS="${vector_dir}"
-  export OPUS_CONFORMANCE_MARKDOWN="${matrix_file}"
+    set +e
+    go test -v -timeout 60m -tags conformance -run TestRFC6716Conformance . 2>&1 | tee "${log_file}"
+    local test_status="${PIPESTATUS[0]}"
+    set -e
 
-  set +e
-  go test -v -timeout 60m -tags conformance -run TestRFC6716Conformance . 2>&1 | tee "${log_file}"
-  local test_status="${PIPESTATUS[0]}"
-  set -e
+    write_result_comment "${test_status}"
 
-  write_result_comment "${test_status}"
-
-  return "${test_status}"
+    return "${test_status}"
 }
 
 main "$@"

--- a/.github/workflows/encoder-quality.yml
+++ b/.github/workflows/encoder-quality.yml
@@ -1,5 +1,5 @@
 #
-#SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+# SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 # SPDX-License-Identifier: MIT
 
 name: Encoder quality
@@ -49,12 +49,15 @@ jobs:
             }
             const body = fs.readFileSync(path, 'utf8');
             const marker = '<!-- opus-encoder-quality -->';
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body && c.body.includes(marker)
+            );
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,

--- a/.github/workflows/encoder-quality.yml
+++ b/.github/workflows/encoder-quality.yml
@@ -1,0 +1,74 @@
+#
+#SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+# SPDX-License-Identifier: MIT
+
+name: Encoder quality
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: test / encoder quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Run encoder quality tests
+        run: bash .github/scripts/run-encoder-quality.sh
+        env:
+          OPUS_QUALITY_RESULT: ${{ runner.temp }}/opus-encoder-quality.md
+        continue-on-error: true
+        timeout-minutes: 60
+
+      - name: Post quality result
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        continue-on-error: true
+        with:
+          script: |
+            const fs = require('fs');
+            const path = process.env.OPUS_QUALITY_RESULT;
+            if (!path || !fs.existsSync(path)) {
+              console.log('No quality result file found');
+              return;
+            }
+            const body = fs.readFileSync(path, 'utf8');
+            const marker = '<!-- opus-encoder-quality -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+        env:
+          OPUS_QUALITY_RESULT: ${{ runner.temp }}/opus-encoder-quality.md

--- a/encoder_conformance_test.go
+++ b/encoder_conformance_test.go
@@ -518,11 +518,25 @@ func TestEncoderQualityVsReference(t *testing.T) {
 	})
 }
 
+// clampToS16 saturates a float32 sample to the int16 range: CELT ringing can
+// push a decoded sample slightly past ±1, and an unclamped round trips wraps
+// around instead of saturating, injecting large artifacts into opus_compare.
+func clampToS16(s float32) int16 {
+	v := math.Round(float64(s) * 32767)
+	switch {
+	case v > math.MaxInt16:
+		return math.MaxInt16
+	case v < math.MinInt16:
+		return math.MinInt16
+	default:
+		return int16(v)
+	}
+}
+
 func float32ToS16LEBytes(samples []float32) []byte {
 	out := make([]byte, len(samples)*2)
 	for i, s := range samples {
-		v := int16(math.Round(float64(s) * 32767))
-		binary.LittleEndian.PutUint16(out[i*2:], uint16(v)) //nolint:gosec // G115.
+		binary.LittleEndian.PutUint16(out[i*2:], uint16(clampToS16(s))) //nolint:gosec // G115.
 	}
 
 	return out
@@ -535,7 +549,7 @@ func toStereoS16LEBytes(samples []float32, channels int) []byte {
 
 	out := make([]byte, len(samples)*4)
 	for i, s := range samples {
-		v := uint16(int16(math.Round(float64(s) * 32767))) //nolint:gosec // G115.
+		v := uint16(clampToS16(s)) //nolint:gosec // G115.
 		idx := i * 4
 		binary.LittleEndian.PutUint16(out[idx:], v)
 		binary.LittleEndian.PutUint16(out[idx+2:], v)

--- a/encoder_conformance_test.go
+++ b/encoder_conformance_test.go
@@ -394,6 +394,133 @@ func logReferenceEncoderBaseline(
 	)
 }
 
+func TestEncoderQualityVsReference(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("RFC 6716 conformance uses the POSIX-oriented reference Makefile")
+	}
+
+	refDir := os.Getenv(envRFC6716Reference)
+	if refDir == "" {
+		t.Skipf("%s is required for Tier 2 quality tests", envRFC6716Reference)
+	}
+
+	opusDemo, opusCompare := buildRFC6716ReferenceTools(t, refDir)
+	baseline := loadQualityBaseline(t)
+	for _, sig := range qualityTestSignals() {
+		t.Run(sig.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			n := qualityTestFrameSize * qualityTestFrameCount
+			original := sig.generate(n)
+			decoded := roundTripGo(t, original, sig.channels)
+
+			originalStereo := toStereoS16LEBytes(original, sig.channels)
+			decodedStereo := toStereoS16LEBytes(decoded, sig.channels)
+
+			originalStereoPath := filepath.Join(dir, "original-stereo.pcm")
+			decodedPath := filepath.Join(dir, "decoded.pcm")
+			writeQualityBytes(t, originalStereoPath, originalStereo)
+			writeQualityBytes(t, decodedPath, decodedStereo)
+
+			trimmedOriginal := filepath.Join(dir, "original-trimmed.pcm")
+			trimmedDecoded := filepath.Join(dir, "decoded-trimmed.pcm")
+			trimAndAlignPCM(t, originalStereo, decodedPath, trimmedOriginal, trimmedDecoded)
+
+			goOut, err := runOpusCompare(opusCompare, qualityTestRate, 2, trimmedOriginal, trimmedDecoded)
+			goQuality := opusCompareQuality(goOut)
+			goWSNR := opusCompareInternalError(goOut)
+			if err != nil && goWSNR == "" {
+				t.Fatalf("opus_compare Go encoder: %v\n%s", err, goOut)
+			}
+			t.Logf("Go encoder quality=%s weighted_error=%s", goQuality, goWSNR)
+
+			refBitstream := filepath.Join(dir, "reference.bit")
+			refDecoded := filepath.Join(dir, "reference-dec.pcm")
+			originalPath := filepath.Join(dir, "original.pcm")
+			writeQualityBytes(t, originalPath, float32ToS16LEBytes(original))
+			runReferenceOpusDemo(t, opusDemo, "encode with reference",
+				"-e", "audio", strconv.Itoa(qualityTestRate), strconv.Itoa(sig.channels),
+				strconv.Itoa(qualityTestBitrate), "-cbr", originalPath, refBitstream,
+			)
+			runReferenceOpusDemo(t, opusDemo, "decode reference bitstream",
+				"-d", strconv.Itoa(qualityTestRate), "2",
+				refBitstream, refDecoded,
+			)
+
+			trimmedRefOriginal := filepath.Join(dir, "ref-original-trimmed.pcm")
+			trimmedRefDecoded := filepath.Join(dir, "ref-decoded-trimmed.pcm")
+			trimAndAlignPCM(t, originalStereo, refDecoded, trimmedRefOriginal, trimmedRefDecoded)
+
+			refOut, err := runOpusCompare(opusCompare, qualityTestRate, 2, trimmedRefOriginal, trimmedRefDecoded)
+			refQuality := opusCompareQuality(refOut)
+			refWSNR := opusCompareInternalError(refOut)
+			if err != nil && refWSNR == "" {
+				t.Fatalf("opus_compare reference encoder: %v\n%s", err, refOut)
+			}
+			t.Logf("reference encoder quality=%s weighted_error=%s", refQuality, refWSNR)
+
+			if sigData, ok := baseline.Signals[sig.name]; ok && sigData.Tier2WSNRDB != 0 {
+				t.Logf("baseline tier2_wsnr_db=%.1f", sigData.Tier2WSNRDB)
+			}
+		})
+	}
+}
+
+func float32ToS16LEBytes(samples []float32) []byte {
+	out := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		v := int16(math.Round(float64(s) * 32767))
+		binary.LittleEndian.PutUint16(out[i*2:], uint16(v)) //nolint:gosec // G115.
+	}
+
+	return out
+}
+
+func toStereoS16LEBytes(samples []float32, channels int) []byte {
+	if channels == 2 {
+		return float32ToS16LEBytes(samples)
+	}
+
+	out := make([]byte, len(samples)*4)
+	for i, s := range samples {
+		v := uint16(int16(math.Round(float64(s) * 32767))) //nolint:gosec // G115.
+		idx := i * 4
+		binary.LittleEndian.PutUint16(out[idx:], v)
+		binary.LittleEndian.PutUint16(out[idx+2:], v)
+	}
+
+	return out
+}
+
+// trimAndAlignPCM aligns decodedPCM against originalStereo by cross-correlation,
+// trims both to the same length, and writes the results.
+func trimAndAlignPCM(t *testing.T, originalStereo []byte, decodedPCM, outOriginal, outDecoded string) {
+	t.Helper()
+
+	decoded, err := os.ReadFile(decodedPCM)
+	if err != nil {
+		t.Fatalf("read decoded PCM: %v", err)
+	}
+
+	lag := estimateCodecDelay(originalStereo, decoded)
+	trimBytes := lag * 4
+	common := min(len(originalStereo), len(decoded)) - trimBytes
+	if common <= 0 {
+		t.Fatalf("decoded too short to align: lag %d samples", lag)
+	}
+
+	writeQualityBytes(t, outOriginal, originalStereo[:common])
+	writeQualityBytes(t, outDecoded, decoded[trimBytes:trimBytes+common])
+}
+
+func writeQualityBytes(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", filepath.Base(path), err)
+	}
+}
+
 // estimateCodecDelay cross-correlates the original and decoded stereo PCM to
 // find the constant codec delay in samples (CELT alone is 120, libopus 312).
 func estimateCodecDelay(originalStereo, decoded []byte) int {

--- a/encoder_conformance_test.go
+++ b/encoder_conformance_test.go
@@ -6,6 +6,7 @@
 package opus
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -15,6 +16,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -406,7 +408,17 @@ func TestEncoderQualityVsReference(t *testing.T) {
 
 	opusDemo, opusCompare := buildRFC6716ReferenceTools(t, refDir)
 	baseline := loadQualityBaseline(t)
-	for _, sig := range qualityTestSignals() {
+	signals := qualityTestSignals()
+
+	type refResult struct {
+		pionWSNR string
+		refWSNR  string
+	}
+
+	refResults := make([]refResult, len(signals))
+	var mu sync.Mutex
+
+	for i, sig := range signals {
 		t.Run(sig.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -463,8 +475,47 @@ func TestEncoderQualityVsReference(t *testing.T) {
 			if sigData, ok := baseline.Signals[sig.name]; ok && sigData.Tier2WSNRDB != 0 {
 				t.Logf("baseline tier2_wsnr_db=%.1f", sigData.Tier2WSNRDB)
 			}
+
+			mu.Lock()
+			refResults[i] = refResult{pionWSNR: goWSNR, refWSNR: refWSNR}
+			mu.Unlock()
 		})
 	}
+
+	t.Cleanup(func() {
+		mdPath := os.Getenv("OPUS_QUALITY_MARKDOWN")
+		if mdPath == "" {
+			return
+		}
+
+		existing, _ := os.ReadFile(mdPath) //nolint:gosec // G304: path from test env var, internal tool.
+
+		var buf bytes.Buffer
+		buf.Write(existing)
+		fmt.Fprintln(&buf)
+		fmt.Fprintln(&buf, "### Tier 2 — opus_compare vs libopus (96 kbps CBR)")
+		fmt.Fprintln(&buf)
+		fmt.Fprintln(&buf, "Weighted error: lower is better. The gap reflects pion lacking constrained VBR; libopus ships with it enabled by default.")
+		fmt.Fprintln(&buf)
+		fmt.Fprintln(&buf, "| Signal | pion weighted error ↓ | libopus weighted error ↓ |")
+		fmt.Fprintln(&buf, "|---|---:|---:|")
+		for i, sig := range signals {
+			res := refResults[i]
+			pionErr := res.pionWSNR
+			if pionErr == "" {
+				pionErr = "—"
+			}
+			refErr := res.refWSNR
+			if refErr == "" {
+				refErr = "—"
+			}
+			fmt.Fprintf(&buf, "| %s | %s | %s |\n", sig.name, pionErr, refErr)
+		}
+
+		if err := os.WriteFile(mdPath, buf.Bytes(), 0o600); err != nil { //nolint:gosec // G306: 0o600 is intentional.
+			t.Logf("write quality markdown tier 2: %v", err)
+		}
+	})
 }
 
 func float32ToS16LEBytes(samples []float32) []byte {

--- a/encoder_conformance_test.go
+++ b/encoder_conformance_test.go
@@ -433,7 +433,7 @@ func TestEncoderQualityVsReference(t *testing.T) {
 			if err != nil && goWSNR == "" {
 				t.Fatalf("opus_compare Go encoder: %v\n%s", err, goOut)
 			}
-			t.Logf("Go encoder quality=%s weighted_error=%s", goQuality, goWSNR)
+			t.Logf("pion quality=%s weighted_error=%s", goQuality, goWSNR)
 
 			refBitstream := filepath.Join(dir, "reference.bit")
 			refDecoded := filepath.Join(dir, "reference-dec.pcm")
@@ -458,7 +458,7 @@ func TestEncoderQualityVsReference(t *testing.T) {
 			if err != nil && refWSNR == "" {
 				t.Fatalf("opus_compare reference encoder: %v\n%s", err, refOut)
 			}
-			t.Logf("reference encoder quality=%s weighted_error=%s", refQuality, refWSNR)
+			t.Logf("libopus quality=%s weighted_error=%s", refQuality, refWSNR)
 
 			if sigData, ok := baseline.Signals[sig.name]; ok && sigData.Tier2WSNRDB != 0 {
 				t.Logf("baseline tier2_wsnr_db=%.1f", sigData.Tier2WSNRDB)

--- a/encoder_quality_test.go
+++ b/encoder_quality_test.go
@@ -4,10 +4,13 @@
 package opus
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -131,7 +134,19 @@ func generateOnset(n int) []float32 {
 
 func TestEncoderQuality(t *testing.T) {
 	baseline := loadQualityBaseline(t)
-	for _, sig := range qualityTestSignals() {
+	signals := qualityTestSignals()
+
+	type signalResult struct {
+		snr     float64
+		base    float64
+		delta   float64
+		hasBase bool
+	}
+
+	results := make([]signalResult, len(signals))
+	var mu sync.Mutex
+
+	for i, sig := range signals {
 		t.Run(sig.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -142,18 +157,54 @@ func TestEncoderQuality(t *testing.T) {
 			snr := computeSNR(original, decoded)
 			t.Logf("signal=%s SNR=%.1f dB", sig.name, snr)
 
+			res := signalResult{snr: snr}
 			if sigData, ok := baseline.Signals[sig.name]; ok {
-				delta := sigData.Tier1SNRDB - snr
+				res.base = sigData.Tier1SNRDB
+				res.delta = sigData.Tier1SNRDB - snr
+				res.hasBase = true
 				t.Logf("baseline=%.1f dB delta=%.1f dB threshold=%.1f dB",
-					sigData.Tier1SNRDB, delta, regressionThresholdDB)
-				assert.LessOrEqualf(t, delta, float64(regressionThresholdDB),
+					sigData.Tier1SNRDB, res.delta, regressionThresholdDB)
+				assert.LessOrEqualf(t, res.delta, float64(regressionThresholdDB),
 					"quality regression: signal=%s SNR=%.1f dB baseline=%.1f dB",
 					sig.name, snr, sigData.Tier1SNRDB)
 			} else {
 				t.Logf("no baseline for signal %s, pass (first run)", sig.name)
 			}
+
+			mu.Lock()
+			results[i] = res
+			mu.Unlock()
 		})
 	}
+
+	t.Cleanup(func() {
+		mdPath := os.Getenv("OPUS_QUALITY_MARKDOWN")
+		if mdPath == "" {
+			return
+		}
+
+		var buf bytes.Buffer
+		fmt.Fprintln(&buf, "### Tier 1 — SNR regression (96 kbps, pion encode → pion decode)")
+		fmt.Fprintln(&buf)
+		fmt.Fprintf(&buf, "Delta = baseline − current SNR; positive = regression. Fail threshold: %.1f dB.\n",
+			regressionThresholdDB)
+		fmt.Fprintln(&buf)
+		fmt.Fprintln(&buf, "| Signal | SNR (dB) | Baseline (dB) | Delta | Status |")
+		fmt.Fprintln(&buf, "|---|---:|---:|---:|---|")
+		for i, sig := range signals {
+			res := results[i]
+			status := "OK"
+			if res.hasBase && res.delta > float64(regressionThresholdDB) {
+				status = "FAIL"
+			}
+			fmt.Fprintf(&buf, "| %s | %.1f | %.1f | %+.1f | %s |\n",
+				sig.name, res.snr, res.base, res.delta, status)
+		}
+
+		if err := os.WriteFile(mdPath, buf.Bytes(), 0o600); err != nil { //nolint:gosec // G306: 0o600 is intentional.
+			t.Logf("write quality markdown: %v", err)
+		}
+	})
 }
 
 func roundTripGo(t *testing.T, pcm []float32, channels int) []float32 {

--- a/encoder_quality_test.go
+++ b/encoder_quality_test.go
@@ -18,13 +18,14 @@ import (
 )
 
 const (
-	qualityTestRate       = 48000
-	qualityTestFrameSize  = 960
-	qualityTestFrameCount = 100
-	qualityTestBitrate    = 96000
-	qualityTestChannels   = 1
-	regressionThresholdDB = 1.5
-	qualityTestMaxLag     = 2048
+	qualityTestRate        = 48000
+	qualityTestFrameSize   = 960
+	qualityTestFrameCount  = 100
+	qualityTestBitrate     = 96000
+	qualityTestChannels    = 1
+	regressionThresholdDB  = 1.5
+	qualityTestMaxLag      = 2048
+	qualityBaselineVersion = 1
 
 	// harmonicsPeakAmplitude is the sum of the amplitudes of the 5-harmonic
 	// series (1 + 1/2 + 1/3 + 1/4 + 1/5), used to normalize generateHarmonics
@@ -164,7 +165,7 @@ func TestEncoderQuality(t *testing.T) {
 				res.hasBase = true
 				t.Logf("baseline=%.1f dB delta=%.1f dB threshold=%.1f dB",
 					sigData.Tier1SNRDB, res.delta, regressionThresholdDB)
-				assert.LessOrEqualf(t, res.delta, float64(regressionThresholdDB),
+				assert.LessOrEqualf(t, res.delta, regressionThresholdDB,
 					"quality regression: signal=%s SNR=%.1f dB baseline=%.1f dB",
 					sig.name, snr, sigData.Tier1SNRDB)
 			} else {
@@ -184,20 +185,20 @@ func TestEncoderQuality(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		fmt.Fprintln(&buf, "### Tier 1 — SNR regression (96 kbps, pion encode → pion decode)")
-		fmt.Fprintln(&buf)
-		fmt.Fprintf(&buf, "Delta = baseline − current SNR; positive = regression. Fail threshold: %.1f dB.\n",
+		_, _ = fmt.Fprintln(&buf, "### Tier 1 — SNR regression (96 kbps, pion encode → pion decode)")
+		_, _ = fmt.Fprintln(&buf)
+		_, _ = fmt.Fprintf(&buf, "Delta = baseline − current SNR; positive = regression. Fail threshold: %.1f dB.\n",
 			regressionThresholdDB)
-		fmt.Fprintln(&buf)
-		fmt.Fprintln(&buf, "| Signal | SNR (dB) | Baseline (dB) | Delta | Status |")
-		fmt.Fprintln(&buf, "|---|---:|---:|---:|---|")
+		_, _ = fmt.Fprintln(&buf)
+		_, _ = fmt.Fprintln(&buf, "| Signal | SNR (dB) | Baseline (dB) | Delta | Status |")
+		_, _ = fmt.Fprintln(&buf, "|---|---:|---:|---:|---|")
 		for i, sig := range signals {
 			res := results[i]
 			status := "OK"
-			if res.hasBase && res.delta > float64(regressionThresholdDB) {
+			if res.hasBase && res.delta > regressionThresholdDB {
 				status = "FAIL"
 			}
-			fmt.Fprintf(&buf, "| %s | %.1f | %.1f | %+.1f | %s |\n",
+			_, _ = fmt.Fprintf(&buf, "| %s | %.1f | %.1f | %+.1f | %s |\n",
 				sig.name, res.snr, res.base, res.delta, status)
 		}
 
@@ -294,7 +295,7 @@ func loadQualityBaseline(t *testing.T) qualityBaseline {
 		t.Logf("no golden file at %s, baseline will be empty (first run)", path)
 
 		return qualityBaseline{
-			Version: 1,
+			Version: qualityBaselineVersion,
 			Bitrate: qualityTestBitrate,
 			Signals: make(map[string]qualityBaselineSignal),
 		}
@@ -302,6 +303,11 @@ func loadQualityBaseline(t *testing.T) qualityBaseline {
 
 	var baseline qualityBaseline
 	require.NoError(t, json.Unmarshal(data, &baseline), "parse golden file")
+
+	require.Equalf(t, qualityBaselineVersion, baseline.Version,
+		"baseline schema version mismatch: got %d, want %d", baseline.Version, qualityBaselineVersion)
+	require.Equalf(t, qualityTestBitrate, baseline.Bitrate,
+		"baseline was generated at a different bitrate: got %d, want %d", baseline.Bitrate, qualityTestBitrate)
 
 	if baseline.Signals == nil {
 		baseline.Signals = make(map[string]qualityBaselineSignal)

--- a/encoder_quality_test.go
+++ b/encoder_quality_test.go
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package opus
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	qualityTestRate       = 48000
+	qualityTestFrameSize  = 960
+	qualityTestFrameCount = 100
+	qualityTestBitrate    = 96000
+	qualityTestChannels   = 1
+	regressionThresholdDB = 1.5
+	qualityTestMaxLag     = 2048
+
+	// harmonicsPeakAmplitude is the sum of the amplitudes of the 5-harmonic
+	// series (1 + 1/2 + 1/3 + 1/4 + 1/5), used to normalize generateHarmonics
+	// so its peak stays near 0.5.
+	harmonicsPeakAmplitude = 1.0 + 1.0/2.0 + 1.0/3.0 + 1.0/4.0 + 1.0/5.0
+)
+
+type qualityBaselineSignal struct {
+	Tier1SNRDB  float64 `json:"tier1SnrDb"`
+	Tier2WSNRDB float64 `json:"tier2WsnrDb,omitempty"`
+}
+
+type qualityBaseline struct {
+	Version int                              `json:"version"`
+	Bitrate int                              `json:"bitrate"`
+	Signals map[string]qualityBaselineSignal `json:"signals"`
+}
+
+type qualitySignal struct {
+	name     string
+	channels int
+	generate func(n int) []float32
+}
+
+func qualityTestSignals() []qualitySignal {
+	return []qualitySignal{
+		{name: "chirp", channels: qualityTestChannels, generate: generateChirp},
+		{name: "harmonics", channels: qualityTestChannels, generate: generateHarmonics},
+		{name: "burst", channels: qualityTestChannels, generate: generateBurst},
+		{name: "shaped_noise", channels: qualityTestChannels, generate: generateShapedNoise},
+		{name: "onset", channels: qualityTestChannels, generate: generateOnset},
+	}
+}
+
+func generateChirp(n int) []float32 {
+	samples := make([]float32, n)
+	freqStart := 200.0
+	freqEnd := 4000.0
+	for i := range n {
+		t := float64(i) / qualityTestRate
+		totalT := float64(n) / qualityTestRate
+		freq := freqStart + (freqEnd-freqStart)*t/totalT
+		samples[i] = float32(0.8 * math.Sin(2*math.Pi*freq*t))
+	}
+
+	return samples
+}
+
+func generateHarmonics(n int) []float32 {
+	samples := make([]float32, n)
+	for i := range n {
+		t := float64(i) / qualityTestRate
+		var s float64
+		for h := 1; h <= 5; h++ {
+			s += math.Sin(2*math.Pi*200*float64(h)*t) / float64(h)
+		}
+		samples[i] = float32(0.5 * s / harmonicsPeakAmplitude)
+	}
+
+	return samples
+}
+
+func generateBurst(n int) []float32 {
+	samples := make([]float32, n)
+	half := n / 2
+	for i := range n {
+		t := float64(i) / qualityTestRate
+		if i >= half {
+			samples[i] = float32(0.9 * math.Sin(2*math.Pi*440*t))
+		}
+	}
+
+	return samples
+}
+
+func generateShapedNoise(n int) []float32 {
+	samples := make([]float32, n)
+	for i := range n {
+		seed := uint64(i)*6364136223846793005 + 1442695040888963407
+		noise := float64(int64(seed>>33)) / float64(1<<30)
+		if i > 0 {
+			noise = (noise + float64(samples[i-1])) / 2.0
+		}
+		samples[i] = float32(0.6 * noise)
+	}
+
+	return samples
+}
+
+func generateOnset(n int) []float32 {
+	samples := make([]float32, n)
+	half := n / 2
+	fadeLen := qualityTestRate / 50
+	for i := range n {
+		t := float64(i) / qualityTestRate
+		if i >= half {
+			env := 1.0
+			if rel := i - half; rel < fadeLen {
+				env = float64(rel) / float64(fadeLen)
+			}
+			samples[i] = float32(0.8 * env * math.Sin(2*math.Pi*440*t))
+		}
+	}
+
+	return samples
+}
+
+func TestEncoderQuality(t *testing.T) {
+	baseline := loadQualityBaseline(t)
+	for _, sig := range qualityTestSignals() {
+		t.Run(sig.name, func(t *testing.T) {
+			t.Parallel()
+
+			n := qualityTestFrameSize * qualityTestFrameCount
+			original := sig.generate(n)
+			decoded := roundTripGo(t, original, sig.channels)
+
+			snr := computeSNR(original, decoded)
+			t.Logf("signal=%s SNR=%.1f dB", sig.name, snr)
+
+			if sigData, ok := baseline.Signals[sig.name]; ok {
+				delta := sigData.Tier1SNRDB - snr
+				t.Logf("baseline=%.1f dB delta=%.1f dB threshold=%.1f dB",
+					sigData.Tier1SNRDB, delta, regressionThresholdDB)
+				assert.LessOrEqualf(t, delta, float64(regressionThresholdDB),
+					"quality regression: signal=%s SNR=%.1f dB baseline=%.1f dB",
+					sig.name, snr, sigData.Tier1SNRDB)
+			} else {
+				t.Logf("no baseline for signal %s, pass (first run)", sig.name)
+			}
+		})
+	}
+}
+
+func roundTripGo(t *testing.T, pcm []float32, channels int) []float32 {
+	t.Helper()
+
+	encoder, err := NewEncoder(WithChannels(channels), WithBitrate(qualityTestBitrate))
+	require.NoError(t, err, "create encoder")
+
+	decoder, err := NewDecoderWithOutput(qualityTestRate, channels)
+	require.NoError(t, err, "create decoder")
+
+	frameSamples := qualityTestFrameSize * channels
+	packet := make([]byte, maxOpusFrameSize+1)
+	var decoded []float32
+	for offset := 0; offset+frameSamples <= len(pcm); offset += frameSamples {
+		frame := make([]float32, frameSamples)
+		copy(frame, pcm[offset:offset+frameSamples])
+
+		n, err := encoder.EncodeFloat32(frame, packet)
+		require.NoErrorf(t, err, "encode frame at sample %d", offset)
+
+		out := make([]float32, frameSamples)
+		_, _, err = decoder.DecodeFloat32(packet[:n], out)
+		require.NoErrorf(t, err, "decode frame at sample %d", offset)
+
+		decoded = append(decoded, out...)
+	}
+
+	return decoded
+}
+
+func computeSNR(original, decoded []float32) float64 {
+	lag := estimateCodecDelayFloat32(original, decoded)
+	if lag > 0 && lag < len(decoded) {
+		decoded = decoded[lag:]
+	}
+
+	n := min(len(original), len(decoded))
+	if n == 0 {
+		return 0
+	}
+
+	var signalPower, noisePower float64
+	for i := range n {
+		signalPower += float64(original[i]) * float64(original[i])
+		diff := float64(original[i]) - float64(decoded[i])
+		noisePower += diff * diff
+	}
+
+	if noisePower == 0 {
+		return 100.0
+	}
+
+	return 10 * math.Log10(signalPower/noisePower)
+}
+
+func estimateCodecDelayFloat32(original, decoded []float32) int {
+	samples := min(len(original), len(decoded))
+	window := min(samples-qualityTestMaxLag, 4*qualityTestRate/10)
+	if window <= 0 {
+		return 0
+	}
+
+	bestLag := 0
+	bestCorrelation := math.Inf(-1)
+	for lag := range qualityTestMaxLag {
+		var correlation float64
+		for i := range window {
+			correlation += float64(original[i]) * float64(decoded[i+lag])
+		}
+
+		if correlation > bestCorrelation {
+			bestCorrelation = correlation
+			bestLag = lag
+		}
+	}
+
+	return bestLag
+}
+
+func loadQualityBaseline(t *testing.T) qualityBaseline {
+	t.Helper()
+
+	path := filepath.Join("testdata", "encoder-quality-baseline.json")
+	data, err := os.ReadFile(path) //nolint:gosec // G304: fixed testdata path.
+	if err != nil {
+		t.Logf("no golden file at %s, baseline will be empty (first run)", path)
+
+		return qualityBaseline{
+			Version: 1,
+			Bitrate: qualityTestBitrate,
+			Signals: make(map[string]qualityBaselineSignal),
+		}
+	}
+
+	var baseline qualityBaseline
+	require.NoError(t, json.Unmarshal(data, &baseline), "parse golden file")
+
+	if baseline.Signals == nil {
+		baseline.Signals = make(map[string]qualityBaselineSignal)
+	}
+
+	t.Logf("loaded baseline: version=%d bitrate=%d signals=%d", baseline.Version, baseline.Bitrate, len(baseline.Signals))
+
+	return baseline
+}

--- a/testdata/encoder-quality-baseline.json
+++ b/testdata/encoder-quality-baseline.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "bitrate": 96000,
+  "signals": {
+    "burst": {
+      "tier1SnrDb": -2.5
+    },
+    "chirp": {
+      "tier1SnrDb": 3.5
+    },
+    "harmonics": {
+      "tier1SnrDb": -0.6
+    },
+    "onset": {
+      "tier1SnrDb": -2.4
+    },
+    "shaped_noise": {
+      "tier1SnrDb": 0.6
+    }
+  }
+}

--- a/testdata/encoder-quality-baseline.json.license
+++ b/testdata/encoder-quality-baseline.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+SPDX-License-Identifier: MIT


### PR DESCRIPTION
#### Description

Adds `TestEncoderQuality` (Tier 1) and `TestEncoderQualityVsReference` (Tier 2) to measure encoder quality and catch regressions.

**Tier 1** runs on every `go test ./...` call — no external tools needed. Generates five synthetic signals (chirp, harmonic stack, burst, shaped noise, onset) and measures SNR after a pion encode+decode round-trip. Compares against a golden file (`testdata/encoder-quality-baseline.json`); fails if any signal drops more than 1.5 dB below baseline. This is the actual regression detector.

**Tier 2** runs under `-tags conformance` when `OPUS_RFC6716_REFERENCE` is set. Encodes each signal with pion, decodes with `opus_demo`, and measures quality with `opus_compare`. Runs the same pipeline with the reference encoder to get a libopus baseline for comparison. Currently informational — logs the delta but doesn't fail.

The CI workflow (`.github/workflows/encoder-quality.yml`) mirrors `conformance.yml`: runs both tiers, posts results as a PR comment.

The reference tool setup that was inline in `run-rfc6716-conformance.sh` is now extracted into `lib-opus-reference.sh` so both scripts share the same download/verify/patch logic without duplication.

#### Reference issue
Prerequisite before constrained VBR — establishes the quality baseline that future encoder PRs will be compared against.