### PR TITLE
Do not export configuration needlessly

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -256,7 +256,7 @@ func (d *Decoder) copyHybridSilkResamplerToSilk() {
 	d.silkResamplerChannels = d.hybridSilkChannels
 }
 
-func (c Configuration) silkFrameSampleCount() int {
+func (c configuration) silkFrameSampleCount() int {
 	if c.mode() != configurationModeSilkOnly {
 		return 0
 	}
@@ -277,7 +277,7 @@ func (c Configuration) silkFrameSampleCount() int {
 	return 0
 }
 
-func (c Configuration) celtFrameSampleCount() int {
+func (c configuration) celtFrameSampleCount() int {
 	if c.mode() != configurationModeCELTOnly {
 		return 0
 	}
@@ -288,7 +288,7 @@ func (c Configuration) celtFrameSampleCount() int {
 	return int(int64(c.frameDuration().nanoseconds()) * int64(celtSampleRate) / 1000000000)
 }
 
-func (c Configuration) hybridFrameSampleCount() int {
+func (c configuration) hybridFrameSampleCount() int {
 	if c.mode() != configurationModeHybrid {
 		return 0
 	}
@@ -296,7 +296,7 @@ func (c Configuration) hybridFrameSampleCount() int {
 	return int(int64(c.frameDuration().nanoseconds()) * int64(celtSampleRate) / 1000000000)
 }
 
-func (c Configuration) decodedSampleRate() int {
+func (c configuration) decodedSampleRate() int {
 	switch c.mode() {
 	case configurationModeSilkOnly:
 		return c.bandwidth().SampleRate()
@@ -609,7 +609,7 @@ func (d *Decoder) decode(
 // decodeCeltFrames keeps CELT synthesis in the internal 48 kHz mode while
 // emitting PCM at the caller-requested Opus API output rate.
 func (d *Decoder) decodeCeltFrames(
-	cfg Configuration,
+	cfg configuration,
 	tocHeader tableOfContentsHeader,
 	encodedFrames [][]byte,
 	out []float32,
@@ -674,7 +674,7 @@ func (d *Decoder) decodeCeltFrames(
 
 // decodeHybridFrames combines the SILK and CELT layers for Hybrid packets.
 func (d *Decoder) decodeHybridFrames(
-	cfg Configuration,
+	cfg configuration,
 	tocHeader tableOfContentsHeader,
 	encodedFrames [][]byte,
 	out []float32,
@@ -1049,7 +1049,7 @@ func (d *Decoder) addHybridSilk(
 //
 //nolint:cyclop
 func (d *Decoder) decodeSilkFrames(
-	cfg Configuration,
+	cfg configuration,
 	tocHeader tableOfContentsHeader,
 	encodedFrames [][]byte,
 	out []float32,

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -337,7 +337,7 @@ func TestCopyChannels(t *testing.T) {
 func TestDecodePLCModes(t *testing.T) {
 	for _, test := range []struct {
 		name          string
-		configuration Configuration
+		configuration configuration
 		frameSamples  int
 	}{
 		{name: "SILK", configuration: 8, frameSamples: 480},
@@ -358,7 +358,7 @@ func TestDecodePLCModes(t *testing.T) {
 func TestDecodeSilkFrameDurations(t *testing.T) {
 	for _, test := range []struct {
 		name          string
-		configuration Configuration
+		configuration configuration
 		sampleCount   int
 	}{
 		{name: "10ms", configuration: 8, sampleCount: 160},
@@ -376,29 +376,29 @@ func TestDecodeSilkFrameDurations(t *testing.T) {
 }
 
 func TestSilkFrameSampleCount(t *testing.T) {
-	assert.Equal(t, 80, Configuration(0).silkFrameSampleCount())
-	assert.Equal(t, 120, Configuration(4).silkFrameSampleCount())
-	assert.Equal(t, 160, Configuration(8).silkFrameSampleCount())
-	assert.Equal(t, 0, Configuration(12).silkFrameSampleCount())
-	assert.Equal(t, 0, Configuration(16).silkFrameSampleCount())
+	assert.Equal(t, 80, configuration(0).silkFrameSampleCount())
+	assert.Equal(t, 120, configuration(4).silkFrameSampleCount())
+	assert.Equal(t, 160, configuration(8).silkFrameSampleCount())
+	assert.Equal(t, 0, configuration(12).silkFrameSampleCount())
+	assert.Equal(t, 0, configuration(16).silkFrameSampleCount())
 }
 
 func TestCeltFrameSampleCount(t *testing.T) {
-	assert.Equal(t, 120, Configuration(16).celtFrameSampleCount())
-	assert.Equal(t, 240, Configuration(17).celtFrameSampleCount())
-	assert.Equal(t, 480, Configuration(18).celtFrameSampleCount())
-	assert.Equal(t, 960, Configuration(19).celtFrameSampleCount())
-	assert.Equal(t, 960, Configuration(31).celtFrameSampleCount())
-	assert.Equal(t, 0, Configuration(0).celtFrameSampleCount())
-	assert.Equal(t, 0, Configuration(12).celtFrameSampleCount())
+	assert.Equal(t, 120, configuration(16).celtFrameSampleCount())
+	assert.Equal(t, 240, configuration(17).celtFrameSampleCount())
+	assert.Equal(t, 480, configuration(18).celtFrameSampleCount())
+	assert.Equal(t, 960, configuration(19).celtFrameSampleCount())
+	assert.Equal(t, 960, configuration(31).celtFrameSampleCount())
+	assert.Equal(t, 0, configuration(0).celtFrameSampleCount())
+	assert.Equal(t, 0, configuration(12).celtFrameSampleCount())
 }
 
 func TestDecodedSampleRate(t *testing.T) {
-	assert.Equal(t, 8000, Configuration(0).decodedSampleRate())
-	assert.Equal(t, 16000, Configuration(8).decodedSampleRate())
-	assert.Equal(t, celtSampleRate, Configuration(16).decodedSampleRate())
-	assert.Equal(t, celtSampleRate, Configuration(31).decodedSampleRate())
-	assert.Equal(t, celtSampleRate, Configuration(12).decodedSampleRate())
+	assert.Equal(t, 8000, configuration(0).decodedSampleRate())
+	assert.Equal(t, 16000, configuration(8).decodedSampleRate())
+	assert.Equal(t, celtSampleRate, configuration(16).decodedSampleRate())
+	assert.Equal(t, celtSampleRate, configuration(31).decodedSampleRate())
+	assert.Equal(t, celtSampleRate, configuration(12).decodedSampleRate())
 }
 
 func TestDecodeCeltOnly(t *testing.T) {
@@ -568,7 +568,7 @@ func TestDecodeSilkFramesAddsHybridTransitionAudio(t *testing.T) {
 	decoder.previousMode = configurationModeHybrid
 
 	bandwidth, _, isStereo, sampleCount, decodedChannelCount, err := decoder.decodeSilkFrames(
-		Configuration(8),
+		configuration(8),
 		tableOfContentsHeader(byte(8<<3)|byte(frameCodeOneFrame)),
 		[][]byte{nil},
 		nil,

--- a/table_of_contents_header.go
+++ b/table_of_contents_header.go
@@ -17,12 +17,12 @@ type (
 	// https://datatracker.ietf.org/doc/html/rfc6716#section-3.1
 	tableOfContentsHeader byte
 
-	// Configuration numbers in each range (e.g., 0...3 for NB SILK-
+	// configuration numbers in each range (e.g., 0...3 for NB SILK-
 	// only) correspond to the various choices of frame size, in the same
 	// order.  For example, configuration 0 has a 10 ms frame size and
 	// configuration 3 has a 60 ms frame size.
 	// +-----------------------+-----------+-----------+-------------------+
-	// | Configuration         | Mode      | Bandwidth | Frame Sizes       |
+	// | configuration         | Mode      | Bandwidth | Frame Sizes       |
 	// | Number(s)             |           |           |                   |
 	// +-----------------------+-----------+-----------+-------------------+
 	// | 0...3                 | SILK-only | NB        | 10, 20, 40, 60 ms |
@@ -45,7 +45,7 @@ type (
 	// +-----------------------+-----------+-----------+-------------------+
 	//
 	// https://datatracker.ietf.org/doc/html/rfc6716#section-3.1
-	Configuration byte
+	configuration byte
 
 	// As described, the LP (SILK) layer and MDCT (CELT) layer can be
 	// combined in three possible operating modes:
@@ -114,8 +114,8 @@ type (
 	frameCode byte
 )
 
-func (t tableOfContentsHeader) configuration() Configuration {
-	return Configuration(t >> 3)
+func (t tableOfContentsHeader) configuration() configuration {
+	return configuration(t >> 3)
 }
 
 func (t tableOfContentsHeader) isStereo() bool {
@@ -154,7 +154,7 @@ func (c configurationMode) String() string {
 
 // See Configuration for mapping of mode to configuration numbers
 // https://datatracker.ietf.org/doc/html/rfc6716#section-3.1
-func (c Configuration) mode() configurationMode {
+func (c configuration) mode() configurationMode {
 	switch {
 	case c <= 11:
 		return configurationModeSilkOnly
@@ -216,7 +216,7 @@ func (f frameDuration) nanoseconds() int {
 
 // See Configuration for mapping of frameDuration to configuration numbers
 // https://datatracker.ietf.org/doc/html/rfc6716#section-3.1
-func (c Configuration) frameDuration() frameDuration {
+func (c configuration) frameDuration() frameDuration {
 	switch c {
 	case 16, 20, 24, 28:
 		return frameDuration2500us
@@ -249,7 +249,7 @@ const (
 
 // See Configuration for mapping of bandwidth to configuration numbers
 // https://datatracker.ietf.org/doc/html/rfc6716#section-3.1
-func (c Configuration) bandwidth() Bandwidth {
+func (c configuration) bandwidth() Bandwidth {
 	switch {
 	case c <= 3:
 		return BandwidthNarrowband

--- a/table_of_contents_header_test.go
+++ b/table_of_contents_header_test.go
@@ -12,10 +12,10 @@ import (
 func TestConfigurationMode(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, configurationModeSilkOnly, Configuration(0).mode())
-	assert.Equal(t, configurationModeHybrid, Configuration(12).mode())
-	assert.Equal(t, configurationModeCELTOnly, Configuration(16).mode())
-	assert.Equal(t, configurationMode(0), Configuration(32).mode())
+	assert.Equal(t, configurationModeSilkOnly, configuration(0).mode())
+	assert.Equal(t, configurationModeHybrid, configuration(12).mode())
+	assert.Equal(t, configurationModeCELTOnly, configuration(16).mode())
+	assert.Equal(t, configurationMode(0), configuration(32).mode())
 }
 
 func TestConfigurationModeString(t *testing.T) {
@@ -30,13 +30,13 @@ func TestConfigurationModeString(t *testing.T) {
 func TestFrameDuration(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, frameDuration2500us, Configuration(16).frameDuration())
-	assert.Equal(t, frameDuration5ms, Configuration(17).frameDuration())
-	assert.Equal(t, frameDuration10ms, Configuration(0).frameDuration())
-	assert.Equal(t, frameDuration20ms, Configuration(1).frameDuration())
-	assert.Equal(t, frameDuration40ms, Configuration(10).frameDuration())
-	assert.Equal(t, frameDuration60ms, Configuration(11).frameDuration())
-	assert.Equal(t, frameDuration(0), Configuration(32).frameDuration())
+	assert.Equal(t, frameDuration2500us, configuration(16).frameDuration())
+	assert.Equal(t, frameDuration5ms, configuration(17).frameDuration())
+	assert.Equal(t, frameDuration10ms, configuration(0).frameDuration())
+	assert.Equal(t, frameDuration20ms, configuration(1).frameDuration())
+	assert.Equal(t, frameDuration40ms, configuration(10).frameDuration())
+	assert.Equal(t, frameDuration60ms, configuration(11).frameDuration())
+	assert.Equal(t, frameDuration(0), configuration(32).frameDuration())
 }
 
 func TestFrameDurationString(t *testing.T) {
@@ -66,16 +66,16 @@ func TestFrameDurationNanoseconds(t *testing.T) {
 func TestBandwidth(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, BandwidthNarrowband, Configuration(0).bandwidth())
-	assert.Equal(t, BandwidthMediumband, Configuration(4).bandwidth())
-	assert.Equal(t, BandwidthWideband, Configuration(8).bandwidth())
-	assert.Equal(t, BandwidthSuperwideband, Configuration(12).bandwidth())
-	assert.Equal(t, BandwidthFullband, Configuration(14).bandwidth())
-	assert.Equal(t, BandwidthNarrowband, Configuration(16).bandwidth())
-	assert.Equal(t, BandwidthWideband, Configuration(20).bandwidth())
-	assert.Equal(t, BandwidthSuperwideband, Configuration(24).bandwidth())
-	assert.Equal(t, BandwidthFullband, Configuration(28).bandwidth())
-	assert.Equal(t, Bandwidth(255), Configuration(32).bandwidth())
+	assert.Equal(t, BandwidthNarrowband, configuration(0).bandwidth())
+	assert.Equal(t, BandwidthMediumband, configuration(4).bandwidth())
+	assert.Equal(t, BandwidthWideband, configuration(8).bandwidth())
+	assert.Equal(t, BandwidthSuperwideband, configuration(12).bandwidth())
+	assert.Equal(t, BandwidthFullband, configuration(14).bandwidth())
+	assert.Equal(t, BandwidthNarrowband, configuration(16).bandwidth())
+	assert.Equal(t, BandwidthWideband, configuration(20).bandwidth())
+	assert.Equal(t, BandwidthSuperwideband, configuration(24).bandwidth())
+	assert.Equal(t, BandwidthFullband, configuration(28).bandwidth())
+	assert.Equal(t, Bandwidth(255), configuration(32).bandwidth())
 }
 
 func TestBandwidthString(t *testing.T) {


### PR DESCRIPTION
#### Description
The `Configuration` type was previously exported, while not being used in any exported function. Thus there is no need to export it. I have made it an internal type in this pull request. In my opinion, this will reduce confusion, when reading the package documentation.

This is a breaking change, but since this library has not yet reached v1.0.0, breaking changes are still acceptable without new major versions, according to semantic versioning.

#### Reference issue
Addresses the first bullet point of #63.
