### PR TITLE
Add CELT encoder band skipping

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -66,6 +66,10 @@ func (d *Decoder) computeAllocation(info *frameSideInfo, bits int) allocationSta
 		nil,
 		0,
 		0,
+		// The decoder reads the skip bits the encoder wrote, so it needs
+		// neither the hysteresis state nor the signal bandwidth.
+		0,
+		0,
 	)
 	state.balance = balance
 
@@ -90,6 +94,8 @@ func computeAllocation(
 	rangeEncoder *rangecoding.Encoder,
 	targetIntensity int,
 	targetDualStereo int,
+	prevCodedBands int,
+	signalBandwidth int,
 ) int {
 	if total < 0 {
 		total = 0
@@ -218,6 +224,8 @@ func computeAllocation(
 		rangeEncoder,
 		targetIntensity,
 		targetDualStereo,
+		prevCodedBands,
+		signalBandwidth,
 	)
 }
 
@@ -247,6 +255,8 @@ func interpolateBitsToPulses(
 	rangeEncoder *rangecoding.Encoder,
 	targetIntensity int,
 	targetDualStereo int,
+	prevCodedBands int,
+	signalBandwidth int,
 ) int {
 	allocationFloor := channelCount << bitResolution
 	stereo := boolIndex(channelCount > 1)
@@ -318,11 +328,32 @@ func interpolateBitsToPulses(
 			if rangeDecoder != nil {
 				skipBit = rangeDecoder.DecodeSymbolLogP(1) != 0
 			} else {
-				// Encoder keeps every band that fits its threshold; emit 1 so
-				// the decoder stops the skip walk here and codedBands stays
-				// at end.
-				skipBit = true
-				rangeEncoder.EncodeSymbolLogP(1, 1)
+				// This decision is the only part of the allocation that is not
+				// mandated by the bitstream: the encoder is free to skip bands
+				// as long as it signals them (libopus celt/rate.c). Skipping a
+				// band whose budget is too thin to code meaningfully frees its
+				// bits for the bands below, which fold into it instead.
+				//
+				// Index mapping against the reference: this loop already
+				// decremented codedBands, so band is the reference's j and
+				// codedBands+1 is its codedBands.
+				depthThreshold := 0
+				if codedBands+1 > 17 {
+					// Hysteresis on the previous frame's band count keeps bands
+					// from oscillating in and out of the stream.
+					depthThreshold = 9
+					if band < prevCodedBands {
+						depthThreshold = 7
+					}
+				}
+				keep := codedBands+1 <= start+2 ||
+					(bandBits > (depthThreshold*bandWidth<<lm<<bitResolution)>>4 && band <= signalBandwidth)
+				skipBit = keep
+				if keep {
+					rangeEncoder.EncodeSymbolLogP(1, 1)
+				} else {
+					rangeEncoder.EncodeSymbolLogP(1, 0)
+				}
 			}
 			if skipBit {
 				codedBands++

--- a/internal/celt/band_skip_test.go
+++ b/internal/celt/band_skip_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bandSkipSignal builds a broadband stereo frame: a harmonic stack plus a noise
+// floor, so the top bands carry enough energy to reach the skip decision.
+func bandSkipSignal(offset int) [][]float32 {
+	left := make([]float32, maxFrameSampleCount)
+	right := make([]float32, maxFrameSampleCount)
+	seed := uint32(12345 + offset) //nolint:gosec // G115: test offsets are small and positive.
+	for i := range left {
+		t := float64(i+offset) / sampleRate
+		var v float64
+		for h := 1; h <= 12; h++ {
+			v += (1.0 / float64(h)) * math.Sin(2*math.Pi*220*float64(h)*t)
+		}
+		seed = 1664525*seed + 1013904223
+		noise := float64(int32(seed>>8)%2000-1000) / 1000.0
+		left[i] = float32(0.25*v + 0.02*noise)
+		right[i] = float32(0.25*v*0.9 + 0.02*noise)
+	}
+
+	return [][]float32{left, right}
+}
+
+// TestBandSkipRoundTrip drives the encoder at a bitrate where the depth
+// threshold skips the top band and checks the decoder stays in sync. The skip
+// bits are written inside the allocation walk, so a desync here would mean the
+// decoder read them in a different order than the encoder wrote them.
+func TestBandSkipRoundTrip(t *testing.T) {
+	const frameBytes = 240 // 96 kbps at 20 ms
+
+	encoder := NewEncoder()
+	decoder := &Decoder{}
+	decoder.Reset()
+
+	packet := make([]byte, frameBytes)
+	out := make([]float32, 2*maxFrameSampleCount)
+	skipped := false
+	for frame := range 10 {
+		n, err := encoder.EncodeFrame(bandSkipSignal(frame*maxFrameSampleCount), packet, frameBytes, 0, maxBands)
+		require.NoErrorf(t, err, "frame %d", frame)
+
+		require.NoErrorf(t,
+			decoder.Decode(packet[:n], out, true, 2, maxFrameSampleCount, 0, maxBands), "frame %d", frame)
+		require.Equalf(t, encoder.FinalRange(), decoder.FinalRange(), "frame %d: range coder desync", frame)
+
+		if encoder.lastCodedBands < maxBands {
+			skipped = true
+		}
+	}
+	assert.True(t, skipped, "expected the depth threshold to skip at least one band at 96 kbps stereo")
+}
+
+// TestBandSkipHysteresisSeed checks the first frame seeds lastCodedBands
+// directly instead of taking the one-step clamp, which would otherwise pin the
+// count near zero for several frames (libopus celt_encoder.c).
+func TestBandSkipHysteresisSeed(t *testing.T) {
+	encoder := NewEncoder()
+	require.Zero(t, encoder.lastCodedBands, "a fresh encoder has no previous frame")
+
+	packet := make([]byte, 240)
+	_, err := encoder.EncodeFrame(bandSkipSignal(0), packet, 240, 0, maxBands)
+	require.NoError(t, err)
+
+	assert.Greater(t, encoder.lastCodedBands, 1,
+		"the first frame must seed the band count directly, not clamp from zero")
+}
+
+// TestBandSkipResetClearsHysteresis checks Reset clears the carry-over so a
+// reused encoder does not inherit the previous stream's band count.
+func TestBandSkipResetClearsHysteresis(t *testing.T) {
+	encoder := NewEncoder()
+	packet := make([]byte, 240)
+	_, err := encoder.EncodeFrame(bandSkipSignal(0), packet, 240, 0, maxBands)
+	require.NoError(t, err)
+	require.NotZero(t, encoder.lastCodedBands)
+
+	encoder.Reset()
+	assert.Zero(t, encoder.lastCodedBands)
+}

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -47,7 +47,11 @@ type Encoder struct {
 	prevSpreadAvg      float32
 	prevSpreadDecision int
 	prevIntensityBand  int
-	prevLogBandAmp     [2][maxBands]float32
+	// lastCodedBands feeds the band-skip hysteresis in computeAllocation
+	// (st->lastCodedBands in libopus celt_encoder.c). Zero means "no previous
+	// frame", which the update below seeds directly instead of clamping.
+	lastCodedBands int
+	prevLogBandAmp [2][maxBands]float32
 
 	// Application mode plumbing — set by root encoder via setter methods.
 	vbr            bool
@@ -114,6 +118,7 @@ func (e *Encoder) Reset() {
 	e.prevSpreadAvg = 0
 	e.prevSpreadDecision = defaultSpreadDecision
 	e.prevIntensityBand = 0
+	e.lastCodedBands = 0
 	e.analysis.prefilter = postFilterState{}
 
 	e.vbrReservoir = 0
@@ -796,8 +801,20 @@ func (e *Encoder) computeAllocationMono(
 		&e.rangeEncoder,
 		targetIntensity,
 		targetDualStereo,
+		e.lastCodedBands,
+		// Without the tonality analysis pipeline libopus falls back to end-1,
+		// which makes the band<=signalBandwidth half of the skip test always
+		// true and leaves the decision to the depth threshold alone.
+		info.endBand-1,
 	)
 	state.balance = balance
+	// Track the band count for the next frame's hysteresis, moving one step at
+	// a time once seeded (libopus celt_encoder.c).
+	if e.lastCodedBands != 0 {
+		e.lastCodedBands = min(e.lastCodedBands+1, max(e.lastCodedBands-1, state.codedBands))
+	} else {
+		e.lastCodedBands = state.codedBands
+	}
 
 	return state
 }


### PR DESCRIPTION
#### Description
The encoder always emitted 1 for the optional band-skip bit, so a high band that barely earns its keep never gets folded into the bands below, even when it has almost nothing to spend. libopus (`celt/rate.c`) makes a real decision here, with hysteresis on the previous frame's band count via `lastCodedBands`. The comment there is explicit about why this exists: it's the one part of the allocation that isn't mandated by the bitstream — any skip decision the encoder makes is legal as long as it signals it.

`signalBandwidth` is fixed to `end-1`. Without the tonality analysis pipeline that's what libopus falls back to as well, so the depth-threshold half of the decision does the work on its own.

I re-measured this after the MDCT/pre-filter/padding/Laplace fixes landed — the first pass was against a broken encoder and the number wasn't trustworthy. Aligned SNR (delay + gain compensated) on stereo music at 96 kbps: **2.49 dB with the skip vs 1.77 dB without**. At 64 kbps there's no difference, since the mandatory force-skip already drops that band either way.

#### Reference issue
Fixes #...
