### PR TITLE
Make CELT pre-filter non-recursive

### DIFF
--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -29,6 +29,7 @@ type analysisState struct {
 	prefilterMem   [2][]float32
 	prefilter      postFilterState
 	prefilterBuf   [2][]float32
+	prefilterOut   [2][]float32
 }
 
 type analysisResult struct {
@@ -61,6 +62,10 @@ func newAnalysisState() analysisState {
 			make([]float32, postfilterHistorySampleCount),
 		},
 		prefilterBuf: [2][]float32{
+			make([]float32, postfilterHistorySampleCount+maxFrame),
+			make([]float32, postfilterHistorySampleCount+maxFrame),
+		},
+		prefilterOut: [2][]float32{
 			make([]float32, postfilterHistorySampleCount+maxFrame),
 			make([]float32, postfilterHistorySampleCount+maxFrame),
 		},
@@ -112,18 +117,21 @@ func analyzeFrame(
 		// Apply pitch pre-filter (whitening) before MDCT, mirroring
 		// libopus run_prefilter. Reuses combFilter with negated gains.
 		if prefilterEnabled {
-			buf := state.prefilterBuf[ch][:postfilterHistorySampleCount+len(pre)]
-			copy(buf, state.prefilterMem[ch])
-			copy(buf[postfilterHistorySampleCount:], pre)
+			src := state.prefilterBuf[ch][:postfilterHistorySampleCount+len(pre)]
+			copy(src, state.prefilterMem[ch])
+			copy(src[postfilterHistorySampleCount:], pre)
+			dst := state.prefilterOut[ch][:len(src)]
 			applyPrefilter(
-				buf,
+				dst, src,
 				state.prefilter.oldPeriod, prefilterPeriod,
 				len(pre),
 				state.prefilter.oldGain, prefilterGain,
 				state.prefilter.oldTapset, prefilterTapset,
 			)
-			copy(pre, buf[postfilterHistorySampleCount:])
-			copy(state.prefilterMem[ch], buf[len(pre):len(pre)+postfilterHistorySampleCount])
+			// Carry the unfiltered tail, since the taps read the input signal
+			// (libopus keeps prefilter_mem from pre, not from the output).
+			copy(state.prefilterMem[ch], src[len(pre):len(pre)+postfilterHistorySampleCount])
+			copy(pre, dst[postfilterHistorySampleCount:])
 		}
 
 		if useShortBlocks {

--- a/internal/celt/pitch.go
+++ b/internal/celt/pitch.go
@@ -244,8 +244,11 @@ func absInt(x int) int {
 // applyPrefilter applies the pitch pre-filter before MDCT by calling
 // combFilter with negated gains — the inverse of the decoder's post-filter.
 // Mirrors libopus run_prefilter (celt_encoder.c lines 1543-1558).
+// applyPrefilter whitens src into dst. dst must not alias src: the taps have to
+// read the unfiltered input so the filter stays non-recursive and the decoder's
+// postfilter inverts it exactly (see combFilter).
 func applyPrefilter(
-	buf []float32,
+	dst, src []float32,
 	oldPeriod, period int,
 	n int,
 	oldGain, gain float32,
@@ -258,7 +261,7 @@ func applyPrefilter(
 	period = max(period, combFilterMinPeriod)
 
 	combFilter(
-		buf,
+		dst, src,
 		start,
 		oldPeriod,
 		period,
@@ -288,18 +291,19 @@ func shouldCancelPrefilter(
 		applyDCBlock(pre, sampleRate, &dcMem)
 		applyPreemphasis(pre, pre, &preemphasisMem)
 
-		buf := state.prefilterBuf[ch][:postfilterHistorySampleCount+len(pre)]
-		copy(buf, state.prefilterMem[ch])
-		copy(buf[postfilterHistorySampleCount:], pre)
-		before[ch] = measureEnergy(buf, postfilterHistorySampleCount, len(pre))
+		src := state.prefilterBuf[ch][:postfilterHistorySampleCount+len(pre)]
+		copy(src, state.prefilterMem[ch])
+		copy(src[postfilterHistorySampleCount:], pre)
+		before[ch] = measureEnergy(src, postfilterHistorySampleCount, len(pre))
+		dst := state.prefilterOut[ch][:len(src)]
 		applyPrefilter(
-			buf,
+			dst, src,
 			state.prefilter.oldPeriod, period,
 			len(pre),
 			state.prefilter.oldGain, gain,
 			state.prefilter.oldTapset, tapset,
 		)
-		after[ch] = measureEnergy(buf, postfilterHistorySampleCount, len(pre))
+		after[ch] = measureEnergy(dst, postfilterHistorySampleCount, len(pre))
 	}
 
 	return cancelPitch(len(pcm), gain, before, after)

--- a/internal/celt/pitch_test.go
+++ b/internal/celt/pitch_test.go
@@ -262,8 +262,9 @@ func TestApplyPrefilterModifiesSignal(t *testing.T) {
 	original := make([]float32, frameLen)
 	copy(original, sine)
 
-	applyPrefilter(buf, period, period, frameLen, gain, gain, tapset, tapset)
-	filtered := buf[histLen:]
+	dst := make([]float32, len(buf))
+	applyPrefilter(dst, buf, period, period, frameLen, gain, gain, tapset, tapset)
+	filtered := dst[histLen:]
 
 	// The pre-filter must change the signal.
 	var maxDiff float32

--- a/internal/celt/prefilter_inverse_test.go
+++ b/internal/celt/prefilter_inverse_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPrefilterInvertsPostfilter checks the encoder's prefilter and the
+// decoder's postfilter cancel out at every gain.
+//
+// They only do so because the prefilter reads unfiltered input while the
+// postfilter reads its own output: running both in place would make each a
+// recursive filter, and the pair would amplify by 1/(1-g^2) instead of
+// returning the signal unchanged — over 2x at the gains a periodic signal
+// reaches.
+func TestPrefilterInvertsPostfilter(t *testing.T) {
+	const (
+		start  = postfilterHistorySampleCount
+		count  = maxFrameSampleCount
+		period = 48 // one cycle of the 1 kHz tone below
+	)
+
+	for _, gain := range []float32{0.09375, 0.25, 0.5, 0.75, 0.9} {
+		src := make([]float32, start+count+8)
+		for i := range src {
+			src[i] = float32(0.5 * math.Sin(2*math.Pi*1000*float64(i)/48000))
+		}
+		original := append([]float32(nil), src...)
+
+		filtered := make([]float32, len(src))
+		copy(filtered, src)
+		applyPrefilter(filtered, src, period, period, count, gain, gain, 0, 0)
+
+		// The postfilter runs in place, the way the decoder applies it.
+		combFilter(filtered, filtered, start, period, period, count, gain, gain, 0, 0)
+
+		var signal, residual float64
+		for i := start; i < start+count; i++ {
+			diff := float64(original[i] - filtered[i])
+			signal += float64(original[i]) * float64(original[i])
+			residual += diff * diff
+		}
+		assert.InDeltaf(t, 1.0, math.Sqrt(1+residual/signal), 1e-3,
+			"gain %v: prefilter and postfilter must cancel", gain)
+	}
+}
+
+// TestPrefilterWhitensPeriodicSignal checks the prefilter actually removes
+// energy from a strongly periodic signal, which is what frees bits for the
+// rest of the spectrum.
+func TestPrefilterWhitensPeriodicSignal(t *testing.T) {
+	const (
+		start  = postfilterHistorySampleCount
+		count  = maxFrameSampleCount
+		period = 48
+	)
+	src := make([]float32, start+count+8)
+	for i := range src {
+		src[i] = float32(0.5 * math.Sin(2*math.Pi*1000*float64(i)/48000))
+	}
+	filtered := make([]float32, len(src))
+	copy(filtered, src)
+	applyPrefilter(filtered, src, period, period, count, 0.75, 0.75, 0, 0)
+
+	var before, after float64
+	for i := start; i < start+count; i++ {
+		before += float64(src[i]) * float64(src[i])
+		after += float64(filtered[i]) * float64(filtered[i])
+	}
+	assert.Lessf(t, after, before/2, "prefilter should strongly attenuate a periodic signal")
+}

--- a/internal/celt/synthesis.go
+++ b/internal/celt/synthesis.go
@@ -293,7 +293,7 @@ func (d *Decoder) applyPostfilter(info *frameSideInfo, time []float32, channel i
 	period := max(d.postfilter.period, combFilterMinPeriod)
 	oldPeriod := max(d.postfilter.oldPeriod, combFilterMinPeriod)
 	combFilter(
-		buf,
+		buf, buf,
 		postfilterHistorySampleCount,
 		oldPeriod,
 		period,
@@ -306,7 +306,7 @@ func (d *Decoder) applyPostfilter(info *frameSideInfo, time []float32, channel i
 	if info.lm != 0 && len(time) > shortBlockSampleCount {
 		current := currentPostfilter(info)
 		combFilter(
-			buf,
+			buf, buf,
 			postfilterHistorySampleCount+shortBlockSampleCount,
 			period,
 			max(current.period, combFilterMinPeriod),
@@ -350,7 +350,16 @@ func currentPostfilter(info *frameSideInfo) postFilterState {
 
 // combFilter applies the RFC 6716 Section 4.3.7.1 pitch post-filter taps,
 // cross-fading from the previous filter state over the overlap window.
-func combFilter(buf []float32, start int, period0 int, period1 int, n int, gain0 float32, gain1 float32, tapset0 int, tapset1 int) {
+// combFilter writes the pitch comb filter of src into dst starting at start.
+//
+// dst and src may alias, and the decoder passes the same buffer for both: the
+// taps then read samples this call already wrote, which makes the postfilter
+// recursive (1/(1-g*z^-T)). The encoder's prefilter must pass a separate src so
+// its taps read the untouched input instead, giving the non-recursive
+// (1-g*z^-T) that the postfilter inverts. libopus draws the same distinction by
+// calling comb_filter(in, pre, ...) in the encoder and comb_filter(out, out,
+// ...) in the decoder (celt_encoder.c, celt_decoder.c).
+func combFilter(dst, src []float32, start int, period0 int, period1 int, n int, gain0 float32, gain1 float32, tapset0 int, tapset1 int) {
 	gains := [3][3]float32{
 		{0.3066406250, 0.2170410156, 0.1296386719},
 		{0.4638671875, 0.2680664062, 0},
@@ -363,21 +372,21 @@ func combFilter(buf []float32, start int, period0 int, period1 int, n int, gain0
 	g11 := gain1 * gains[tapset1][1]
 	g12 := gain1 * gains[tapset1][2]
 	overlap := min(shortBlockSampleCount, n)
-	output := buf[start : start+n]
-	previous0 := buf[start-period0 : start-period0+overlap]
-	previous0Minus1 := buf[start-period0-1 : start-period0-1+overlap]
-	previous0Plus1 := buf[start-period0+1 : start-period0+1+overlap]
-	previous0Minus2 := buf[start-period0-2 : start-period0-2+overlap]
-	previous0Plus2 := buf[start-period0+2 : start-period0+2+overlap]
-	previous1 := buf[start-period1 : start-period1+n]
-	previous1Minus1 := buf[start-period1-1 : start-period1-1+n]
-	previous1Plus1 := buf[start-period1+1 : start-period1+1+n]
-	previous1Minus2 := buf[start-period1-2 : start-period1-2+n]
-	previous1Plus2 := buf[start-period1+2 : start-period1+2+n]
+	output := dst[start : start+n]
+	previous0 := src[start-period0 : start-period0+overlap]
+	previous0Minus1 := src[start-period0-1 : start-period0-1+overlap]
+	previous0Plus1 := src[start-period0+1 : start-period0+1+overlap]
+	previous0Minus2 := src[start-period0-2 : start-period0-2+overlap]
+	previous0Plus2 := src[start-period0+2 : start-period0+2+overlap]
+	previous1 := src[start-period1 : start-period1+n]
+	previous1Minus1 := src[start-period1-1 : start-period1-1+n]
+	previous1Plus1 := src[start-period1+1 : start-period1+1+n]
+	previous1Minus2 := src[start-period1-2 : start-period1-2+n]
+	previous1Plus2 := src[start-period1+2 : start-period1+2+n]
 	for i := 0; i < overlap; i++ {
 		window := celtWindow(i)
 		fade := window * window
-		output[i] = output[i] +
+		output[i] = src[start+i] +
 			(1-fade)*g00*previous0[i] +
 			(1-fade)*g01*previous0Minus1[i] +
 			(1-fade)*g01*previous0Plus1[i] +
@@ -390,7 +399,7 @@ func combFilter(buf []float32, start int, period0 int, period1 int, n int, gain0
 			fade*g12*previous1Plus2[i]
 	}
 	for i := overlap; i < n; i++ {
-		output[i] = output[i] +
+		output[i] = src[start+i] +
 			g10*previous1[i] +
 			g11*previous1Minus1[i] +
 			g11*previous1Plus1[i] +

--- a/testdata/encoder-quality-baseline.json
+++ b/testdata/encoder-quality-baseline.json
@@ -3,19 +3,19 @@
   "bitrate": 96000,
   "signals": {
     "burst": {
-      "tier1SnrDb": -2.5
+      "tier1SnrDb": 4.7
     },
     "chirp": {
-      "tier1SnrDb": 3.5
+      "tier1SnrDb": 9.5
     },
     "harmonics": {
-      "tier1SnrDb": -0.6
+      "tier1SnrDb": 15.1
     },
     "onset": {
-      "tier1SnrDb": -2.4
+      "tier1SnrDb": 4.6
     },
     "shaped_noise": {
-      "tier1SnrDb": 0.6
+      "tier1SnrDb": 0.7
     }
   }
 }


### PR DESCRIPTION
#### Description
The pitch pre-filter ran in place, so its taps read samples the same call had just written. That makes it recursive, exactly like the post-filter, and the two stopped being inverses: instead of cancelling, the pair amplifies by 1/(1-g^2). At the gains a periodic signal reaches that is over 2x, and it does not improve with bitrate.

libopus keeps the two asymmetric, and it shows up in comb_filter's arguments:
the encoder calls `comb_filter(in, pre, ...)` with a separate unfiltered source, the decoder calls `comb_filter(out_mem, out_mem, ...)` in place. This gives `combFilter` explicit `dst`/`src` so the encoder can do the same. The decoder passes the same slice for both, so its behaviour is unchanged. `prefilterMem` now carries the unfiltered tail, since that is what the taps read (libopus keeps it from `pre`, not from the output).

Measured on a 1 kHz tone: the round trip through pre-filter and post-filter is now exactly unity at every gain (was 2.03 at g=0.75), and the pre-filter actually whitens - band energy drops instead of growing.

Tier 1 SNRs all turn positive as a result, so the baseline is regenerated:

| signal | before | after |
|---|---|---|
| harmonics | -0.6 | +15.1 |
| burst | -2.5 | +4.7 |
| onset | -2.4 | +4.6 |
| chirp | +3.5 | +9.5 |

The negative baselines were this bug recorded as normal.

#### Reference issue
Fixes #...
