### PR TITLE
Fix CELT forward MDCT aliasing fold

### DIFF
--- a/internal/celt/mdct.go
+++ b/internal/celt/mdct.go
@@ -65,10 +65,8 @@ func forwardMDCT(time []float32) []float32 {
 	deshuffled := make([]float32, n2)
 
 	for i := 0; i < overlap/2; i++ {
-		windowValue := celtWindow(i)
-		// Apply analysis window: multiply (not divide) to mirror the synthesis
-		// windowing in inverseMDCT for TDAC.
-		deshuffled[overlap/2-1-i] = -time[i] * windowValue
+		j := overlap/2 - 1 - i
+		deshuffled[j] = -celtWindow(i)*time[i] + celtWindow(overlap/2+j)*time[overlap/2+j]
 	}
 
 	for i := overlap / 2; i < n4; i++ {
@@ -80,8 +78,8 @@ func forwardMDCT(time []float32) []float32 {
 	}
 
 	for i := 0; i < overlap/2; i++ {
-		windowValue := celtWindow(i)
-		deshuffled[n2-overlap/2+i] = time[n2+overlap-1-i] * windowValue
+		deshuffled[n2-overlap/2+i] = celtWindow(i)*time[n2+overlap-1-i] +
+			celtWindow(overlap-1-i)*time[n2+i]
 	}
 
 	postRotated := make([]float32, n2)
@@ -170,8 +168,8 @@ func forwardMDCTWithScratch(
 	freq := scratch.freq[channel]
 
 	for i := 0; i < overlap/2; i++ {
-		windowValue := celtWindow(i)
-		deshuffled[overlap/2-1-i] = -time[i] * windowValue
+		j := overlap/2 - 1 - i
+		deshuffled[j] = -celtWindow(i)*time[i] + celtWindow(overlap/2+j)*time[overlap/2+j]
 	}
 
 	for i := overlap / 2; i < n4; i++ {
@@ -183,8 +181,8 @@ func forwardMDCTWithScratch(
 	}
 
 	for i := 0; i < overlap/2; i++ {
-		windowValue := celtWindow(i)
-		deshuffled[n2-overlap/2+i] = time[n2+overlap-1-i] * windowValue
+		deshuffled[n2-overlap/2+i] = celtWindow(i)*time[n2+overlap-1-i] +
+			celtWindow(overlap-1-i)*time[n2+i]
 	}
 
 	for i := range n4 {

--- a/internal/celt/reconstruction_test.go
+++ b/internal/celt/reconstruction_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// alignedSNR returns the best SNR over a delay search with the best single gain
+// removed, so the codec's constant delay and any overall level offset cannot
+// show up as reconstruction error.
+func alignedSNR(ref, got []float32, maxDelay int) float64 {
+	best := math.Inf(-1)
+	for delay := range maxDelay {
+		var signal, dot, energy float64
+		for i := 0; i+delay < len(got) && i < len(ref); i++ {
+			r := float64(ref[i])
+			g := float64(got[i+delay])
+			signal += r * r
+			dot += r * g
+			energy += g * g
+		}
+		if energy == 0 || signal == 0 {
+			continue
+		}
+		gain := dot / energy
+		residual := signal - 2*gain*dot + gain*gain*energy
+		if residual <= 0 {
+			continue
+		}
+		best = math.Max(best, 10*math.Log10(signal/residual))
+	}
+
+	return best
+}
+
+// TestReconstructionWithoutQuantization runs the encoder's analysis and the
+// decoder's synthesis back to back with quantization skipped: the MDCT
+// coefficients are handed over with unit band energies, so denormaliseBands is
+// a no-op and nothing is rounded anywhere.
+//
+// Any error left here is structural — windowing, overlap-add, emphasis — and no
+// bitrate can remove it. The MDCT pair only reconstructs if the forward fold is
+// the exact adjoint of the inverse unfold, so this catches a broken fold that
+// per-band energy checks and FinalRange comparisons both miss.
+func TestReconstructionWithoutQuantization(t *testing.T) {
+	const (
+		frameCount  = 8
+		frameLength = maxFrameSampleCount
+	)
+
+	mode := DefaultMode()
+	state := newAnalysisState()
+	var mdctScratch forwardMDCTScratch
+	var fftScratch []complex32
+	decoder := &Decoder{}
+	decoder.Reset()
+
+	source := make([]float32, frameLength*frameCount)
+	for i := range source {
+		source[i] = float32(0.5 * math.Sin(2*math.Pi*1000*float64(i)/sampleRate))
+	}
+
+	var unitEnergy [2][maxBands]float32
+	for band := range maxBands {
+		unitEnergy[0][band] = 1
+		unitEnergy[1][band] = 1
+	}
+
+	decoded := make([]float32, 0, frameLength*frameCount)
+	for frame := range frameCount {
+		pcm := [][]float32{source[frame*frameLength : (frame+1)*frameLength]}
+		// No transient and no pre-filter: one long MDCT per frame, and no
+		// post-filter needed on the way back.
+		res, err := analyzeFrame(
+			mode, pcm, 0, maxBands, &state, &mdctScratch, &fftScratch, false, false, 0, 0, 0)
+		require.NoErrorf(t, err, "frame %d", frame)
+
+		info := res.info
+		info.outputChannelCount = 1
+		info.outputSampleRate = sampleRate
+
+		out := make([]float32, frameLength)
+		decoder.denormaliseAndSynthesize(&info, res.mdct[0], nil, unitEnergy, out)
+		decoded = append(decoded, out...)
+	}
+
+	// Skip the first frame: the MDCT overlap and the emphasis memories are
+	// still filling there.
+	snr := alignedSNR(source[frameLength:], decoded[frameLength:], 300)
+	assert.Greaterf(t, snr, 40.0,
+		"transform chain must reconstruct without quantization, got %.2f dB", snr)
+}

--- a/testdata/encoder-quality-baseline.json
+++ b/testdata/encoder-quality-baseline.json
@@ -3,16 +3,16 @@
   "bitrate": 96000,
   "signals": {
     "burst": {
-      "tier1SnrDb": 4.7
+      "tier1SnrDb": 4.1
     },
     "chirp": {
-      "tier1SnrDb": 9.5
+      "tier1SnrDb": 14.5
     },
     "harmonics": {
-      "tier1SnrDb": 15.1
+      "tier1SnrDb": 27.8
     },
     "onset": {
-      "tier1SnrDb": 4.6
+      "tier1SnrDb": 4.0
     },
     "shaped_noise": {
       "tier1SnrDb": 0.7


### PR DESCRIPTION
#### Description
The forward MDCT's fold wrote a single windowed term where it needs the sum of two. The consequence is visible by inspection: of the 1080 input samples, 120 were never read - the four loops covered `time[0..59]`, `[120..539]`, `[540..959]` and `[1020..1079]`, skipping `[60..119]` and `[960..1019]`

Without the aliased term, the time-domain aliasing that the decoder's overlap-add is supposed to cancel never gets set up, so the transform does not reconstruct. That is an error floor no bitrate can lower, because it has nothing to do with quantisation

libopus builds each folded value from two windowed input samples, with the window walked in opposite directions (`celt/mdct.c`). The missing terms are exactly the adjoint of the two writes `inverseMDCT` makes when it unfolds, and they read precisely the samples that were being skipped

Verified two independent ways:

- The patched forward now matches the exact adjoint of `inverseMDCT` (built by probing it with basis vectors) to 1.7e-7 across all 960 coefficients, with a clean 1/N4 scale factor
- Reconstruction through the real analysis and synthesis paths, with quantisation skipped, goes from 10.36 dB to 49.79 dB. The residual error is concentrated nowhere in particular now; before the fix it sat entirely in the two overlap regions (0.74 dB in the last 120 samples of every frame)

A pure 1 kHz tone now improves with bitrate - 26.5 dB at 64k up to 31.7 dB at 256k - where before it was flat at ~16.3 dB from 64k all the way to 510k

Tier 1 SNRs improve on tonal content, so the baseline is regenerated:

| signal | before | after |
|---|---|---|
| harmonics | 15.1 | 27.8 |
| chirp | 9.5 | 14.5 |
| shaped_noise | 0.7 | 0.7 |
| burst | 4.7 | 4.1 |
| onset | 4.6 | 4.0 |

Noise and transient content does not benefit, and moves slightly the other way. That is consistent with what is left: transient detection never fires, so short blocks and anti-collapse are both unreachable today. Separate work.

`reconstruction_test.go` is the regression guard. It runs the encoder's analysis into the decoder's synthesis with unit band energies, so nothing is quantised and any structural error shows up directly. Neither `FinalRange` comparisons nor per-band energy checks catch this class of bug: the range coder stays perfectly in sync while the transform silently fails to reconstruct.

#### Reference issue
Fixes #...
