### PR TITLE
Use entry block count for mono split theta

### DIFF
--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -262,7 +262,7 @@ func quantBandMono(
 		itheta := 0
 		if qn != 1 {
 			thetaSym = quantizeMonoSplitTheta(x, y, qn)
-			encodeBandThetaMono(thetaSym, qn, blocks, state.rangeEncoder)
+			encodeBandThetaMono(thetaSym, qn, originalBlocks, state.rangeEncoder)
 			itheta = thetaSym * 16384 / qn
 		}
 		qalloc := int(state.rangeEncoder.TellFrac()) - tell


### PR DESCRIPTION
#### Description

`quantBandMono` passed the post-halving `blocks` to `encodeBandThetaMono`, but the decoder passes `originalBlocks` the value from before the split. libopus hands `compute_theta` both `B` and `B0` and uses `B0` for the coding-scheme choice (celt/bands.c:799, with `int B0=B` captured at the top of `quant_partition`).

The two sides therefore picked different probability models for the same symbol whenever a wide band split deep enough for `blocks` to reach 1 mid-recursion. `originalBlocks` was already computed right there, just not passed.

Latent until now — it needs a wide band with a lot of bits in a transient frame, which nothing exercised. It doesn't move `opus_compare` on real music, but it desynchronises the range coder when it does trigger.

#### Reference issue

Part of the CELT encoder series (#175)