### PR TITLE
Enable anti-collapse in CELT encoder

### DIFF
--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -52,6 +52,10 @@ type Encoder struct {
 	// frame", which the update below seeds directly instead of clamping.
 	lastCodedBands int
 	prevLogBandAmp [2][maxBands]float32
+	// consecTransient counts consecutive transient frames (st->consec_transient
+	// in libopus celt_encoder.c) — anti-collapse only fires for the first two
+	// in a row.
+	consecTransient int
 
 	// Application mode plumbing — set by root encoder via setter methods.
 	vbr            bool
@@ -119,6 +123,7 @@ func (e *Encoder) Reset() {
 	e.prevSpreadDecision = defaultSpreadDecision
 	e.prevIntensityBand = 0
 	e.lastCodedBands = 0
+	e.consecTransient = 0
 	e.analysis.prefilter = postFilterState{}
 
 	e.vbrReservoir = 0
@@ -665,9 +670,16 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 
 	if info.antiCollapseRsv > 0 {
 		// RFC 6716 §4.3.5 puts one raw tail bit here right after the band
-		// residuals; the decoder reads it before finalizeFineEnergy. I always
-		// write 0 — the noise injection it controls is left for a later pass.
-		e.rangeEncoder.EncodeRawBits(1, 0)
+		// residuals; the decoder reads it before finalizeFineEnergy. libopus
+		// only keeps anti-collapse on for the first two transient frames in a
+		// row (celt_encoder.c consec_transient), not every transient frame.
+		antiCollapseOn := e.consecTransient < 2
+		e.rangeEncoder.EncodeRawBits(1, uint32(boolIndex(antiCollapseOn)))
+	}
+	if info.transient {
+		e.consecTransient++
+	} else {
+		e.consecTransient = 0
 	}
 
 	bitsLeft := int(info.totalBits) - int(e.rangeEncoder.Tell())

--- a/internal/celt/encoder_test.go
+++ b/internal/celt/encoder_test.go
@@ -463,6 +463,54 @@ func TestEncodeFrameTransientNoRegressionNonTransient(t *testing.T) {
 	assert.LessOrEqual(t, len(data2), frameBytes)
 }
 
+func TestAntiCollapseConsecutiveTransientHysteresis(t *testing.T) {
+	// libopus only keeps anti-collapse on for the first two transient frames
+	// in a row (celt_encoder.c st->consec_transient), then leaves it off until
+	// a non-transient frame resets the run. Verify the counter follows that
+	// pattern and that the decoder stays in sync regardless of the bit value.
+	encoder := NewEncoder()
+	decoder := NewDecoder()
+
+	frameSampleCount := shortBlockSampleCount << maxLM
+	frameBytes := 60
+
+	impulse := make([]float32, frameSampleCount)
+	impulse[frameSampleCount/2] = 1.0
+
+	for frame, wantConsecTransient := range []int{1, 2, 3, 4} {
+		data := encodeFrame(t, &encoder, [][]float32{impulse}, frameBytes)
+		require.NotEmpty(t, data, "frame %d", frame)
+		assert.Equal(t, wantConsecTransient, encoder.consecTransient, "consecTransient after frame %d", frame)
+
+		out := make([]float32, frameSampleCount)
+		require.NoError(t, decoder.Decode(data, out, false, 1, frameSampleCount, 0, maxBands), "frame %d", frame)
+		assert.Equal(t, encoder.FinalRange(), decoder.FinalRange(), "range coder out of sync at frame %d", frame)
+	}
+
+	// A phase-continuous steady tone: the first frame is itself an onset (a
+	// real amplitude step from the impulse frames' near-silent tail), so it
+	// stays transient too — the run only breaks once the tone has settled.
+	steadyTone := func(sampleOffset int) []float32 {
+		steady := make([]float32, frameSampleCount)
+		for i := range steady {
+			steady[i] = float32(math.Sin(2 * math.Pi * 440 * float64(sampleOffset+i) / sampleRate))
+		}
+
+		return steady
+	}
+
+	data := encodeFrame(t, &encoder, [][]float32{steadyTone(0)}, frameBytes)
+	require.NotEmpty(t, data)
+
+	data = encodeFrame(t, &encoder, [][]float32{steadyTone(frameSampleCount)}, frameBytes)
+	require.NotEmpty(t, data)
+	assert.Equal(t, 0, encoder.consecTransient, "a settled non-transient frame must reset the run")
+
+	out := make([]float32, frameSampleCount)
+	require.NoError(t, decoder.Decode(data, out, false, 1, frameSampleCount, 0, maxBands))
+	assert.Equal(t, encoder.FinalRange(), decoder.FinalRange(), "range coder out of sync after reset frame")
+}
+
 func assertStereoFinalRangeMatch(t *testing.T, frameBytes int) {
 	t.Helper()
 


### PR DESCRIPTION
#### Description

The anti-collapse bit was hardcoded to 0, so the noise injection it controls never ran even though the decoder side (`antiCollapse` in synthesis.go) has been implemented and tested all along.

libopus only keeps anti-collapse on for the first two transient frames in a row (`st->consec_transient`, celt_encoder.c:2701), not every transient frame, so this tracks that run length and signals accordingly.

`TestAntiCollapseConsecutiveTransientHysteresis` covers the counter and checks the decoder stays in sync across the run— this is the first time a round-trip actually exercises the decoder's anti-collapse path rather than its isolated unit test.

#### Reference issue

Part of the CELT encoder series (#175)