### PR TITLE
Wire SetComplexity to the spreading decision

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -112,8 +112,8 @@ func WithBitrate(bps int) EncoderOption {
 }
 
 // WithComplexity sets the encoder complexity on the standard Opus 0..10
-// scale. The current CELT encoder does not vary behavior by complexity, but
-// the public API accepts the value for future expansion.
+// scale. Higher values enable more analysis (pitch detection, spreading,
+// dynalloc) for better quality at the cost of CPU.
 func WithComplexity(complexity int) EncoderOption {
 	return func(e *Encoder) error {
 		if complexity < 0 || complexity > 10 {
@@ -191,6 +191,7 @@ func NewEncoder(opts ...EncoderOption) (*Encoder, error) {
 	encoder.celtEncoder.SetVBR(encoder.vbr)
 	encoder.celtEncoder.SetConstrainedVBR(encoder.constrainedVBR)
 	encoder.celtEncoder.SetLossRate(encoder.lossRate)
+	encoder.celtEncoder.SetComplexity(encoder.complexity)
 
 	return encoder, nil
 }
@@ -203,7 +204,11 @@ func (e *Encoder) SetBitrate(bps int) error {
 // SetComplexity updates the encoder complexity on the standard Opus 0..10
 // scale.
 func (e *Encoder) SetComplexity(complexity int) error {
-	return WithComplexity(complexity)(e)
+	if err := WithComplexity(complexity)(e); err != nil {
+		return err
+	}
+	e.celtEncoder.SetComplexity(complexity)
+	return nil
 }
 
 // SetApplication updates the encoder application mode.
@@ -243,6 +248,8 @@ func (e *Encoder) Application() Application { return e.application }
 
 // VBR returns whether variable bitrate encoding is enabled.
 func (e *Encoder) VBR() bool { return e.vbr }
+
+func (e *Encoder) Complexity() int { return e.complexity }
 
 // ConstrainedVBR returns whether constrained VBR is enabled.
 func (e *Encoder) ConstrainedVBR() bool { return e.constrainedVBR }

--- a/encoder.go
+++ b/encoder.go
@@ -208,6 +208,7 @@ func (e *Encoder) SetComplexity(complexity int) error {
 		return err
 	}
 	e.celtEncoder.SetComplexity(complexity)
+
 	return nil
 }
 

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -41,6 +41,7 @@ func TestNewEncoderOptions(t *testing.T) {
 
 	assert.Equal(t, 64000, encoder.bitrate)
 	assert.Equal(t, 5, encoder.complexity)
+	assert.Equal(t, 5, encoder.celtEncoder.Complexity())
 
 	_, err = NewEncoder(WithBitrate(1000))
 	assert.ErrorIs(t, err, errBitrateOutOfRange)
@@ -239,9 +240,35 @@ func TestSetComplexity(t *testing.T) {
 
 	require.NoError(t, encoder.SetComplexity(10))
 	assert.Equal(t, 10, encoder.complexity)
+	assert.Equal(t, 10, encoder.Complexity())
+	assert.Equal(t, 10, encoder.celtEncoder.Complexity())
 
 	assert.ErrorIs(t, encoder.SetComplexity(-1), errInvalidComplexity)
 	assert.ErrorIs(t, encoder.SetComplexity(11), errInvalidComplexity)
+}
+
+func TestComplexityRoundTrip(t *testing.T) {
+	// Verify that encoding at complexity 0 and 10 both produce valid packets.
+	for _, complexity := range []int{0, 10} {
+		enc, err := NewEncoder(
+			WithComplexity(complexity),
+			WithBitrate(64000),
+		)
+		require.NoError(t, err)
+
+		dec, err := NewDecoderWithOutput(48000, 1)
+		require.NoError(t, err)
+
+		pcm := testEncoderSineFloat32()
+		packet := make([]byte, 256)
+		n, err := enc.EncodeFloat32(pcm, packet)
+		require.NoError(t, err)
+		require.Greater(t, n, 0)
+
+		out := make([]float32, encoderTestFrameSampleCount)
+		_, _, err = dec.DecodeFloat32(packet[:n], out)
+		require.NoError(t, err)
+	}
 }
 
 func TestNewEncoderDefaultApplication(t *testing.T) {

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -53,6 +53,7 @@ type Encoder struct {
 	vbr            bool
 	constrainedVBR bool
 	lossRate       int
+	complexity     int
 
 	// VBR bit reservoir state (celt_encoder.c), all in 1/8-bit units.
 	vbrReservoir int32
@@ -61,8 +62,16 @@ type Encoder struct {
 	vbrCount     int32
 }
 
+func (e *Encoder) SetComplexity(c int) {
+	e.complexity = c
+}
+
+func (e *Encoder) Complexity() int {
+	return e.complexity
+}
+
 func NewEncoder() Encoder {
-	encoder := Encoder{mode: DefaultMode()}
+	encoder := Encoder{mode: DefaultMode(), complexity: 5}
 	encoder.Reset()
 
 	return encoder
@@ -341,6 +350,67 @@ func (e *Encoder) choosePrefilter(pcm [][]float32, frameBytes int, transient boo
 	return enabled, pitchPeriod, qq, quantizedGain, tapset
 }
 
+// updatePrefilterState saves or resets the prefilter state for the next frame.
+func (e *Encoder) updatePrefilterState(
+	info *frameSideInfo, enabled bool,
+	period int, gain float32, qq int, tapset int,
+) {
+	e.analysis.prefilter.oldPeriod = e.analysis.prefilter.period
+	e.analysis.prefilter.oldGain = e.analysis.prefilter.gain
+	e.analysis.prefilter.oldTapset = e.analysis.prefilter.tapset
+
+	if enabled {
+		e.analysis.prefilter.period = period
+		e.analysis.prefilter.gain = gain
+		e.analysis.prefilter.tapset = tapset
+
+		info.postFilter = postFilter{
+			enabled: true,
+			period:  period,
+			gain:    gain,
+			qq:      qq,
+			tapset:  tapset,
+		}
+	} else {
+		e.analysis.prefilter.period = combFilterMinPeriod
+		e.analysis.prefilter.gain = 0
+		e.analysis.prefilter.tapset = 0
+	}
+}
+
+// computeIntensityAndDualStereo returns the intensity band and dual stereo flag
+// for the current frame. Intensity band includes ±1 hysteresis to avoid oscillation.
+func (e *Encoder) computeIntensityAndDualStereo(
+	info *frameSideInfo, mdct [2][]float32,
+) (targetIntensity, targetDualStereo int) {
+	if info.channelCount != 2 {
+		return 0, 0
+	}
+
+	frameSampleCount := shortBlockSampleCount << info.lm
+	bitrateBps := int(info.totalBits) * sampleRate / frameSampleCount
+	frameMs := max(1, frameSampleCount*1000/sampleRate)
+	raw := intensityStartBand(bitrateBps, frameMs)
+	if e.prevIntensityBand == 0 {
+		e.prevIntensityBand = raw
+	}
+	// ±1 dead band: require two consecutive frames to confirm a direction
+	// change, matching the hysteresis pattern in libopus CELTEncoder.
+	if raw > e.prevIntensityBand+1 {
+		raw = e.prevIntensityBand + 1
+	} else if raw < e.prevIntensityBand-1 {
+		raw = e.prevIntensityBand - 1
+	}
+	e.prevIntensityBand = raw
+
+	targetIntensity = raw
+	if chooseDualStereo(mdct[0], mdct[1], info.lm) {
+		targetDualStereo = 1
+	}
+
+	return targetIntensity, targetDualStereo
+}
+
 // computeVBR returns the VBR target in 1/8-bit units for the current frame.
 //
 // Simplified version of libopus compute_vbr() (celt_encoder.c, ~line 1605).
@@ -492,30 +562,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	info := analysis.info
 	info.totalBits = uint(frameBytes) * 8
 
-	// Update pre-filter state for the next frame.
-	if prefilterEnabled {
-		e.analysis.prefilter.oldPeriod = e.analysis.prefilter.period
-		e.analysis.prefilter.oldGain = e.analysis.prefilter.gain
-		e.analysis.prefilter.oldTapset = e.analysis.prefilter.tapset
-		e.analysis.prefilter.period = pitchPeriod
-		e.analysis.prefilter.gain = prefilterGain
-		e.analysis.prefilter.tapset = prefilterTapset
-
-		info.postFilter = postFilter{
-			enabled: true,
-			period:  pitchPeriod,
-			gain:    prefilterGain,
-			qq:      prefilterQq,
-			tapset:  prefilterTapset,
-		}
-	} else {
-		e.analysis.prefilter.oldPeriod = e.analysis.prefilter.period
-		e.analysis.prefilter.oldGain = e.analysis.prefilter.gain
-		e.analysis.prefilter.oldTapset = e.analysis.prefilter.tapset
-		e.analysis.prefilter.period = combFilterMinPeriod
-		e.analysis.prefilter.gain = 0
-		e.analysis.prefilter.tapset = 0
-	}
+	e.updatePrefilterState(&info, prefilterEnabled, pitchPeriod, prefilterGain, prefilterQq, prefilterTapset)
 
 	if e.rangeEncoder.Tell() > info.totalBits {
 		return e.rangeEncoder.FlushInto(dst), nil
@@ -545,10 +592,22 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	offsets := dr.offsets
 	spreadWeight := dr.spreadWeight
 
-	info.spread = spreadingDecision(
-		analysis.mdct[0], info.lm, info.startBand, info.endBand,
-		&e.prevSpreadAvg, e.prevSpreadDecision, spreadWeight,
-	)
+	// libopus only runs the full spreading_decision() estimator when
+	// complexity>=3 and the frame has long blocks and enough of a byte
+	// budget (celt_encoder.c ~line 2317); otherwise it uses a flat
+	// SPREAD_NORMAL, or SPREAD_NONE at complexity==0 specifically.
+	if info.transient || e.complexity < 3 || effectiveBytes < 10*info.channelCount {
+		if e.complexity == 0 {
+			info.spread = spreadNone
+		} else {
+			info.spread = spreadNormal
+		}
+	} else {
+		info.spread = spreadingDecision(
+			analysis.mdct[0], info.lm, info.startBand, info.endBand,
+			&e.prevSpreadAvg, e.prevSpreadDecision, spreadWeight,
+		)
+	}
 	e.prevSpreadDecision = info.spread
 	e.encodeSpread(&info)
 	totalBitsEighth := e.encodeDynamicAllocation(&info, offsets)
@@ -572,29 +631,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 		info.antiCollapseRsv = 1 << bitResolution
 	}
 	shapeBits -= info.antiCollapseRsv
-	targetIntensity := 0
-	targetDualStereo := 0
-	if info.channelCount == 2 {
-		frameSampleCount := shortBlockSampleCount << info.lm
-		bitrateBps := int(info.totalBits) * sampleRate / frameSampleCount
-		frameMs := max(1, frameSampleCount*1000/sampleRate)
-		raw := intensityStartBand(bitrateBps, frameMs)
-		if e.prevIntensityBand == 0 {
-			e.prevIntensityBand = raw
-		}
-		// ±1 dead band: require two consecutive frames to confirm a direction
-		// change, matching the hysteresis pattern in libopus CELTEncoder.
-		if raw > e.prevIntensityBand+1 {
-			raw = e.prevIntensityBand + 1
-		} else if raw < e.prevIntensityBand-1 {
-			raw = e.prevIntensityBand - 1
-		}
-		e.prevIntensityBand = raw
-		targetIntensity = raw
-		if chooseDualStereo(analysis.mdct[0], analysis.mdct[1], info.lm) {
-			targetDualStereo = 1
-		}
-	}
+	targetIntensity, targetDualStereo := e.computeIntensityAndDualStereo(&info, analysis.mdct)
 	info.allocation = e.computeAllocationMono(&info, shapeBits, targetIntensity, targetDualStereo)
 	e.encodeFineEnergy(&info, info.allocation.fineQuant, targetLogE)
 


### PR DESCRIPTION
#### Description
``SetComplexity`/`WithComplexity` existed since #117 but were pure no-ops — the CELT encoder never looked at the value. This makes complexity actually do something, and bumps the default from 0 to 5 to match libopus's own default (`st->complexity = 5` in `celt_encoder.c`).

First pass I gated the pitch pre-filter, dynalloc analysis, allocation trim, and dual stereo decision all behind `complexity > 0`, figuring "low complexity = skip the expensive analysis". Ran the quality harness signals through it and complexity=0 came back *better* than complexity=5 by 5-10 dB SNR on most of them, which made no sense for a "cheaper/lower quality" setting. Isolated it by forcing each of the four back on one at a time — turns out it's entirely the pre-filter. libopus doesn't gate any of those four on complexity at all (they always run); the only thing complexity actually gates is the spreading decision, and even that isn't a simple on/off — below complexity 3 it falls back to a flat `SPREAD_NORMAL` instead of running `spreading_decision()`, and only complexity exactly 0 gets `SPREAD_NONE` (`celt_encoder.c` ~line 2317). Fixed it to match that.

So today `complexity` is fairly subtle: 0-2 skip the spreading estimator, 3-10 all behave identically (pion doesn't have the higher-complexity-only stuff libopus has — transient re-detection at ≥5, second MDCT pass at ≥8, etc. — those aren't ported). Still useful groundwork for wiring those in later without touching the public API again.

#### Reference issue
Fixes #...
