### PR TITLE
Port transient_analysis, fix stereo short-block desync

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -111,9 +111,15 @@ func TestEncodeFloat32StereoRoundTrip(t *testing.T) {
 	decoder, err := NewDecoderWithOutput(48000, 2)
 	require.NoError(t, err)
 
-	pcm := testEncoderStereoSineFloat32()
 	packet := make([]byte, 256)
 
+	// Warm up the encoder on a phase-continuous steady tone first so the
+	// measured frame isn't the cold-start onset, which the transient detector
+	// correctly flags as transient and which this test isn't meant to exercise.
+	_, err = encoder.EncodeFloat32(testEncoderStereoSineFloat32At(0), packet)
+	require.NoError(t, err)
+
+	pcm := testEncoderStereoSineFloat32At(encoderTestFrameSampleCount)
 	n, err := encoder.EncodeFloat32(pcm, packet)
 	require.NoError(t, err)
 	require.Positive(t, n)
@@ -791,10 +797,18 @@ func testEncoderSineFloat32() []float32 {
 }
 
 func testEncoderStereoSineFloat32() []float32 {
+	return testEncoderStereoSineFloat32At(0)
+}
+
+// testEncoderStereoSineFloat32At generates a frame of the same dual-tone
+// stereo signal starting at sampleOffset, so consecutive frames stay
+// phase-continuous instead of restarting the tone from zero each time.
+func testEncoderStereoSineFloat32At(sampleOffset int) []float32 {
 	pcm := make([]float32, encoderTestFrameSampleCount*2)
 	for i := range encoderTestFrameSampleCount {
-		left := float32(math.Sin(2 * math.Pi * 440 * float64(i) / 48000))
-		right := float32(math.Sin(2 * math.Pi * 660 * float64(i) / 48000))
+		sample := sampleOffset + i
+		left := float32(math.Sin(2 * math.Pi * 440 * float64(sample) / 48000))
+		right := float32(math.Sin(2 * math.Pi * 660 * float64(sample) / 48000))
 		pcm[i*2] = left
 		pcm[i*2+1] = right
 	}

--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -13,23 +13,34 @@ const preemphasisCoefficient = 0.85000610
 // matching libopus dc_reject (src/opus_encoder.c:479-507).
 const dcBlockCutoffHz = 3.0
 
-// transientRatioThreshold is the minimum ratio between the energy of the
-// second half of the frame and the first half that the detector reports as
-// a transient. It was calibrated empirically against the synthetic fixtures
-// in analysis_test.go.
-const transientRatioThreshold = 1.5
-
 type analysisState struct {
-	prevPCM        [2][]float32
-	preemphasisMem [2]float32
-	dcBlockMem     [2]float32
-	preScratch     [2][]float32
-	mdctInput      [2][]float32
-	transientMDCT  [2][]float32
-	prefilterMem   [2][]float32
-	prefilter      postFilterState
-	prefilterBuf   [2][]float32
-	prefilterOut   [2][]float32
+	prevPCM           [2][]float32
+	preemphasisMem    [2]float32
+	dcBlockMem        [2]float32
+	preScratch        [2][]float32
+	mdctInput         [2][]float32
+	transientMDCT     [2][]float32
+	prefilterMem      [2][]float32
+	prefilter         postFilterState
+	prefilterBuf      [2][]float32
+	prefilterOut      [2][]float32
+	transientProbe    [2][]float32
+	transientEnvelope [2][]float32
+	// transientHistory holds the last shortBlockSampleCount samples of the
+	// DC-blocked + pre-emphasized (but not pitch-whitened) signal, updated by
+	// detectTransient every frame. prevPCM can't serve this role: it's
+	// captured after the pitch pre-filter runs, so it goes whitened whenever
+	// the pre-filter is active, and libopus's own history source for this
+	// (prefilter_mem) is specifically the unwhitened tail.
+	transientHistory [2][]float32
+	// transientDCMem/transientPreMem are the probe's own filter memories,
+	// separate from dcBlockMem/preemphasisMem. detectTransient runs before
+	// analyzeFrame each frame, so borrowing the real memories would only
+	// stay correct if analyzeFrame always ran right after with the same
+	// samples — true in the real encoder, but a landmine for anything that
+	// calls detectTransient on its own (tests included).
+	transientDCMem  [2]float32
+	transientPreMem [2]float32
 }
 
 type analysisResult struct {
@@ -68,6 +79,18 @@ func newAnalysisState() analysisState {
 		prefilterOut: [2][]float32{
 			make([]float32, postfilterHistorySampleCount+maxFrame),
 			make([]float32, postfilterHistorySampleCount+maxFrame),
+		},
+		transientProbe: [2][]float32{
+			make([]float32, shortBlockSampleCount+maxFrame),
+			make([]float32, shortBlockSampleCount+maxFrame),
+		},
+		transientEnvelope: [2][]float32{
+			make([]float32, shortBlockSampleCount+maxFrame),
+			make([]float32, shortBlockSampleCount+maxFrame),
+		},
+		transientHistory: [2][]float32{
+			make([]float32, shortBlockSampleCount),
+			make([]float32, shortBlockSampleCount),
 		},
 	}
 
@@ -189,64 +212,131 @@ func analyzeTransientChannel(
 	}
 }
 
-// detectTransient reports whether any channel of the input PCM contains a
-// transient using a half-frame energy ratio.
-//
-// A mid-frame impulse concentrates energy in the second half of the frame;
-// a steady sine distributes it roughly evenly. A channel is transient when
-// the ratio exceeds transientRatioThreshold; the frame is transient if any
-// channel is. The threshold was chosen against the synthetic fixtures in
-// analysis_test.go (steady sine: 0.92, stereo sine: 1.01, impulse: >>1).
-//
-// The libopus detector (celt_encoder.c: transient_analysis) uses a
-// sub-frame STFT with 6.7 dB/ms forward masking and is more accurate on
-// gradual ramps — known limitation of this simpler approach.
-func detectTransient(pcm [][]float32, _ *analysisState) bool {
-	return debugDetectTransient(pcm) > transientRatioThreshold
+const (
+	// transientForwardDecay/transientBackwardDecay set the post-echo (6.7
+	// dB/ms) and pre-echo (13.9 dB/ms) masking decay of the envelope
+	// follower in transientMaskMetric, matching libopus's non-hybrid
+	// transient_analysis (celt_encoder.c).
+	transientForwardDecay  = 0.0625
+	transientBackwardDecay = 0.875
+	// transientMaskThreshold is libopus's mask_metric>200 cutoff.
+	transientMaskThreshold = 200
+)
+
+// transientInverseTable is libopus's inv_table: 6*64/x, trained on real data
+// to minimize the average error when turning a per-sample masking ratio into
+// a harmonic-mean-friendly weight (celt_encoder.c).
+var transientInverseTable = [128]int{ //nolint:gochecknoglobals
+	255, 255, 156, 110, 86, 70, 59, 51, 45, 40, 37, 33, 31, 28, 26, 25,
+	23, 22, 21, 20, 19, 18, 17, 16, 16, 15, 15, 14, 13, 13, 12, 12,
+	12, 12, 11, 11, 11, 10, 10, 10, 9, 9, 9, 9, 9, 9, 8, 8,
+	8, 8, 8, 7, 7, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6,
+	6, 6, 6, 6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5,
+	5, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 3,
+	3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2,
 }
 
-// debugDetectTransient returns the maximum half-frame energy ratio across
-// channels. Test-only helper used to calibrate transientRatioThreshold
-// against the synthetic fixtures.
-func debugDetectTransient(pcm [][]float32) float64 {
-	if len(pcm) == 0 || len(pcm[0]) < 4 {
+// detectTransient reports whether the frame needs short MDCT blocks, mirroring
+// libopus's transient_analysis (celt_encoder.c, float build). It runs its own
+// DC-block + pre-emphasis pass over dedicated state (transientDCMem/PreMem/
+// History), independent of dcBlockMem/preemphasisMem/prevPCM, so it works the
+// same whether or not analyzeFrame follows it.
+//
+// tone_freq/toneishness (the low-frequency-tone guard) and allow_weak_transients
+// (hybrid low-bitrate mode) aren't ported — pion has no tonality analysis or
+// hybrid mode yet, matching how signalBandwidth defaults to end-1 elsewhere.
+func detectTransient(pcm [][]float32, state *analysisState) bool {
+	return transientFrameMetric(pcm, state) > transientMaskThreshold
+}
+
+func transientFrameMetric(pcm [][]float32, state *analysisState) int {
+	if len(pcm) == 0 {
 		return 0
 	}
 
-	frameSize := len(pcm[0])
-	half := frameSize / 2
-
-	var maxRatio float64
+	maskMetric := 0
 	for ch := range pcm {
-		// Skip the first and last shortBlockSampleCount samples: those are
-		// the MDCT overlap regions shared with the neighboring frames and
-		// don't belong to this frame's "clean" content.
-		start := shortBlockSampleCount
-		if start >= half {
-			continue
-		}
-		end := frameSize - shortBlockSampleCount
-		if end <= start {
-			continue
+		if len(pcm[ch]) == 0 {
+			return 0
 		}
 
-		var e1, e2 float64
-		for i := start; i < half; i++ {
-			x := float64(pcm[ch][i]) //nolint:gosec // bounds checked: i < half <= frameSize = len(pcm[ch])
-			e1 += x * x
-		}
-		for i := half; i < end; i++ {
-			x := float64(pcm[ch][i]) //nolint:gosec // bounds checked: i < end <= frameSize = len(pcm[ch])
-			e2 += x * x
-		}
+		n := shortBlockSampleCount + len(pcm[ch])
+		probe := state.transientProbe[ch][:n]
+		copy(probe, state.transientHistory[ch])
 
-		ratio := e2 / math.Max(e1, 1e-30)
-		if ratio > maxRatio {
-			maxRatio = ratio
+		tail := probe[shortBlockSampleCount:]
+		copy(tail, pcm[ch])
+		applyDCBlock(tail, sampleRate, &state.transientDCMem[ch])
+		applyPreemphasis(tail, tail, &state.transientPreMem[ch])
+		copy(state.transientHistory[ch], tail[len(tail)-shortBlockSampleCount:])
+
+		if m := transientMaskMetric(probe, state.transientEnvelope[ch][:n]); m > maskMetric {
+			maskMetric = m
 		}
 	}
 
-	return maxRatio
+	return maskMetric
+}
+
+// transientMaskMetric returns libopus's post/pre-echo masking metric for one
+// channel: the ratio of the frame's energy over the harmonic mean of a
+// masking envelope built from a 2nd-order high-passed version of the signal.
+// scratch must be at least len(signal) long; it's used as scratch and left
+// with unspecified contents on return.
+func transientMaskMetric(signal, scratch []float32) int {
+	n := len(signal)
+	tmp := scratch[:n]
+
+	var mem0, mem1 float32
+	for i, x := range signal {
+		y := mem0 + x
+		prevMem0 := mem0
+		mem0 = mem0 - x + 0.5*mem1
+		mem1 = x - prevMem0
+		tmp[i] = y
+	}
+	// The first few samples are unreliable since the filter memory hasn't
+	// propagated yet.
+	clear(tmp[:min(12, n)])
+
+	len2 := n / 2
+	if len2 < 18 {
+		return 0
+	}
+
+	var mean float32
+	mem0 = 0
+	for i := range len2 {
+		x2 := tmp[2*i]*tmp[2*i] + tmp[2*i+1]*tmp[2*i+1]
+		mean += x2
+		mem0 = x2 + (1-transientForwardDecay)*mem0
+		tmp[i] = transientForwardDecay * mem0
+	}
+
+	mem0 = 0
+	var maxE float32
+	for i := len2 - 1; i >= 0; i-- {
+		mem0 = tmp[i] + transientBackwardDecay*mem0
+		tmp[i] = (1 - transientBackwardDecay) * mem0
+		maxE = max(maxE, tmp[i])
+	}
+
+	// Frame energy is the geometric mean of the average envelope and half the
+	// peak — a compromise with the older, simpler detector this replaces.
+	frameEnergy := float32(math.Sqrt(float64(mean * maxE * 0.5 * float32(len2))))
+	norm := float32(len2) / (1e-15 + frameEnergy)
+
+	unmask := 0
+	for i := 12; i < len2-5; i += 4 {
+		id := int(math.Floor(float64(64 * norm * (tmp[i] + 1e-15))))
+		id = min(max(id, 0), 127)
+		unmask += transientInverseTable[id]
+	}
+
+	// Compensate for the 1/4th sampling above and the factor of 6 baked into
+	// the inverse table.
+	return 64 * unmask * 4 / (6 * (len2 - 17))
 }
 
 func applyPreemphasis(in []float32, out []float32, mem *float32) {

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -136,79 +136,111 @@ func TestAnalyzeFrameAdaptiveSpread(t *testing.T) {
 			"(sine=%x, noise=%x)", enc1.FinalRange(), enc2.FinalRange())
 }
 
+// warmTransientState runs a few frames through detectTransient so
+// transientHistory settles into steady state, matching how the real encoder
+// calls it every frame rather than in isolation.
+func warmTransientState(state *analysisState, gen func(frame int) [][]float32) {
+	const warmupFrames = 4
+	for f := range warmupFrames {
+		detectTransient(gen(f), state)
+	}
+}
+
 func TestDetectTransientSteadySine(t *testing.T) {
 	state := newAnalysisState()
-	pcm := make([]float32, 960)
-	for i := range pcm {
-		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
+	gen := func(f int) [][]float32 {
+		pcm := make([]float32, 960)
+		for i := range pcm {
+			pcm[i] = float32(0.5 * math.Sin(2*math.Pi*440*float64(f*960+i)/sampleRate))
+		}
+
+		return [][]float32{pcm}
 	}
-	metric := debugDetectTransient([][]float32{pcm})
-	t.Logf("steady sine metric=%f", metric)
-	assert.False(t, detectTransient([][]float32{pcm}, &state),
-		"steady sine should not be detected as transient (metric=%f)", metric)
+	warmTransientState(&state, gen)
+
+	metric := transientFrameMetric(gen(4), &state)
+	t.Logf("steady 440 Hz sine metric=%d", metric)
+	assert.LessOrEqual(t, metric, transientMaskThreshold,
+		"a steady tone should not be detected as transient once history settles (metric=%d)", metric)
 }
 
-func TestDetectTransientSpike(t *testing.T) {
+func TestDetectTransientWhiteNoiseNotFlagged(t *testing.T) {
+	state := newAnalysisState()
+	seed := uint32(12345)
+	noise := func() float32 {
+		seed = 1664525*seed + 1013904223
+
+		return float32(int32(seed>>8)%2000-1000) / 1000.0 //nolint:gosec // G115: bounded LCG output.
+	}
+	gen := func(int) [][]float32 {
+		pcm := make([]float32, 960)
+		for i := range pcm {
+			pcm[i] = 0.3 * noise()
+		}
+
+		return [][]float32{pcm}
+	}
+	warmTransientState(&state, gen)
+
+	metric := transientFrameMetric(gen(4), &state)
+	t.Logf("white noise metric=%d", metric)
+	assert.LessOrEqual(t, metric, transientMaskThreshold,
+		"stationary broadband noise should not be detected as transient (metric=%d)", metric)
+}
+
+func TestDetectTransientSpikeAfterSteadySignal(t *testing.T) {
+	state := newAnalysisState()
+	amp := 0.3
+	gen := func(f int) [][]float32 {
+		pcm := make([]float32, 960)
+		for i := range pcm {
+			pcm[i] = float32(amp * math.Sin(2*math.Pi*440*float64(f*960+i)/sampleRate))
+		}
+
+		return [][]float32{pcm}
+	}
+	warmTransientState(&state, gen)
+
+	spike := gen(4)
+	spike[0][480] += 1.0
+	metric := transientFrameMetric(spike, &state)
+	t.Logf("spike-after-steady metric=%d", metric)
+	assert.Greater(t, metric, transientMaskThreshold,
+		"a sharp mid-frame spike after steady content should be detected as transient (metric=%d)", metric)
+}
+
+func TestDetectTransientStereoSpikeOnOneChannel(t *testing.T) {
+	state := newAnalysisState()
+	gen := func(f int) [][]float32 {
+		left := make([]float32, 960)
+		right := make([]float32, 960)
+		for i := range left {
+			left[i] = float32(0.3 * math.Sin(2*math.Pi*440*float64(f*960+i)/sampleRate))
+		}
+
+		return [][]float32{left, right}
+	}
+	warmTransientState(&state, gen)
+
+	frame := gen(4)
+	frame[0][480] += 1.0 // right channel stays silent
+	metric := transientFrameMetric(frame, &state)
+	assert.Greater(t, metric, transientMaskThreshold,
+		"a spike on either stereo channel should be detected, even with the other channel silent (metric=%d)", metric)
+}
+
+// TestDetectTransientColdStart documents intentional, expected behavior: the
+// very first call sees all-zero history, so a signal starting abruptly reads
+// as a real silence-to-signal transient. This isn't a bug — a fresh Encoder's
+// first frame has no prior context to compare against.
+func TestDetectTransientColdStart(t *testing.T) {
 	state := newAnalysisState()
 	pcm := make([]float32, 960)
-	pcm[480] = 1.0
-	metric := debugDetectTransient([][]float32{pcm})
-	t.Logf("spike metric=%f", metric)
+	for i := range pcm {
+		pcm[i] = float32(0.5 * math.Sin(2*math.Pi*440*float64(i)/sampleRate))
+	}
 	assert.True(t, detectTransient([][]float32{pcm}, &state),
-		"mid-frame spike should be detected as transient (metric=%f)", metric)
-}
-
-func TestDetectTransientStereoSpike(t *testing.T) {
-	state := newAnalysisState()
-	left := make([]float32, 960)
-	right := make([]float32, 960)
-	left[480] = 1.0
-	metric := debugDetectTransient([][]float32{left, right})
-	t.Logf("stereo spike metric=%f", metric)
-	assert.True(t, detectTransient([][]float32{left, right}, &state),
-		"transient on a single stereo channel should be detected (metric=%f)", metric)
-}
-
-func TestDetectTransientSilentChannel(t *testing.T) {
-	state := newAnalysisState()
-	left := make([]float32, 960)
-	right := make([]float32, 960)
-	left[480] = 1.0
-	right[600] = 1.0
-	metric := debugDetectTransient([][]float32{left, right})
-	t.Logf("silent-channel metric=%f", metric)
-	assert.True(t, detectTransient([][]float32{left, right}, &state),
-		"transient on one stereo channel should be detected even when the "+
-			"other channel is silent (metric=%f)", metric)
-}
-
-func TestDetectTransientStereoSteady(t *testing.T) {
-	state := newAnalysisState()
-	left := make([]float32, 960)
-	right := make([]float32, 960)
-	for i := range left {
-		left[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / sampleRate))
-		right[i] = float32(math.Sin(2 * math.Pi * 660 * float64(i) / sampleRate))
-	}
-	metric := debugDetectTransient([][]float32{left, right})
-	t.Logf("stereo steady metric=%f", metric)
-	assert.False(t, detectTransient([][]float32{left, right}, &state),
-		"steady stereo sines should not be detected as transient (metric=%f)", metric)
-}
-
-func TestDetectTransientGradualFade(t *testing.T) {
-	pcm := make([]float32, 960)
-	for i := range pcm {
-		pcm[i] = float32(i) / 960
-	}
-	metric := debugDetectTransient([][]float32{pcm})
-	t.Logf("gradual fade metric=%f", metric)
-	// A linear ramp from 0 to 1 over a frame is flagged by this detector
-	// because the second half carries more energy. This is a known
-	// limitation: libopus handles ramps correctly via sub-frame STFT and
-	// forward masking (transient_analysis in celt_encoder.c).
-	assert.Greater(t, metric, 1.0,
-		"gradual ramp should be flagged by the simple detector (metric=%f)", metric)
+		"a signal starting from zero history is a legitimate transient")
 }
 
 func TestDetectTransientEmpty(t *testing.T) {
@@ -227,19 +259,6 @@ func TestDetectTransientFrameSize2_5ms(t *testing.T) {
 	pcm[60] = 1.0
 	state := newAnalysisState()
 	_ = detectTransient([][]float32{pcm}, &state)
-}
-
-func TestDetectTransientSmallSpike(t *testing.T) {
-	pcm := make([]float32, 960)
-	pcm[480] = 0.01
-	metric := debugDetectTransient([][]float32{pcm})
-	t.Logf("small spike metric=%f", metric)
-	// a small spike on a silent background has an infinite ratio; the
-	// simplified detector flags it as transient. This is the intended
-	// behavior: the encoder does not run on full silence, so any
-	// spike represents a real signal change.
-	assert.Greater(t, metric, 1.5,
-		"small spike on silence should be flagged by the simple detector (metric=%f)", metric)
 }
 
 func TestDCBlockRemovesConstantOffset(t *testing.T) {

--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -267,7 +267,6 @@ func quantBandMono(
 		}
 		qalloc := int(state.rangeEncoder.TellFrac()) - tell
 		bandBits -= qalloc
-		originalFill := fill
 		delta := 0
 		imid := 0
 		iside := 0
@@ -343,7 +342,7 @@ func quantBandMono(
 				nextLevel,
 				gain*side,
 				lowbandScratch,
-				originalFill>>blocks,
+				fill>>blocks,
 				state,
 				yScratch, absXScratch, signScratch, cwrsScratch,
 			) << collapseShift
@@ -363,7 +362,7 @@ func quantBandMono(
 				nextLevel,
 				gain*side,
 				lowbandScratch,
-				originalFill>>blocks,
+				fill>>blocks,
 				state,
 				yScratch, absXScratch, signScratch, cwrsScratch,
 			) << collapseShift
@@ -584,16 +583,17 @@ func quantBandStereo(
 	qalloc := int(state.rangeEncoder.TellFrac()) - tell
 	bandBits -= qalloc
 
-	originalFill := fill
 	delta := 0
 	imid := 0
 	iside := 0
 	switch itheta {
 	case 0:
 		imid = 32767
+		fill &= (1 << blocks) - 1
 		delta = -16384
 	case 16384:
 		iside = 32767
+		fill &= ((1 << blocks) - 1) << blocks
 		delta = 16384
 	default:
 		imid = bitexactCos(itheta)
@@ -619,7 +619,7 @@ func quantBandStereo(
 		}
 		collapseMask |= quantBandMono(
 			band, y, n, sideBits, spread, blocks, tfChange,
-			nil, remainingBits, lm, nil, 0, gain*side, nil, originalFill>>blocks, state,
+			nil, remainingBits, lm, nil, 0, gain*side, nil, fill>>blocks, state,
 			yScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
 		)
 		if n != 2 {
@@ -636,7 +636,7 @@ func quantBandStereo(
 
 	collapseMask := quantBandMono(
 		band, y, n, sideBits, spread, blocks, tfChange,
-		nil, remainingBits, lm, nil, 0, gain*side, nil, originalFill>>blocks, state,
+		nil, remainingBits, lm, nil, 0, gain*side, nil, fill>>blocks, state,
 		yScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
 	)
 	rebalance = sideBits - (rebalance - *remainingBits)

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -325,9 +325,20 @@ func (e *Encoder) encodeDynamicAllocation(info *frameSideInfo, offsets [maxBands
 	return totalBitsEighth
 }
 
-// encodeAllocationTrim writes the default allocation trim.
-func (e *Encoder) encodeAllocationTrim(info *frameSideInfo, totalBitsEighth uint) {
+// encodeAllocationTrim chooses and writes the allocation trim, falling back to
+// defaultAllocationTrim (matching the decoder's fallback) when there isn't
+// enough budget left to signal it.
+func (e *Encoder) encodeAllocationTrim(
+	info *frameSideInfo, logBandAmp [2][maxBands]float32, mdct [2][]float32, totalBitsEighth uint,
+) {
+	info.allocationTrim = defaultAllocationTrim
 	if e.rangeEncoder.TellFrac()+uint(allocationTrimBitCost<<bitResolution) <= totalBitsEighth {
+		info.allocationTrim = chooseAllocationTrim(
+			logBandAmp,
+			mdct,
+			info.channelCount, info.lm, info.endBand,
+			info.totalBits,
+		)
 		e.rangeEncoder.EncodeSymbolWithICDF(icdfAllocationTrim, uint32(info.allocationTrim))
 	}
 }
@@ -616,13 +627,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	e.prevSpreadDecision = info.spread
 	e.encodeSpread(&info)
 	totalBitsEighth := e.encodeDynamicAllocation(&info, offsets)
-	info.allocationTrim = chooseAllocationTrim(
-		analysis.logBandAmp,
-		analysis.mdct,
-		info.channelCount, info.lm, info.endBand,
-		info.totalBits,
-	)
-	e.encodeAllocationTrim(&info, totalBitsEighth)
+	e.encodeAllocationTrim(&info, analysis.logBandAmp, analysis.mdct, totalBitsEighth)
 
 	tellFrac := int(e.rangeEncoder.TellFrac())
 

--- a/testdata/encoder-quality-baseline.json
+++ b/testdata/encoder-quality-baseline.json
@@ -3,13 +3,13 @@
   "bitrate": 96000,
   "signals": {
     "burst": {
-      "tier1SnrDb": 4.1
+      "tier1SnrDb": 3.8
     },
     "chirp": {
-      "tier1SnrDb": 14.5
+      "tier1SnrDb": 12.1
     },
     "harmonics": {
-      "tier1SnrDb": 27.8
+      "tier1SnrDb": 25.9
     },
     "onset": {
       "tier1SnrDb": 4.0


### PR DESCRIPTION
#### Description
`detectTransient` was a placeholder (energy ratio between frame halves) that almost never fired, so short blocks and anti-collapse were dead code. Ported the real `transient_analysis` from libopus (`celt_encoder.c:267-469`): 2nd-order highpass, forward/backward masking decay, and a harmonic-mean mask metric against the reference's `inv_table`

Getting the detector to actually fire surfaced a pre-existing range-coder desync in stereo + short blocks (confirmed on clean `main` by forcing the old detector to always return true — same desync, same final range). Root cause: `chooseAllocationTrim` ran unconditionally, but `encodeAllocationTrim` only wrote the trim symbol when there was bit budget left, leaving `info.allocationTrim` on the computed (never transmitted) value instead of falling back to the default like the decoder does. Fixed by gating the computation the same way libopus does (`alloc_trim = 5` first, only overwritten inside the budget check). Also fixed a sibling bug in the same area: the stereo/mono band split wasn't masking `fill` on extreme theta angles the way decode does

Regenerated the Tier1 quality baseline now that harmonics/chirp correctly trigger short blocks

Anti-collapse is still a hardcoded 0 — that's next now that the detector isn't blocking it
#### Reference issue
Fixes #...
