### PR TITLE
Pad CELT packets to allocated size

### DIFF
--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -565,7 +565,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	e.updatePrefilterState(&info, prefilterEnabled, pitchPeriod, prefilterGain, prefilterQq, prefilterTapset)
 
 	if e.rangeEncoder.Tell() > info.totalBits {
-		return e.rangeEncoder.FlushInto(dst), nil
+		return e.rangeEncoder.FlushIntoPadded(dst, frameBytes), nil
 	}
 
 	e.encodeSilenceFlag()
@@ -667,7 +667,11 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 
 	e.rng = e.rangeEncoder.FinalRange()
 
-	return e.rangeEncoder.FlushInto(dst), nil
+	// Pad to the size the allocation was derived from (info.totalBits), so the
+	// decoder re-derives the same allocation from the packet it receives. Under
+	// VBR that size is the per-frame target rather than frameBytes, which is
+	// what keeps packet sizes varying.
+	return e.rangeEncoder.FlushIntoPadded(dst, effectiveBytes), nil
 }
 
 func smallEnergySymbol(delta int) uint32 {

--- a/internal/celt/packet_padding_test.go
+++ b/internal/celt/packet_padding_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func paddingTestSignal() []float32 {
+	pcm := make([]float32, maxFrameSampleCount)
+	for i := range pcm {
+		pcm[i] = float32(0.5 * math.Sin(2*math.Pi*1000*float64(i)/48000))
+	}
+
+	return pcm
+}
+
+// TestEncodeFrameFillsRequestedSize checks the encoder emits exactly the frame
+// size its bit allocation was derived from. A shorter packet makes the decoder
+// derive a different allocation, so the two sides disagree on how many raw bits
+// each band's fine energy occupies.
+func TestEncodeFrameFillsRequestedSize(t *testing.T) {
+	pcm := paddingTestSignal()
+	for _, frameBytes := range []int{240, 640, 1275} {
+		encoder := NewEncoder()
+		packet := make([]byte, frameBytes)
+		n, err := encoder.EncodeFrame([][]float32{pcm}, packet, frameBytes, 0, maxBands)
+		require.NoErrorf(t, err, "frameBytes %d", frameBytes)
+		assert.Equalf(t, frameBytes, n, "packet must fill the requested frame size")
+	}
+}
+
+// TestEncodeDecodeAgreeOnBandEnergy is the invariant the padding protects: both
+// sides run the same allocation, so they must land on identical band energies.
+// Fine energy rides on raw bits, which do not disturb the range coder state, so
+// a mismatch here would not show up as a FinalRange desync.
+func TestEncodeDecodeAgreeOnBandEnergy(t *testing.T) {
+	pcm := paddingTestSignal()
+	for _, frameBytes := range []int{240, 640, 1275} {
+		encoder := NewEncoder()
+		decoder := &Decoder{}
+		decoder.Reset()
+		packet := make([]byte, frameBytes)
+		out := make([]float32, maxFrameSampleCount)
+
+		// Three frames so the inter-frame energy prediction is exercised: a
+		// divergence compounds through it rather than staying local.
+		for frame := range 3 {
+			n, err := encoder.EncodeFrame([][]float32{pcm}, packet, frameBytes, 0, maxBands)
+			require.NoErrorf(t, err, "frameBytes %d frame %d", frameBytes, frame)
+			require.NoErrorf(t,
+				decoder.Decode(packet[:n], out, false, 1, maxFrameSampleCount, 0, maxBands),
+				"frameBytes %d frame %d", frameBytes, frame)
+			require.Equalf(t, encoder.FinalRange(), decoder.FinalRange(),
+				"frameBytes %d frame %d: range coder desync", frameBytes, frame)
+		}
+
+		for band := range maxBands {
+			assert.InDeltaf(t, encoder.previousLogE[0][band], decoder.previousLogE[0][band], 1e-6,
+				"frameBytes %d band %d: encoder and decoder disagree on band energy", frameBytes, band)
+		}
+	}
+}

--- a/internal/rangecoding/encoder.go
+++ b/internal/rangecoding/encoder.go
@@ -406,6 +406,24 @@ func (e *Encoder) FlushInto(dst []byte) int {
 	return n
 }
 
+// FlushIntoPadded finalizes the frame into dst and zero-fills the result out to
+// size bytes when the coded data is shorter.
+//
+// CELT derives its bit allocation from the frame size the encoder was asked
+// for, and the decoder re-derives it from the size of the packet it receives.
+// Emitting a shorter packet makes the two sides compute different allocations,
+// so they disagree on how many raw bits each band's fine energy occupies and
+// the decoder reads that region at the wrong offsets. libopus avoids this by
+// initializing the range coder with the target size up front and clearing the
+// unused middle in ec_enc_done (celt/entenc.c).
+func (e *Encoder) FlushIntoPadded(dst []byte, size int) int {
+	remainingBits := e.flush()
+	n := max(e.outputSize(remainingBits), size)
+	e.writeOutput(dst, n, remainingBits)
+
+	return n
+}
+
 func (e *Encoder) flush() int {
 	remainingBits := e.flushRangeCoder()
 	if e.rem >= 0 || e.extBytes > 0 {
@@ -424,24 +442,20 @@ func (e *Encoder) outputSize(remainingBits int) int {
 	return len(e.buf) + len(e.tail) + boolToInt(e.shouldWritePartialToNewByte(freeBits))
 }
 
-func (e *Encoder) writeOutput(dst []byte, n, remainingBits int) {
-	freeBits := uint(0)
-	if remainingBits < 0 {
-		freeBits = uint(-remainingBits) //nolint:gosec // G115
-	}
-
+func (e *Encoder) writeOutput(dst []byte, n, _ int) {
+	// Layout mirrors ec_enc_done (celt/entenc.c): range-coded bytes at the
+	// front, raw bits growing backwards from the end, and the space between
+	// them cleared. Any leftover raw bits go in the byte just before the raw
+	// region, which is the last range-coded byte when the two regions meet.
 	copy(dst, e.buf)
+	clear(dst[len(e.buf) : n-len(e.tail)])
 	for index, value := range e.tail {
 		dst[n-1-index] = value
 	}
 
 	if e.nendBits > 0 {
 		partial := byte(e.endWindow & uint64(bitMask(e.nendBits))) //nolint:gosec // G115: masked to at most 8 bits.
-		if e.shouldWritePartialToNewByte(freeBits) {
-			dst[len(e.buf)] = partial
-		} else {
-			dst[len(e.buf)-1] |= partial
-		}
+		dst[n-len(e.tail)-1] |= partial
 	}
 }
 


### PR DESCRIPTION
#### Description
The encoder derives its bit allocation from the frame size it was asked for, but emitted fewer bytes than that: 640 requested became 624, and 1275 became 626. The decoder then re-derives the allocation from the short packet it receives, lands on a different fineQuant, and reads the fine-energy raw bits at the wrong offsets. Encoder and decoder end up disagreeing on band energy by up to 1.08 in the log2 domain

FinalRange still matched, which is why conformance never caught it - fine energy rides on raw bits, and those do not touch the range coder state.

FlushIntoPadded fills the packet out to the size the allocation was derived from, following ec_enc_done (celt/entenc.c): coded bytes at the front, raw bits growing from the end, the gap between them cleared to zero.

One detail worth calling out: the target is `effectiveBytes`, not `frameBytes`. The allocation comes from `info.totalBits = effectiveBytes * 8`, and under VBR `effectiveBytes` is the per-frame target `applyVBR` computed, not the fixed frame size. Padding to `frameBytes` would make every packet the same length and defeat VBR.

`max|encoderEnergy - decoderEnergy|` goes from 1.08 to exactly 0.

#### Reference issue
Fixes #...
