### PR TITLE
Add application, VBR, and loss rate controls

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -10,6 +10,36 @@ import (
 	"github.com/pion/opus/internal/celt"
 )
 
+// Application selects the encoder's tuning profile, mirroring libopus's
+// OPUS_APPLICATION_* control values (opus_defines.h) and their numeric IDs.
+// RFC 6716 does not define per-application behavior as part of the
+// bitstream; it only describes the underlying control parameters — bitrate
+// mode, frame duration, DTX — that each profile is meant to bias (see
+// RFC 6716 Section 2.1, "Control Parameters"). Selecting an Application here
+// only records the chosen profile, retrievable via Application(); it does
+// not change VBR, frame duration, or DTX on its own — pass WithVBR,
+// WithConstrainedVBR, etc. explicitly.
+type Application int
+
+const (
+	// ApplicationAudio tunes the encoder for music and general audio. This
+	// is the default application.
+	ApplicationAudio Application = 2049
+
+	// ApplicationVoIP tunes the encoder for voice over a lossy,
+	// latency-sensitive network. In libopus this profile defaults to VBR
+	// (RFC 6716 Section 2.1.8) and DTX (RFC 6716 Section 2.1.9); this
+	// encoder does not wire those defaults automatically.
+	ApplicationVoIP Application = 2048
+
+	// ApplicationRestrictedLowDelay tunes the encoder for the lowest
+	// possible algorithmic delay by skipping mode-switching analysis
+	// between the SILK and CELT layers. Frame duration and look-ahead
+	// trade-offs are described in RFC 6716 Section 2.1.4; this encoder
+	// does not vary either by application.
+	ApplicationRestrictedLowDelay Application = 2051
+)
+
 const (
 	defaultBitrate = 24000
 	minBitrate     = 6000
@@ -24,11 +54,15 @@ const celtOnlyFullband20msConfig = 31
 
 // Encoder encodes PCM into Opus packets.
 type Encoder struct {
-	celtEncoder celt.Encoder
-	sampleRate  int
-	channels    int
-	bitrate     int
-	complexity  int
+	celtEncoder    celt.Encoder
+	sampleRate     int
+	channels       int
+	bitrate        int
+	complexity     int
+	application    Application
+	vbr            bool
+	constrainedVBR bool
+	lossRate       int
 }
 
 // EncoderOption configures an Encoder during construction.
@@ -91,6 +125,44 @@ func WithComplexity(complexity int) EncoderOption {
 	}
 }
 
+// WithApplication sets the encoder application mode.
+func WithApplication(app Application) EncoderOption {
+	return func(e *Encoder) error {
+		switch app {
+		case ApplicationAudio, ApplicationVoIP, ApplicationRestrictedLowDelay:
+		default:
+			return fmt.Errorf("%w: %d", errInvalidApplication, app)
+		}
+		e.application = app
+
+		return nil
+	}
+}
+
+// WithVBR enables or disables variable bitrate encoding. VBR is the more
+// efficient mode and is the Opus default; CBR is reserved for transports
+// that require a fixed frame size or for highly sensitive streams (RFC 6716
+// Section 2.1.8).
+func WithVBR(vbr bool) EncoderOption {
+	return func(e *Encoder) error {
+		e.vbr = vbr
+
+		return nil
+	}
+}
+
+// WithConstrainedVBR enables or disables constrained VBR. When enabled, the
+// encoder simulates a "bit reservoir" to bound short-term bitrate variation
+// instead of producing plain VBR — recommended for low-latency links over a
+// constrained connection (RFC 6716 Section 2.1.8).
+func WithConstrainedVBR(cvbr bool) EncoderOption {
+	return func(e *Encoder) error {
+		e.constrainedVBR = cvbr
+
+		return nil
+	}
+}
+
 // NewEncoder creates a new Opus encoder with the supplied options.
 //
 // Defaults: 48 kHz, mono, 24 kbit/s, complexity 0. Pass options to override
@@ -99,11 +171,15 @@ func WithComplexity(complexity int) EncoderOption {
 // in follow-up PRs.
 func NewEncoder(opts ...EncoderOption) (*Encoder, error) {
 	encoder := &Encoder{
-		celtEncoder: celt.NewEncoder(),
-		sampleRate:  celtSampleRate,
-		channels:    1,
-		bitrate:     defaultBitrate,
-		complexity:  0,
+		celtEncoder:    celt.NewEncoder(),
+		sampleRate:     celtSampleRate,
+		channels:       1,
+		bitrate:        defaultBitrate,
+		complexity:     0,
+		application:    ApplicationAudio,
+		vbr:            false,
+		constrainedVBR: true,
+		lossRate:       0,
 	}
 
 	for _, opt := range opts {
@@ -111,6 +187,10 @@ func NewEncoder(opts ...EncoderOption) (*Encoder, error) {
 			return nil, err
 		}
 	}
+
+	encoder.celtEncoder.SetVBR(encoder.vbr)
+	encoder.celtEncoder.SetConstrainedVBR(encoder.constrainedVBR)
+	encoder.celtEncoder.SetLossRate(encoder.lossRate)
 
 	return encoder, nil
 }
@@ -125,6 +205,50 @@ func (e *Encoder) SetBitrate(bps int) error {
 func (e *Encoder) SetComplexity(complexity int) error {
 	return WithComplexity(complexity)(e)
 }
+
+// SetApplication updates the encoder application mode.
+func (e *Encoder) SetApplication(app Application) error {
+	return WithApplication(app)(e)
+}
+
+// SetVBR enables or disables variable bitrate encoding (RFC 6716
+// Section 2.1.8).
+func (e *Encoder) SetVBR(vbr bool) {
+	e.vbr = vbr
+	e.celtEncoder.SetVBR(vbr)
+}
+
+// SetConstrainedVBR enables or disables constrained VBR (RFC 6716
+// Section 2.1.8).
+func (e *Encoder) SetConstrainedVBR(cvbr bool) {
+	e.constrainedVBR = cvbr
+	e.celtEncoder.SetConstrainedVBR(cvbr)
+}
+
+// SetLossRate sets the expected packet loss rate (0-100 percent), the
+// control parameter behind the packet loss resilience trade-off described
+// in RFC 6716 Section 2.1.6.
+func (e *Encoder) SetLossRate(rate int) error {
+	if rate < 0 || rate > 100 {
+		return fmt.Errorf("%w: %d", errInvalidLossRate, rate)
+	}
+	e.lossRate = rate
+	e.celtEncoder.SetLossRate(rate)
+
+	return nil
+}
+
+// Application returns the current encoder application mode.
+func (e *Encoder) Application() Application { return e.application }
+
+// VBR returns whether variable bitrate encoding is enabled.
+func (e *Encoder) VBR() bool { return e.vbr }
+
+// ConstrainedVBR returns whether constrained VBR is enabled.
+func (e *Encoder) ConstrainedVBR() bool { return e.constrainedVBR }
+
+// LossRate returns the expected packet loss rate (0-100 percent).
+func (e *Encoder) LossRate() int { return e.lossRate }
 
 // Encode encodes S16LE PCM into a single Opus packet.
 //

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -244,6 +244,170 @@ func TestSetComplexity(t *testing.T) {
 	assert.ErrorIs(t, encoder.SetComplexity(11), errInvalidComplexity)
 }
 
+func TestNewEncoderDefaultApplication(t *testing.T) {
+	encoder, err := NewEncoder()
+	require.NoError(t, err)
+
+	assert.Equal(t, ApplicationAudio, encoder.Application())
+	assert.False(t, encoder.VBR())
+	assert.True(t, encoder.ConstrainedVBR())
+	assert.Equal(t, 0, encoder.LossRate())
+}
+
+func TestWithApplication(t *testing.T) {
+	encoder, err := NewEncoder(WithApplication(ApplicationVoIP))
+	require.NoError(t, err)
+	assert.Equal(t, ApplicationVoIP, encoder.Application())
+
+	encoder, err = NewEncoder(WithApplication(ApplicationRestrictedLowDelay))
+	require.NoError(t, err)
+	assert.Equal(t, ApplicationRestrictedLowDelay, encoder.Application())
+
+	_, err = NewEncoder(WithApplication(Application(9999)))
+	assert.ErrorIs(t, err, errInvalidApplication)
+}
+
+func TestSetApplication(t *testing.T) {
+	encoder, err := NewEncoder()
+	require.NoError(t, err)
+
+	require.NoError(t, encoder.SetApplication(ApplicationVoIP))
+	assert.Equal(t, ApplicationVoIP, encoder.Application())
+
+	assert.ErrorIs(t, encoder.SetApplication(Application(0)), errInvalidApplication)
+}
+
+func TestWithVBR(t *testing.T) {
+	encoder, err := NewEncoder(WithVBR(true))
+	require.NoError(t, err)
+	assert.True(t, encoder.VBR())
+
+	encoder, err = NewEncoder(WithVBR(false))
+	require.NoError(t, err)
+	assert.False(t, encoder.VBR())
+}
+
+func TestSetVBR(t *testing.T) {
+	encoder, err := NewEncoder()
+	require.NoError(t, err)
+	require.False(t, encoder.VBR())
+
+	encoder.SetVBR(true)
+	assert.True(t, encoder.VBR())
+
+	encoder.SetVBR(false)
+	assert.False(t, encoder.VBR())
+}
+
+func TestWithConstrainedVBR(t *testing.T) {
+	encoder, err := NewEncoder(WithConstrainedVBR(false))
+	require.NoError(t, err)
+	assert.False(t, encoder.ConstrainedVBR())
+}
+
+func TestSetConstrainedVBR(t *testing.T) {
+	encoder, err := NewEncoder()
+	require.NoError(t, err)
+	require.True(t, encoder.ConstrainedVBR())
+
+	encoder.SetConstrainedVBR(false)
+	assert.False(t, encoder.ConstrainedVBR())
+
+	encoder.SetConstrainedVBR(true)
+	assert.True(t, encoder.ConstrainedVBR())
+}
+
+func TestSetLossRate(t *testing.T) {
+	encoder, err := NewEncoder()
+	require.NoError(t, err)
+
+	require.NoError(t, encoder.SetLossRate(50))
+	assert.Equal(t, 50, encoder.LossRate())
+
+	assert.ErrorIs(t, encoder.SetLossRate(-1), errInvalidLossRate)
+	assert.ErrorIs(t, encoder.SetLossRate(101), errInvalidLossRate)
+}
+
+func TestVBRPacketRoundTrip(t *testing.T) {
+	encoder, err := NewEncoder(WithVBR(true), WithConstrainedVBR(false))
+	require.NoError(t, err)
+
+	pcm := testEncoderSineFloat32()
+	packet := make([]byte, 256)
+	n, err := encoder.EncodeFloat32(pcm, packet)
+	require.NoError(t, err)
+	require.Greater(t, n, 1)
+
+	// TOC byte is unchanged by VBR for single-frame (c=0) packets.
+	// The VBR bit lives in the frame count byte, which is absent for c=0.
+	assert.Equal(t, byte(celtOnlyFullband20msConfig<<3)|byte(frameCodeOneFrame), packet[0])
+
+	decoder, err := NewDecoderWithOutput(48000, 1)
+	require.NoError(t, err)
+
+	out := make([]float32, encoderTestFrameSampleCount)
+	_, _, err = decoder.DecodeFloat32(packet[:n], out)
+	require.NoError(t, err)
+	assert.Greater(t, vectorEnergyFloat32(out), 1e-6)
+}
+
+func TestConstrainedVBRPacketRoundTrip(t *testing.T) {
+	encoder, err := NewEncoder(WithVBR(true), WithConstrainedVBR(true))
+	require.NoError(t, err)
+
+	pcm := testEncoderSineFloat32()
+	packet := make([]byte, 256)
+	n, err := encoder.EncodeFloat32(pcm, packet)
+	require.NoError(t, err)
+	require.Greater(t, n, 1)
+
+	decoder, err := NewDecoderWithOutput(48000, 1)
+	require.NoError(t, err)
+
+	out := make([]float32, encoderTestFrameSampleCount)
+	_, _, err = decoder.DecodeFloat32(packet[:n], out)
+	require.NoError(t, err)
+	assert.Greater(t, vectorEnergyFloat32(out), 1e-6)
+}
+
+func TestApplicationRoundTrip(t *testing.T) {
+	encoder, err := NewEncoder(
+		WithApplication(ApplicationVoIP),
+		WithVBR(true),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, ApplicationVoIP, encoder.Application())
+	assert.True(t, encoder.VBR())
+
+	decoder, err := NewDecoderWithOutput(48000, 1)
+	require.NoError(t, err)
+
+	pcm := testEncoderSineFloat32()
+	packet := make([]byte, 256)
+	n, err := encoder.EncodeFloat32(pcm, packet)
+	require.NoError(t, err)
+
+	out := make([]float32, encoderTestFrameSampleCount)
+	_, _, err = decoder.DecodeFloat32(packet[:n], out)
+	require.NoError(t, err)
+	assert.Greater(t, vectorEnergyFloat32(out), 1e-6)
+}
+
+func TestLossRateGetterSetter(t *testing.T) {
+	encoder, err := NewEncoder()
+	require.NoError(t, err)
+
+	require.NoError(t, encoder.SetLossRate(0))
+	assert.Equal(t, 0, encoder.LossRate())
+
+	require.NoError(t, encoder.SetLossRate(100))
+	assert.Equal(t, 100, encoder.LossRate())
+
+	require.NoError(t, encoder.SetLossRate(25))
+	assert.Equal(t, 25, encoder.LossRate())
+}
+
 func testEncoderSineFloat32() []float32 {
 	pcm := make([]float32, encoderTestFrameSampleCount)
 	for i := range pcm {

--- a/errors.go
+++ b/errors.go
@@ -31,4 +31,8 @@ var (
 	errInvalidFrameByteBudget = errors.New("invalid frame byte budget")
 
 	errInvalidPLCFrameSize = errors.New("PLC output must contain exactly 20 ms of interleaved samples")
+
+	errInvalidApplication = errors.New("invalid application")
+
+	errInvalidLossRate = errors.New("loss rate must be 0-100")
 )

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -48,6 +48,14 @@ type Encoder struct {
 	prevSpreadDecision int
 	prevIntensityBand  int
 	prevLogBandAmp     [2][maxBands]float32
+
+	// Application mode plumbing — set by root encoder via setter methods.
+	// Values flow from opus.WithApplication / opus.WithVBR / etc. CELT
+	// records them but does not yet change its encoding behavior based on
+	// them.
+	vbr            bool
+	constrainedVBR bool
+	lossRate       int
 }
 
 func NewEncoder() Encoder {
@@ -95,6 +103,19 @@ func (e *Encoder) Reset() {
 	e.prevSpreadDecision = defaultSpreadDecision
 	e.prevIntensityBand = 0
 	e.analysis.prefilter = postFilterState{}
+}
+
+func (e *Encoder) SetVBR(vbr bool) {
+	e.vbr = vbr
+}
+
+func (e *Encoder) SetConstrainedVBR(cvbr bool) {
+	e.constrainedVBR = cvbr
+}
+
+// SetLossRate sets the expected packet loss rate (0-100 percent).
+func (e *Encoder) SetLossRate(rate int) {
+	e.lossRate = rate
 }
 
 func (e *Encoder) Mode() *Mode {


### PR DESCRIPTION
#### Description
Adds the application mode and rate-control knobs from the public libopus API: `Application` (`ApplicationAudio`/`ApplicationVoIP`/`ApplicationRestrictedLowDelay`, matching libopus's numeric IDs from opus_defines.h), `WithVBR()`/`SetVBR()`, `WithConstrainedVBR()`/`SetConstrainedVBR()`, and `SetLossRate()`, plus getters for all four.

Defaults match what callers get today (`ApplicationAudio`, VBR off, constrained VBR on, loss rate 0), so this doesn't change behavior for anyone already using the encoder.

`vbr`, `constrainedVBR`, and `lossRate` are plumbed down to `celt.Encoder` through new setter methods, but CELT just stores them for now — it doesn't branch on them yet. `Application` isn't plumbed to CELT at all since nothing in the CELT-only path reads it. RFC 6716 doesn't define per-application behavior in the bitstream itself, it only describes the underlying knobs each profile is meant to bias (VBR/CBR in §2.1.8, DTX in §2.1.9, frame duration in §2.1.4), so I tried to keep the doc comments honest about that: picking `ApplicationVoIP` today only records the choice, it doesn't turn on VBR or DTX by itself. Wiring actual per-application defaults and constrained VBR (bit reservoir, frame difficulty analysis) is a bigger piece I'm leaving for a follow-up PR.

#### Reference issue
Fixes #...
