### PR TITLE
Add constrained VBR bit reservoir

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -370,6 +370,129 @@ func TestConstrainedVBRPacketRoundTrip(t *testing.T) {
 	assert.Greater(t, vectorEnergyFloat32(out), 1e-6)
 }
 
+func TestVBRProducesVaryingPacketSizes(t *testing.T) {
+	enc, err := NewEncoder(WithVBR(true), WithConstrainedVBR(false))
+	require.NoError(t, err)
+
+	sizes := make(map[int]bool)
+	for i := range 20 {
+		pcm := make([]float32, encoderTestFrameSampleCount)
+		if i%2 == 0 {
+			for j := range pcm {
+				pcm[j] = float32(j%100) / 100
+			}
+		} else {
+			for j := range pcm {
+				pcm[j] = 0.0001
+			}
+		}
+		packet := make([]byte, 256)
+		n, err := enc.EncodeFloat32(pcm, packet)
+		require.NoError(t, err)
+		sizes[n] = true
+	}
+
+	assert.Greater(t, len(sizes), 1, "VBR should produce varying packet sizes")
+}
+
+func TestVBRPacketRoundTripMultiFrame(t *testing.T) {
+	enc, err := NewEncoder(WithVBR(true), WithConstrainedVBR(false))
+	require.NoError(t, err)
+
+	dec, err := NewDecoderWithOutput(48000, 1)
+	require.NoError(t, err)
+
+	for i := range 10 {
+		pcm := make([]float32, encoderTestFrameSampleCount)
+		for j := range pcm {
+			pcm[j] = float32(math.Sin(2*math.Pi*440*float64(j)/48000)) * float32(i%3) * 0.3
+		}
+		packet := make([]byte, 256)
+		n, err := enc.EncodeFloat32(pcm, packet)
+		require.NoError(t, err)
+
+		out := make([]float32, encoderTestFrameSampleCount)
+		_, _, err = dec.DecodeFloat32(packet[:n], out)
+		require.NoError(t, err)
+		assert.Greater(t, vectorEnergyFloat32(out), 1e-6)
+	}
+}
+
+func TestCVBRBoundsVariation(t *testing.T) {
+	enc, err := NewEncoder(WithVBR(true), WithConstrainedVBR(true))
+	require.NoError(t, err)
+
+	var minSize, maxSize int
+	for i := range 30 {
+		pcm := make([]float32, encoderTestFrameSampleCount)
+		for j := range pcm {
+			switch i % 3 {
+			case 0:
+				pcm[j] = float32(j%50) / 50
+			case 1:
+				pcm[j] = 0.0001
+			case 2:
+				pcm[j] = float32(j%200-100) / 200
+			}
+		}
+		packet := make([]byte, 256)
+		n, err := enc.EncodeFloat32(pcm, packet)
+		require.NoError(t, err)
+		if i == 0 || n < minSize {
+			minSize = n
+		}
+		if i == 0 || n > maxSize {
+			maxSize = n
+		}
+	}
+
+	assert.LessOrEqual(t, maxSize, minSize*3,
+		"CVBR should bound packet size variation")
+}
+
+func TestCBRUnchanged(t *testing.T) {
+	enc, err := NewEncoder()
+	require.NoError(t, err)
+
+	sizes := make(map[int]bool)
+	for i := range 10 {
+		pcm := make([]float32, encoderTestFrameSampleCount)
+		for j := range pcm {
+			pcm[j] = float32(i%3-1) * 0.1
+		}
+		packet := make([]byte, 256)
+		n, err := enc.EncodeFloat32(pcm, packet)
+		require.NoError(t, err)
+		sizes[n] = true
+	}
+
+	assert.Equal(t, 1, len(sizes), "CBR should produce constant packet sizes")
+}
+
+func TestVBRWithStereo(t *testing.T) {
+	enc, err := NewEncoder(WithChannels(2), WithVBR(true))
+	require.NoError(t, err)
+
+	dec, err := NewDecoderWithOutput(48000, 2)
+	require.NoError(t, err)
+
+	pcm := testEncoderStereoSineFloat32()
+	packet := make([]byte, 256)
+	n, err := enc.EncodeFloat32(pcm, packet)
+	require.NoError(t, err)
+
+	out := make([]float32, encoderTestFrameSampleCount*2)
+	_, _, err = dec.DecodeFloat32(packet[:n], out)
+	require.NoError(t, err)
+	assert.Greater(t, vectorEnergyFloat32(out), 1e-6)
+}
+
+func TestVBRDefaultIsCBR(t *testing.T) {
+	enc, err := NewEncoder()
+	require.NoError(t, err)
+	assert.False(t, enc.VBR(), "default encoder should be CBR")
+}
+
 func TestApplicationRoundTrip(t *testing.T) {
 	encoder, err := NewEncoder(
 		WithApplication(ApplicationVoIP),

--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -31,6 +31,13 @@ type allocationState struct {
 	bits         int
 }
 
+type dynallocResult struct {
+	offsets      [maxBands]int
+	spreadWeight [maxBands]int
+	maxDepth     float32
+	totBoostBits int
+}
+
 // computeAllocation derives the per-band shape and fine-energy budgets in
 // 1/8-bit units.  The implementation follows the RFC 6716 Section 4.3.3
 // structure: reserve later side-symbol budgets, choose and interpolate static
@@ -794,7 +801,10 @@ func dynallocAnalysis(
 	lm, startBand, endBand, channelCount int,
 	effectiveBytes int,
 	isTransient bool,
-) (offsets [maxBands]int, spreadWeight [maxBands]int) {
+) dynallocResult {
+	var offsets [maxBands]int
+	var spreadWeight [maxBands]int
+
 	var noiseFloor [maxBands]float32
 	for band := range endBand {
 		logN := float32(logN400[band]) / 8.0 // log2(band width)
@@ -867,7 +877,12 @@ func dynallocAnalysis(
 	}
 
 	if effectiveBytes < 30+5*lm {
-		return offsets, spreadWeight
+		return dynallocResult{
+			offsets:      offsets,
+			spreadWeight: spreadWeight,
+			maxDepth:     maxDepth,
+			totBoostBits: 0,
+		}
 	}
 
 	// follower tracks the previous frame's spectrum (bandLogE2 in libopus).
@@ -1049,5 +1064,10 @@ func dynallocAnalysis(
 		totBoostBits += boostBits
 	}
 
-	return offsets, spreadWeight
+	return dynallocResult{
+		offsets:      offsets,
+		spreadWeight: spreadWeight,
+		maxDepth:     maxDepth,
+		totBoostBits: totBoostBits,
+	}
 }

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -463,13 +463,13 @@ func TestDynallocFlatSpectrumNoBoost(t *testing.T) {
 	// Flat spectrum → no isolated peaks → all offsets zero.
 	logBandAmp := makeFlatLogBandAmp(0.0)
 	prev := makeFlatLogBandAmp(0.0)
-	offsets, _ := dynallocAnalysis(
+	dr := dynallocAnalysis(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
 		[2][maxBands]float32{prev, prev},
 		maxLM, 0, maxBands, 1, 120, false,
 	)
 	for band := range maxBands {
-		assert.Equal(t, 0, offsets[band], "flat spectrum band %d should get no boost", band)
+		assert.Equal(t, 0, dr.offsets[band], "flat spectrum band %d should get no boost", band)
 	}
 }
 
@@ -478,12 +478,12 @@ func TestDynallocIsolatedPeakGetsBoost(t *testing.T) {
 	logBandAmp := makeFlatLogBandAmp(0.0)
 	logBandAmp[10] = 10.0
 	prev := makeFlatLogBandAmp(0.0)
-	offsets, _ := dynallocAnalysis(
+	dr := dynallocAnalysis(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
 		[2][maxBands]float32{prev, prev},
 		maxLM, 0, maxBands, 1, 120, false,
 	)
-	assert.Greater(t, offsets[10], 0, "isolated peak should get boost")
+	assert.Greater(t, dr.offsets[10], 0, "isolated peak should get boost")
 }
 
 func TestDynallocSpreadWeightMaskedBandReduced(t *testing.T) {
@@ -491,13 +491,13 @@ func TestDynallocSpreadWeightMaskedBandReduced(t *testing.T) {
 	logBandAmp := makeFlatLogBandAmp(0.0)
 	logBandAmp[15] = 20.0
 	prev := makeFlatLogBandAmp(0.0)
-	_, spreadWeight := dynallocAnalysis(
+	dr := dynallocAnalysis(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
 		[2][maxBands]float32{prev, prev},
 		maxLM, 0, maxBands, 1, 120, false,
 	)
 	// Bands far from the peak should have reduced weight.
-	assert.Less(t, spreadWeight[5], 32, "band far from peak should have reduced weight")
+	assert.Less(t, dr.spreadWeight[5], 32, "band far from peak should have reduced weight")
 }
 
 func TestDynallocLowBitrateGated(t *testing.T) {
@@ -505,13 +505,13 @@ func TestDynallocLowBitrateGated(t *testing.T) {
 	logBandAmp := makeFlatLogBandAmp(0.0)
 	logBandAmp[10] = 10.0
 	prev := makeFlatLogBandAmp(0.0)
-	offsets, _ := dynallocAnalysis(
+	dr := dynallocAnalysis(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
 		[2][maxBands]float32{prev, prev},
 		maxLM, 0, maxBands, 1, 10, false, // 10 bytes < 30+15=45
 	)
 	for band := range maxBands {
-		assert.Equal(t, 0, offsets[band], "low bitrate should gate dynalloc")
+		assert.Equal(t, 0, dr.offsets[band], "low bitrate should gate dynalloc")
 	}
 }
 

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -50,12 +50,15 @@ type Encoder struct {
 	prevLogBandAmp     [2][maxBands]float32
 
 	// Application mode plumbing — set by root encoder via setter methods.
-	// Values flow from opus.WithApplication / opus.WithVBR / etc. CELT
-	// records them but does not yet change its encoding behavior based on
-	// them.
 	vbr            bool
 	constrainedVBR bool
 	lossRate       int
+
+	// VBR bit reservoir state (celt_encoder.c), all in 1/8-bit units.
+	vbrReservoir int32
+	vbrDrift     int32
+	vbrOffset    int32
+	vbrCount     int32
 }
 
 func NewEncoder() Encoder {
@@ -103,6 +106,11 @@ func (e *Encoder) Reset() {
 	e.prevSpreadDecision = defaultSpreadDecision
 	e.prevIntensityBand = 0
 	e.analysis.prefilter = postFilterState{}
+
+	e.vbrReservoir = 0
+	e.vbrDrift = 0
+	e.vbrOffset = 0
+	e.vbrCount = 0
 }
 
 func (e *Encoder) SetVBR(vbr bool) {
@@ -333,6 +341,111 @@ func (e *Encoder) choosePrefilter(pcm [][]float32, frameBytes int, transient boo
 	return enabled, pitchPeriod, qq, quantizedGain, tapset
 }
 
+// computeVBR returns the VBR target in 1/8-bit units for the current frame.
+//
+// Simplified version of libopus compute_vbr() (celt_encoder.c, ~line 1605).
+// Not ported: tonality/activity boost, stereo saving, surround masking,
+// temporal VBR — these need the full analysis pipeline pion doesn't have yet.
+func computeVBR(
+	baseTarget int, // 1/8-bit units
+	maxDepth float32,
+	totBoostBits int,
+	transient, constrainedVBR bool,
+	channelCount int,
+	effectiveBytes int,
+	lm int,
+) int {
+	target := baseTarget + totBoostBits - (19 << lm) // dynalloc calibration
+	if transient {
+		target += target >> 3
+	}
+
+	floorDepth := float32(channelCount*effectiveBytes*8) * maxDepth / 65536
+	if floorDepth < float32(target>>2) {
+		floorDepth = float32(target >> 2)
+	}
+	if float32(target) > floorDepth {
+		target = int(floorDepth)
+	}
+
+	// Constrained VBR can't sustain a higher bitrate for long, so pull 1/3
+	// of the way back to baseTarget (libopus's fixed 0.67 factor).
+	if constrainedVBR {
+		target = baseTarget + int(0.67*float32(target-baseTarget))
+	}
+
+	return max(min(target, 2*baseTarget), 0)
+}
+
+// applyVBR computes the VBR-adjusted effectiveBytes for the current frame
+// and updates the bit reservoir/drift state that biases future frames.
+// tellFrac is e.rangeEncoder.TellFrac() at the point of the call. Mirrors
+// celt_encoder.c's VBR block around compute_vbr (~lines 2436-2530).
+func (e *Encoder) applyVBR(
+	frameBytes int, transient bool, dr dynallocResult,
+	effectiveBytes, lm, channelCount, tellFrac int,
+) int {
+	vbrRate := frameBytes << 6 // libopus vbr_rate, 1/8-bit units
+
+	if e.constrainedVBR {
+		// libopus allows any multiple of vbrRate as the bound; pion always
+		// uses 2x (vbr_bound == vbr_rate in celt_encoder.c).
+		maxAllowed := max(2, (2*vbrRate-int(e.vbrReservoir))>>6)
+		effectiveBytes = min(effectiveBytes, maxAllowed)
+	}
+
+	baseTarget := max(0, vbrRate-((40*channelCount+20)<<3))
+	if e.constrainedVBR {
+		baseTarget += int(e.vbrOffset)
+	}
+
+	// rawTarget folds in tellFrac (bits already spent) before rounding to
+	// bytes. libopus uses this pre-rounding value for the drift update below
+	// and the rounded value for the reservoir — they're not the same number.
+	rawTarget := computeVBR(
+		baseTarget, dr.maxDepth, dr.totBoostBits, transient, e.constrainedVBR, channelCount, effectiveBytes, lm,
+	) + tellFrac
+
+	nbAvailableBytes := max(2, (rawTarget+(1<<5))>>6)
+	nbAvailableBytes = min(nbAvailableBytes, effectiveBytes)
+
+	e.updateVBRReservoir(vbrRate, rawTarget, nbAvailableBytes<<6)
+
+	return nbAvailableBytes
+}
+
+// updateVBRReservoir tracks the VBR bit surplus/deficit for this frame and
+// updates the drift correction that biases baseTarget on future frames.
+// All three args are in 1/8-bit units (see applyVBR), matching libopus's
+// vbr_reservoir/vbr_drift/vbr_offset in celt_encoder.c.
+func (e *Encoder) updateVBRReservoir(vbrRate, rawTarget, roundedTarget int) {
+	if !e.vbr {
+		return
+	}
+
+	var alpha float32
+	if e.vbrCount < 970 {
+		e.vbrCount++
+		alpha = 1.0 / float32(e.vbrCount+20)
+	} else {
+		alpha = 0.001
+	}
+
+	if !e.constrainedVBR {
+		return
+	}
+
+	e.vbrReservoir += int32(roundedTarget - vbrRate)
+
+	driftDelta := float32(rawTarget-vbrRate) - float32(e.vbrOffset) - float32(e.vbrDrift)
+	e.vbrDrift += int32(alpha * driftDelta)
+	e.vbrOffset = -e.vbrDrift
+
+	if e.vbrReservoir < 0 {
+		e.vbrReservoir = 0
+	}
+}
+
 // EncodeFrame encodes one CELT frame from float PCM into dst.
 // It returns the number of bytes written. dst must be at least frameBytes long.
 //
@@ -424,11 +537,13 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	// because spread_weight feeds spreadingDecision (libopus computes
 	// dynalloc_analysis before spreading_decision).
 	effectiveBytes := frameBytes
-	offsets, spreadWeight := dynallocAnalysis(
+	dr := dynallocAnalysis(
 		analysis.logBandAmp, e.prevLogBandAmp,
 		info.lm, info.startBand, info.endBand, info.channelCount,
 		effectiveBytes, info.transient,
 	)
+	offsets := dr.offsets
+	spreadWeight := dr.spreadWeight
 
 	info.spread = spreadingDecision(
 		analysis.mdct[0], info.lm, info.startBand, info.endBand,
@@ -446,6 +561,11 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	e.encodeAllocationTrim(&info, totalBitsEighth)
 
 	tellFrac := int(e.rangeEncoder.TellFrac())
+
+	if e.vbr {
+		effectiveBytes = e.applyVBR(frameBytes, transient, dr, effectiveBytes, info.lm, info.channelCount, tellFrac)
+	}
+	info.totalBits = uint(effectiveBytes) * 8
 	shapeBits := (int(info.totalBits) << bitResolution) - tellFrac - 1
 	info.antiCollapseRsv = 0
 	if info.transient && info.lm >= 2 && shapeBits >= (info.lm+2)<<bitResolution {
@@ -507,6 +627,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	e.finalizeFineEnergy(&info, info.allocation.fineQuant, info.allocation.finePriority, targetLogE, bitsLeft)
 
 	e.prevLogBandAmp = analysis.logBandAmp
+
 	e.rng = e.rangeEncoder.FinalRange()
 
 	return e.rangeEncoder.FlushInto(dst), nil


### PR DESCRIPTION
#### Description
Wires up real VBR. Until now `SetVBR`/`SetConstrainedVBR` just stored the flag on `celt.Encoder` — the bitrate stayed CBR no matter what you asked for. This makes VBR actually adjust the per-frame byte budget based on how "hard" the frame is, following libopus's `compute_vbr()`/`vbr_reservoir` machinery in `celt_encoder.c`.

`computeVBR()` ports the core of `compute_vbr()`: dynalloc calibration, transient boost, floor depth (don't waste bits on quiet frames), and the 0.67 dampening libopus applies for constrained VBR specifically ("can't sustain a higher bitrate for long", straight from their comment). `applyVBR()` wraps that with the reservoir/drift bookkeeping — constrained VBR gets an early cap based on the previous frame's reservoir, then once the byte count for this frame is picked it updates `vbrReservoir`/`vbrDrift`/`vbrOffset` so the next frame's target gets nudged back toward the nominal rate.

One thing that bit me while porting this: libopus actually uses two different values here — the raw pre-rounding target (with the bits already spent on side info folded in) for the drift update, and the rounded byte-based target for the reservoir. I first collapsed those into one number and the reservoir basically never left zero. Split them back out and the dynamics match now.

`dynallocAnalysis` returns a small struct now (`maxDepth`, `totBoostBits` alongside the existing offsets/spreadWeight) instead of two bare return values, since `computeVBR` needs those too.

Same as `compute_vbr` itself, still not ported: tonality/activity boost, stereo saving, surround masking, temporal VBR — all need the full analysis pipeline pion doesn't have. Hybrid mode and the `min_allowed`/silence-frame handling from `celt_encoder.c` are also skipped since pion doesn't do hybrid or silence detection at that level yet.

Added round-trip tests for VBR/CVBR/CBR (packet sizes actually vary vs. stay constant, CVBR keeps the swing bounded) plus a stereo VBR round trip.

#### Reference issue
Fixes #...
