### PR TITLE
Report clamped Laplace value back

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -660,7 +660,11 @@ func TestVBRPacketRoundTripMultiFrame(t *testing.T) {
 		out := make([]float32, encoderTestFrameSampleCount)
 		_, _, err = dec.DecodeFloat32(packet[:n], out)
 		require.NoError(t, err)
-		assert.Greater(t, vectorEnergyFloat32(out), 1e-6)
+		// i%3 == 0 feeds digital silence, which must not be required to decode
+		// into energy. Only the frames that actually carry signal are checked.
+		if i%3 != 0 {
+			assert.Greaterf(t, vectorEnergyFloat32(out), 1e-6, "frame %d", i)
+		}
 	}
 }
 

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -691,13 +691,14 @@ func (e *Encoder) encodeCoarseEnergyDelta(info *frameSideInfo, probModel []uint8
 	switch {
 	case bitsLeft >= 15:
 		probIndex := 2 * min(band, maxBands-1)
-		e.rangeEncoder.EncodeLaplace(
+
+		// The Laplace coder clamps values its tail cannot represent, so the
+		// energy state has to follow what the decoder will actually see.
+		return e.rangeEncoder.EncodeLaplace(
 			uint32(probModel[probIndex])<<7,
 			uint32(probModel[probIndex+1])<<6,
 			delta,
 		)
-
-		return delta
 	case bitsLeft >= 2:
 		if delta < -1 {
 			delta = -1

--- a/internal/rangecoding/decoder.go
+++ b/internal/rangecoding/decoder.go
@@ -83,7 +83,8 @@ type Decoder struct {
 const (
 	maxUniformRangeCoderBits = 8
 	laplaceTotal             = 32768
-	laplaceMinProbability    = 1
+	laplaceLogMinProbability = 0
+	laplaceMinProbability    = 1 << laplaceLogMinProbability
 	laplaceGuaranteedDeltas  = 16
 )
 

--- a/internal/rangecoding/encoder.go
+++ b/internal/rangecoding/encoder.go
@@ -258,9 +258,14 @@ func (e *Encoder) EncodeUniform(total, symbol uint32) {
 // (the geometric decay rate of adjacent-magnitude frequencies, Q15).
 //
 // https://datatracker.ietf.org/doc/html/rfc6716#section-4.3.2.1
-func (e *Encoder) EncodeLaplace(fs0, decay uint32, value int) {
-	low, high := laplaceInterval(fs0, decay, value)
+// EncodeLaplace encodes a Laplace-distributed value and returns the value the
+// decoder will recover, which differs from the input when the tail of the
+// distribution cannot represent it (see laplaceInterval).
+func (e *Encoder) EncodeLaplace(fs0, decay uint32, value int) int {
+	low, high, encoded := laplaceInterval(fs0, decay, value)
 	e.EncodeCumulative(low, high, laplaceTotal)
+
+	return encoded
 }
 
 // EncodeRawBits appends n bits of value to the raw-bits region at the end of
@@ -555,37 +560,52 @@ func bitMask(n uint) uint32 {
 // values of equal magnitude share a frequency but occupy disjoint halves of the
 // cumulative axis: the positive half comes first, the negative half follows
 // immediately.  laplaceFirstDecayFrequency() computes the per-step decay.
-func laplaceInterval(fs0 uint32, decay uint32, value int) (uint32, uint32) {
+// laplaceInterval returns the coding interval for value plus the magnitude the
+// interval actually represents. The tail of the distribution only has room for
+// a bounded number of steps, so a large value gets clamped to the last one that
+// fits (ec_laplace_encode, celt/laplace.c). The clamped value is what the
+// decoder will recover, so callers must propagate it into any state they derive
+// from the encoded symbol rather than assuming their input was coded verbatim.
+func laplaceInterval(fs0 uint32, decay uint32, value int) (low, high uint32, encoded int) {
 	if value == 0 {
-		return 0, min(fs0, uint32(laplaceTotal))
+		return 0, min(fs0, uint32(laplaceTotal)), 0
 	}
 
-	magnitude := value
-	if magnitude < 0 {
-		magnitude = -magnitude
-	}
-
-	low := fs0
-	frequency := laplaceFirstDecayFrequency(fs0, decay) + laplaceMinProbability
-	currentMagnitude := 1
-	for currentMagnitude < magnitude && frequency > laplaceMinProbability {
-		low += 2 * frequency
-		frequency = ((2*frequency - 2*laplaceMinProbability) * decay) >> 15
-		frequency += laplaceMinProbability
-		currentMagnitude++
-	}
-	if currentMagnitude < magnitude {
-		deltaCount := uint32(magnitude - currentMagnitude) //nolint:gosec // G115
-		low += 2 * deltaCount * laplaceMinProbability
-		frequency = laplaceMinProbability
-	}
+	// sign is 0 for positive values and -1 for negative ones, mirroring the
+	// reference's branch-free sign handling.
+	sign := 0
 	if value < 0 {
-		return min(low, uint32(laplaceTotal)), min(low+frequency, uint32(laplaceTotal))
+		sign = -1
+	}
+	magnitude := (value + sign) ^ sign
+
+	fl := int(fs0)
+	fs := int(laplaceFirstDecayFrequency(fs0, decay))
+	step := 1
+	for ; fs > 0 && step < magnitude; step++ {
+		fs *= 2
+		fl += fs + 2*laplaceMinProbability
+		fs = (fs * int(decay)) >> 15
 	}
 
-	low += frequency
+	if fs == 0 {
+		// Past the decaying part every step costs the minimum probability, so
+		// only so many of them fit before the interval is exhausted.
+		maxSteps := (laplaceTotal - fl + laplaceMinProbability - 1) >> laplaceLogMinProbability
+		maxSteps = (maxSteps - sign) >> 1
+		extra := min(magnitude-step, maxSteps-1)
+		fl += (2*extra + 1 + sign) * laplaceMinProbability
+		fs = min(laplaceMinProbability, laplaceTotal-fl)
+		encoded = (step + extra + sign) ^ sign
+	} else {
+		fs += laplaceMinProbability
+		if sign == 0 {
+			fl += fs
+		}
+		encoded = value
+	}
 
-	return min(low, uint32(laplaceTotal)), min(low+frequency, uint32(laplaceTotal))
+	return uint32(fl), uint32(fl + fs), encoded //nolint:gosec // G115: bounded by laplaceTotal.
 }
 
 // boolToInt converts a bool to 0 or 1.

--- a/internal/rangecoding/encoder_test.go
+++ b/internal/rangecoding/encoder_test.go
@@ -358,3 +358,23 @@ func assertFuzzOperation(t *testing.T, decoder *Decoder, op fuzzOperation) {
 		assert.Equal(t, op.rawValue, decoder.DecodeRawBits(op.rawBits))
 	}
 }
+
+// TestEncodeLaplaceClampsToDecodableValue checks that when a value exceeds
+// what the tail of the Laplace distribution can represent, EncodeLaplace
+// returns the clamped value instead of the input — that is what the decoder
+// will actually recover, and callers must use it for any state they derive
+// from the encoded symbol (e.g. CELT's coarse energy prediction).
+func TestEncodeLaplaceClampsToDecodableValue(t *testing.T) {
+	const fs0, decay = 100, 1000
+
+	encoder := &Encoder{}
+	encoder.Init()
+	encoded := encoder.EncodeLaplace(fs0, decay, 500)
+	assert.NotEqual(t, 500, encoded, "500 should fall in the clamped tail")
+
+	packet := encoder.Done()
+	decoder := &Decoder{}
+	decoder.Init(packet)
+	assert.Equal(t, encoded, decoder.DecodeLaplace(fs0, decay),
+		"the decoder must recover exactly the value EncodeLaplace returned, not the original input")
+}


### PR DESCRIPTION
#### Description
`ec_laplace_encode` clamps values the tail of the distribution cannot represent and writes the clamped value back through its pointer (`celt/laplace.c:51`), and `quant_coarse_energy` uses that value for its state update (`celt/quant_bands.c:246`). `laplaceInterval` instead saturated the interval and told the caller the original value had been coded, so the energy state the encoder tracked diverged from what the decoder would recover

`EncodeLaplace` now returns the value that was actually coded, and `encodeCoarseEnergyDelta` propagates it into `previousLogE` instead of the input `delta`

One existing test changed: `TestVBRPacketRoundTripMultiFrame` fed digital silence and required the decoded output to have energy, which only held because this divergence was injecting spurious energy into what should decode as silence. The assertion is now limited to the frames that actually carry signal

New test: `TestEncodeLaplaceClampsToDecodableValue`, exercising the clamp directly with parameters that trigger it and checking the decoder recovers exactly the returned value

#### Reference issue
Fixes #...
