### PR TITLE
Soft-clip the integer decode output

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -47,6 +47,7 @@ type Decoder struct {
 	silkRedundancyFades    []silkRedundancyFade
 	silkCeltAdditions      []silkCeltAddition
 	floatBuffer            []float32
+	softClipMem            softClipMemory
 	plcBuffer              []float32
 	plcOutputBuffer        []float32
 	sampleRate             int
@@ -112,6 +113,7 @@ func (d *Decoder) Init(sampleRate, channels int) error {
 	d.silkResampler = [2]silkresample.Resampler{}
 	d.silkResamplerBandwidth = 0
 	d.silkResamplerChannels = 0
+	d.softClipMem = softClipMemory{}
 	d.hybridSilkResampler = [2]silkresample.Resampler{}
 	d.hybridSilkChannels = 0
 	d.clearSilkRedundancyTransitions()
@@ -1538,6 +1540,11 @@ func (d *Decoder) Decode(in, out []byte) (bandwidth Bandwidth, isStereo bool, er
 	if err != nil {
 		return
 	}
+
+	// libopus soft-clips on the integer path only (OPTIONAL_CLIP in
+	// src/opus_decoder.c), so an overshoot lands as a bent peak rather than a
+	// hard-clipped one; DecodeFloat32 leaves that choice to the caller.
+	softClip(d.floatBuffer[:sampleCount*d.channels], d.channels, &d.softClipMem)
 
 	err = bitdepth.ConvertFloat32LittleEndianToSigned16LittleEndian(
 		d.floatBuffer[:sampleCount*d.channels],

--- a/softclip.go
+++ b/softclip.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package opus
+
+// softClipMemory carries the clipping non-linearity across frame boundaries so
+// a peak that straddles two frames does not pick up a discontinuity.
+type softClipMemory [2]float32
+
+// softClip bends samples that overshoot [-1, 1] back inside it with a
+// quadratic non-linearity instead of letting the int16 conversion square them
+// off, which is audible as a click. Port of libopus opus_pcm_soft_clip_impl
+// (src/opus.c); libopus applies it on the integer decode path only, leaving
+// float callers free to handle headroom themselves.
+//
+// Samples are first clamped to [-2, 2], the domain the non-linearity is
+// defined over — beyond it the derivative is zero, so clamping there
+// introduces no discontinuity of its own.
+//
+//nolint:cyclop,gocognit // Mirrors the reference peak-scan and ramp structure.
+func softClip(x []float32, channels int, mem *softClipMemory) {
+	if channels < 1 || len(x) < channels {
+		return
+	}
+	n := len(x) / channels
+
+	for i := range x {
+		x[i] = min(2, max(-2, x[i]))
+	}
+
+	for channel := range channels {
+		at := func(i int) float32 { return x[i*channels+channel] }
+		set := func(i int, v float32) { x[i*channels+channel] = v }
+
+		curve := mem[channel]
+		// Finish applying the previous frame's non-linearity.
+		for i := range n {
+			if at(i)*curve >= 0 {
+				break
+			}
+			set(i, at(i)+curve*at(i)*at(i))
+		}
+
+		curr := 0
+		x0 := at(0)
+		for {
+			i := curr
+			for ; i < n; i++ {
+				if at(i) > 1 || at(i) < -1 {
+					break
+				}
+			}
+			if i == n {
+				curve = 0
+
+				break
+			}
+
+			peakPos := i
+			maxVal := absFloat32(at(i))
+			start, end := i, i
+			// Widen to the zero crossings on either side of the peak so the
+			// correction is applied over a whole half-cycle.
+			for start > 0 && at(i)*at(start-1) >= 0 {
+				start--
+			}
+			for end < n && at(i)*at(end) >= 0 {
+				if absFloat32(at(end)) > maxVal {
+					maxVal = absFloat32(at(end))
+					peakPos = end
+				}
+				end++
+			}
+			special := start == 0 && at(i)*at(0) >= 0
+
+			// Pick the curve so that maxVal + curve*maxVal² == 1, nudged just enough that
+			// rounding cannot leave a sample above 1.
+			curve = (maxVal - 1) / (maxVal * maxVal)
+			curve += curve * 2.4e-7
+			if at(i) > 0 {
+				curve = -curve
+			}
+			for j := start; j < end; j++ {
+				set(j, at(j)+curve*at(j)*at(j))
+			}
+
+			if special && peakPos >= 2 {
+				// The clip started before the first zero crossing, so ramp the
+				// correction in from the frame edge rather than stepping.
+				offset := x0 - at(0)
+				delta := offset / float32(peakPos)
+				for j := curr; j < peakPos; j++ {
+					offset -= delta
+					set(j, min(1, max(-1, at(j)+offset)))
+				}
+			}
+
+			curr = end
+			if curr == n {
+				break
+			}
+		}
+		mem[channel] = curve
+	}
+}
+
+func absFloat32(v float32) float32 {
+	if v < 0 {
+		return -v
+	}
+
+	return v
+}

--- a/softclip_test.go
+++ b/softclip_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package opus
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSoftClipKeepsSamplesInRange(t *testing.T) {
+	const n = 480
+	x := make([]float32, n*2)
+	for i := range n {
+		v := float32(1.4 * math.Sin(2*math.Pi*300*float64(i)/48000))
+		x[i*2] = v
+		x[i*2+1] = -v
+	}
+
+	var mem softClipMemory
+	softClip(x, 2, &mem)
+
+	for i, v := range x {
+		assert.LessOrEqualf(t, math.Abs(float64(v)), 1.0,
+			"sample %d left the valid range: %v", i, v)
+	}
+}
+
+func TestSoftClipLeavesQuietSignalUntouched(t *testing.T) {
+	const n = 480
+	x := make([]float32, n)
+	want := make([]float32, n)
+	for i := range n {
+		x[i] = float32(0.5 * math.Sin(2*math.Pi*300*float64(i)/48000))
+		want[i] = x[i]
+	}
+
+	var mem softClipMemory
+	softClip(x, 1, &mem)
+
+	assert.Equal(t, want, x, "a signal already inside [-1,1] must pass through unchanged")
+}
+
+func TestSoftClipIsContinuousAcrossFrames(t *testing.T) {
+	// A peak that straddles the frame boundary must not pick up a step: the
+	// carried-over curve is what prevents it.
+	const n = 240
+	sig := make([]float32, n*2)
+	for i := range sig {
+		sig[i] = float32(1.3 * math.Sin(2*math.Pi*200*float64(i)/48000))
+	}
+
+	var mem softClipMemory
+	first := append([]float32(nil), sig[:n]...)
+	second := append([]float32(nil), sig[n:]...)
+	softClip(first, 1, &mem)
+	softClip(second, 1, &mem)
+
+	joined := append(first, second...) //nolint:gocritic // deliberately building the joined signal
+	var maxStep float64
+	for i := 1; i < len(joined); i++ {
+		if step := math.Abs(float64(joined[i] - joined[i-1])); step > maxStep {
+			maxStep = step
+		}
+	}
+	assert.Lessf(t, maxStep, 0.1, "soft clipping introduced a discontinuity of %v", maxStep)
+}


### PR DESCRIPTION
#### Description
The decoder let overshoot hit the int16 rail directly, which is audible as a click. libopus bends those peaks with a quadratic non-linearity instead (`opus_pcm_soft_clip_impl`, src/opus.c), carrying the curve across frame boundaries so a peak that straddles two frames doesn't pick up a step

Applied on the integer path only, matching libopus — `opus_decode` passes `OPTIONAL_CLIP` while `opus_decode_float` passes 0, leaving headroom handling to float callers

On a 25s music clip this takes hard-clipped samples from 4 to 0; the 2 that remain sit at exactly full scale, which is where the non-linearity is meant to land them rather than a clipped peak. It does not move `opus_compare` — this addresses a specific artifact, not aggregate quality

Tests cover the range guarantee, that a signal already inside [-1,1] passes through untouched, and that a peak straddling a frame boundary doesn't gain a discontinuity

#### Reference issue
Fixes a decoder-side artifact found while chasing clicks in #180's follow-up