### PR TITLE
Apply intensity stereo at zero split angle

### DIFF
--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -18,6 +18,10 @@ type bandEncodeState struct {
 	norm           []float32
 	lowbandScratch []float32
 	collapseMasks  []byte
+	// bandEnergy holds the linear per-band amplitude of both channels, which
+	// intensityStereo weighs its downmix by. libopus hands quant_all_bands the
+	// unquantized bandE from compute_band_energies, so this mirrors that.
+	bandEnergy [2][maxBands]float32
 }
 
 func (s *bandEncodeState) floatScratch(n int) []float32 {
@@ -585,11 +589,16 @@ func quantBandStereo(
 	if qn != 1 {
 		thetaSym = quantizeStereoBandTheta(x, y, qn)
 		encodeBandTheta(thetaSym, qn, n, true, blocks, state.rangeEncoder)
-		// The two halves are quantized as mid/side from here on; stereoMerge
-		// at the end of this function undoes it (libopus compute_theta,
-		// celt/bands.c:866-871).
-		stereoSplit(x, y, n)
 		itheta = thetaSym * 16384 / qn
+		// libopus compute_theta (celt/bands.c:866-871): a zero angle means the
+		// side carries nothing, so the band collapses to an energy-weighted
+		// downmix instead of being rotated. Otherwise the two halves are coded
+		// as mid/side, which stereoMerge undoes at the end of this function.
+		if itheta == 0 {
+			intensityStereo(x, y, n, state.bandEnergy[0][band], state.bandEnergy[1][band])
+		} else {
+			stereoSplit(x, y, n)
+		}
 	} else if bandBits > 2<<bitResolution && *remainingBits > 2<<bitResolution {
 		inner := float32(0)
 		for i := range n {
@@ -702,6 +711,19 @@ func encodeBandThetaStereoLarge(symbol int, qn int, rangeEncoder *rangecoding.En
 		high = low + 1
 	}
 	rangeEncoder.EncodeCumulative(low, high, total)
+}
+
+// intensityStereo collapses a band to an energy-weighted mono downmix, which
+// is what libopus does when theta lands on zero: all the energy is in the mid,
+// so the side is not worth coding (celt/bands.c intensity_stereo).
+func intensityStereo(x []float32, y []float32, n int, left, right float32) {
+	norm := float32(1e-15) + float32(math.Sqrt(float64(1e-15+left*left+right*right)))
+	a1 := left / norm
+	a2 := right / norm
+	for i := range n {
+		x[i] = a1*x[i] + a2*y[i]
+		// The side is not encoded, so there is nothing to write back to y.
+	}
 }
 
 // stereoSplit rotates a left/right band pair into mid/side, mirroring

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -5,6 +5,7 @@
 package celt
 
 import (
+	"math"
 	"math/bits"
 
 	"github.com/pion/opus/internal/rangecoding"
@@ -688,6 +689,12 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 		norm:           e.bandNorm[:0],
 		lowbandScratch: e.bandLowScratch[:0],
 		collapseMasks:  e.bandCollapseMasks[:0],
+	}
+	for ch := range info.channelCount {
+		for band := info.startBand; band < info.endBand; band++ {
+			bandState.bandEnergy[ch][band] = float32(math.Pow(2,
+				float64(analysis.logBandAmp[ch][band]+energyMeans[band])))
+		}
 	}
 	shape0 := normaliseBandsForEncoding(&info, analysis.mdct[0], analysis.logBandAmp[0], e.normalisedBands[0][:0])
 	if info.channelCount == 2 {

--- a/internal/celt/intensity_stereo_test.go
+++ b/internal/celt/intensity_stereo_test.go
@@ -1,0 +1,36 @@
+package celt
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntensityStereoUnbalancedRoundTrip drives the itheta==0 path with a
+// strongly unbalanced pair, where the energy-weighted downmix differs from a
+// plain mid/side rotation, and checks the range coder stays in sync.
+func TestIntensityStereoUnbalancedRoundTrip(t *testing.T) {
+	encoder := NewEncoder()
+	decoder := NewDecoder()
+
+	frameSampleCount := shortBlockSampleCount << maxLM
+	left := make([]float32, frameSampleCount)
+	right := make([]float32, frameSampleCount)
+	for i := range frameSampleCount {
+		v := float32(math.Sin(2 * math.Pi * 700 * float64(i) / sampleRate))
+		left[i] = v
+		right[i] = 0.05 * v
+	}
+
+	out := make([]float32, frameSampleCount*2)
+	for frame := range 3 {
+		data := encodeFrame(t, &encoder, [][]float32{left, right}, 120)
+		require.NotEmptyf(t, data, "frame %d", frame)
+		require.NoErrorf(t, decoder.Decode(data, out, true, 2, frameSampleCount, 0, maxBands),
+			"frame %d", frame)
+		assert.Equalf(t, encoder.FinalRange(), decoder.FinalRange(),
+			"range coder out of sync at frame %d", frame)
+	}
+}


### PR DESCRIPTION
#### Description

When theta quantizes to zero the side carries no energy, and libopus collapses the band to an energy-weighted downmix rather than rotating it into mid/side (`intensity_stereo`, celt/bands.c:869). We always rotated

It fires on about 5% of theta-coded bands. On balanced stereo it converges to the same thing as the rotation — with equal channel energies both weights are 1/sqrt(2) — so it only changes the output when one channel dominates a band, which is why `opus_compare` doesn't move on ordinary music. This is reference parity, not a quality claim

Weights come from the unquantized band energies, matching what libopus hands `quant_all_bands`

`TestIntensityStereoUnbalancedRoundTrip` drives the path with a strongly unbalanced pair, where the downmix and the rotation actually differ, and checks the range coder stays in sync

#### Reference issue
Part of the CELT encoder series (#180)