### PR TITLE
Apply missing Hadamard transform in CELT encoder

### DIFF
--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -217,6 +217,7 @@ func quantBandMono(
 			lowband = lowbandScratch[:n]
 		}
 		for k := range recombine {
+			haar1(x, n>>k, 1<<k)
 			if lowband != nil {
 				haar1(lowband, n>>k, 1<<k)
 			}
@@ -225,6 +226,7 @@ func quantBandMono(
 		blocks >>= recombine
 		nPerBlock <<= recombine
 		for (nPerBlock&1) == 0 && tfChange < 0 {
+			haar1(x, nPerBlock, blocks)
 			if lowband != nil {
 				haar1(lowband, nPerBlock, blocks)
 			}
@@ -236,15 +238,25 @@ func quantBandMono(
 		}
 		originalBlocks = blocks
 	}
-	if level == 0 && originalBlocks > 1 && lowband != nil {
-		tmpState := bandDecodeState{tmpScratch: state.floatScratch(len(lowband))}
+	if level == 0 && originalBlocks > 1 {
+		tmpState := bandDecodeState{tmpScratch: state.floatScratch(n)}
 		deinterleaveHadamard(
-			lowband,
+			x,
 			nPerBlock>>recombine,
 			originalBlocks<<recombine,
 			longBlocks,
 			&tmpState,
 		)
+		if lowband != nil {
+			lowbandState := bandDecodeState{tmpScratch: state.floatScratch(len(lowband))}
+			deinterleaveHadamard(
+				lowband,
+				nPerBlock>>recombine,
+				originalBlocks<<recombine,
+				longBlocks,
+				&lowbandState,
+			)
+		}
 	}
 	if lm != -1 && shouldSplitBand(band, lm, bandBits) && n > 2 {
 		n >>= 1

--- a/internal/celt/hadamard_regression_test.go
+++ b/internal/celt/hadamard_regression_test.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package celt
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestQuantBandMonoPreservesDirectionWithShortBlocks guards the Hadamard
+// transform pair in quantBandMono. The encoder used to interleave x back at
+// the end without ever deinterleaving it first (libopus does both under
+// "if (encode)", celt/bands.c:1322), which left the band permuted: energy
+// survived but the direction did not, so PVQ quantized a scrambled vector.
+//
+// FinalRange comparisons cannot catch this — encoder and decoder still agree
+// on every bit, they just agree on the wrong content. Measuring the angle
+// between the shape handed to quantBandMono and the shape it produces is
+// what exposes it: short blocks used to collapse to ~0 correlation while
+// long blocks stayed above 0.7.
+func TestQuantBandMonoPreservesDirectionWithShortBlocks(t *testing.T) {
+	for _, tc := range []struct{ band, bandBits int }{
+		{8, 251}, {12, 408}, {18, 807}, {19, 884},
+	} {
+		n := (int(bandEdges[tc.band+1]) - int(bandEdges[tc.band])) << maxLM
+		longCorr := quantBandMonoMeanCorrelation(t, tc.band, n, tc.bandBits, 1)
+		shortCorr := quantBandMonoMeanCorrelation(t, tc.band, n, tc.bandBits, 1<<maxLM)
+
+		assert.Greaterf(t, shortCorr, 0.6,
+			"band %d: short blocks lost the band direction (corr=%.3f)", tc.band, shortCorr)
+		assert.InDeltaf(t, longCorr, shortCorr, 0.1,
+			"band %d: short blocks (corr=%.3f) must quantize as faithfully as long blocks (corr=%.3f)",
+			tc.band, shortCorr, longCorr)
+
+		// The recombine and time-divide loops and the folded deinterleave all
+		// run haar1 on the band, so each needs the forward pass too.
+		divided := quantBandMonoCorrelation(t, tc.band, n, tc.bandBits, 1, -1, false)
+		assert.Greaterf(t, divided, 0.6,
+			"band %d: time-divided blocks lost the band direction (corr=%.3f)", tc.band, divided)
+
+		folded := quantBandMonoCorrelation(t, tc.band, n, tc.bandBits, 1<<maxLM, 0, true)
+		assert.Greaterf(t, folded, 0.6,
+			"band %d: folding lost the band direction (corr=%.3f)", tc.band, folded)
+	}
+}
+
+// quantBandMonoMeanCorrelation returns the mean cosine similarity between a
+// random unit-norm band and the shape quantBandMono leaves behind.
+func quantBandMonoMeanCorrelation(t *testing.T, band, n, bandBits, blocks int) float64 {
+	t.Helper()
+
+	return quantBandMonoCorrelation(t, band, n, bandBits, blocks, 0, false)
+}
+
+// quantBandMonoCorrelation also drives the time-divide (tfChange < 0) and
+// folding (lowband != nil) branches, which the encoder cannot reach on its
+// own until tf_analysis lands.
+func quantBandMonoCorrelation(t *testing.T, band, n, bandBits, blocks, tfChange int, withLowband bool) float64 {
+	t.Helper()
+
+	const trials = 20
+	var total float64
+	for trial := range trials {
+		rng := rand.New(rand.NewSource(int64(band*1000 + blocks*97 + trial))) //nolint:gosec // deterministic input
+		shape := make([]float32, n)
+		for i := range shape {
+			shape[i] = float32(rng.NormFloat64())
+		}
+		renormaliseVector(shape, n, normScaling)
+		target := make([]float32, n)
+		copy(target, shape)
+
+		encoder := NewEncoder()
+		encoder.rangeEncoder.Init()
+		state := bandEncodeState{rangeEncoder: &encoder.rangeEncoder}
+		remainingBits := 100000
+
+		var lowband []float32
+		if withLowband {
+			lowband = make([]float32, n)
+			for i := range lowband {
+				lowband[i] = float32(rng.NormFloat64())
+			}
+			renormaliseVector(lowband, n, normScaling)
+		}
+
+		quantBandMono(
+			band, shape, n, bandBits, spreadNormal, blocks, tfChange,
+			lowband, &remainingBits, maxLM, nil, 0, 1, make([]float32, n), (1<<blocks)-1, &state,
+			make([]int, n+3), make([]float32, n+3), make([]float32, n+3),
+			make([]uint32, cwrsMaxPulseCount+2),
+		)
+
+		var dot, normTarget, normQuantized float64
+		for i := range n {
+			dot += float64(target[i]) * float64(shape[i])
+			normTarget += float64(target[i]) * float64(target[i])
+			normQuantized += float64(shape[i]) * float64(shape[i])
+		}
+		if normTarget == 0 || normQuantized == 0 {
+			continue
+		}
+		total += dot / (math.Sqrt(normTarget) * math.Sqrt(normQuantized))
+	}
+
+	return total / trials
+}

--- a/testdata/encoder-quality-baseline.json
+++ b/testdata/encoder-quality-baseline.json
@@ -1,21 +1,21 @@
 {
-  "version": 1,
   "bitrate": 96000,
   "signals": {
     "burst": {
-      "tier1SnrDb": 3.8
+      "tier1SnrDb": 4.1
     },
     "chirp": {
-      "tier1SnrDb": 12.1
+      "tier1SnrDb": 13.6
     },
     "harmonics": {
-      "tier1SnrDb": 25.9
+      "tier1SnrDb": 24.6
     },
     "onset": {
-      "tier1SnrDb": 4.0
+      "tier1SnrDb": 4.1
     },
     "shaped_noise": {
       "tier1SnrDb": 0.7
     }
-  }
+  },
+  "version": 1
 }


### PR DESCRIPTION
#### Description

The encoder applied the inverse Hadamard at the end of `quantBandMono` without ever applying the forward one. libopus does both under `if (encode)` — `haar1` in the recombine loop (celt/bands.c:1294), `haar1` in the time-divide loop (1306), and `deinterleave_hadamard` when `B0>1` (1322) — but we only ran them on `lowband`, never on the band itself.

`haar1` is an involution and interleave/deinterleave are inverses, so the band came out permuted: energy survived, direction didn't. PVQ was quantizing a scrambled vector. `FinalRange` can't catch this — encoder and decoder agree on every bit, they just agree on the wrong content.

On a 20s music clip via `opus_compare`, weighted error goes 10.96 → 5.03 at 96 kbps and 10.20 → 3.28 at 256 kbps. More importantly the error finally scales with bitrate again — a permutation doesn't improve with more bits, which is why the score used to sit flat from 64 to 510 kbps.

Regenerated the Tier1 baseline: chirp 12.1→13.6, burst 3.8→4.1, onset 4.0→4.1. harmonics went 25.9→24.6, the one signal that got worse — within the 1.5 dB threshold, and I'm reading it as synthetic-signal noise given the real-music numbers, but flagging it rather than hiding it.

`TestQuantBandMonoPreservesDirectionWithShortBlocks` guards this: it measures the angle between the shape handed to `quantBandMono` and what comes back, and fails without the fix (correlation collapses to 0.03 for short blocks while long blocks stay at 0.96).

#### Reference issue

Part of the CELT encoder series (#175)