### PR TITLE
Fix pitch prefilter state across frames

### DIFF
--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -139,23 +139,28 @@ func analyzeFrame(
 
 		// Apply pitch pre-filter (whitening) before MDCT, mirroring
 		// libopus run_prefilter. Reuses combFilter with negated gains.
+		src := state.prefilterBuf[ch][:postfilterHistorySampleCount+len(pre)]
+		copy(src, state.prefilterMem[ch])
+		copy(src[postfilterHistorySampleCount:], pre)
 		if prefilterEnabled {
-			src := state.prefilterBuf[ch][:postfilterHistorySampleCount+len(pre)]
-			copy(src, state.prefilterMem[ch])
-			copy(src[postfilterHistorySampleCount:], pre)
 			dst := state.prefilterOut[ch][:len(src)]
+			// The crossfade starts from the previous frame's filter, which is
+			// still in prefilter.period/gain/tapset here — updatePrefilterState
+			// only rotates them in after the frame is encoded.
 			applyPrefilter(
 				dst, src,
-				state.prefilter.oldPeriod, prefilterPeriod,
+				state.prefilter.period, prefilterPeriod,
 				len(pre),
-				state.prefilter.oldGain, prefilterGain,
-				state.prefilter.oldTapset, prefilterTapset,
+				state.prefilter.gain, prefilterGain,
+				state.prefilter.tapset, prefilterTapset,
 			)
-			// Carry the unfiltered tail, since the taps read the input signal
-			// (libopus keeps prefilter_mem from pre, not from the output).
-			copy(state.prefilterMem[ch], src[len(pre):len(pre)+postfilterHistorySampleCount])
 			copy(pre, dst[postfilterHistorySampleCount:])
 		}
+		// The history advances every frame, filtered or not (libopus updates
+		// prefilter_mem outside the pf_on branch); otherwise the comb filter
+		// picks up stale samples whenever it switches back on. It carries the
+		// unfiltered signal, since the taps read the input, not the output.
+		copy(state.prefilterMem[ch], src[len(pre):len(pre)+postfilterHistorySampleCount])
 
 		if useShortBlocks {
 			analyzeTransientChannel(

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -389,10 +389,6 @@ func (e *Encoder) updatePrefilterState(
 	info *frameSideInfo, enabled bool,
 	period int, gain float32, qq int, tapset int,
 ) {
-	e.analysis.prefilter.oldPeriod = e.analysis.prefilter.period
-	e.analysis.prefilter.oldGain = e.analysis.prefilter.gain
-	e.analysis.prefilter.oldTapset = e.analysis.prefilter.tapset
-
 	if enabled {
 		e.analysis.prefilter.period = period
 		e.analysis.prefilter.gain = gain

--- a/internal/celt/pitch.go
+++ b/internal/celt/pitch.go
@@ -296,12 +296,14 @@ func shouldCancelPrefilter(
 		copy(src[postfilterHistorySampleCount:], pre)
 		before[ch] = measureEnergy(src, postfilterHistorySampleCount, len(pre))
 		dst := state.prefilterOut[ch][:len(src)]
+		// Must mirror what analyzeFrame will actually apply, crossfade
+		// endpoints included, or the decision is about a different filter.
 		applyPrefilter(
 			dst, src,
-			state.prefilter.oldPeriod, period,
+			state.prefilter.period, period,
 			len(pre),
-			state.prefilter.oldGain, gain,
-			state.prefilter.oldTapset, tapset,
+			state.prefilter.gain, gain,
+			state.prefilter.tapset, tapset,
 		)
 		after[ch] = measureEnergy(dst, postfilterHistorySampleCount, len(pre))
 	}

--- a/internal/celt/pitch_test.go
+++ b/internal/celt/pitch_test.go
@@ -366,5 +366,4 @@ func TestEncoderResetClearsPrefilterState(t *testing.T) {
 	assert.Zero(t, encoder.analysis.prefilter.period)
 	assert.Zero(t, encoder.analysis.prefilter.gain)
 	assert.Zero(t, encoder.analysis.prefilter.tapset)
-	assert.Zero(t, encoder.analysis.prefilter.oldPeriod)
 }


### PR DESCRIPTION
#### Description

I found two bugs in how the CELT encoder carries the pitch prefilter state between frames. Both can produce short bursts of audible noise in music.

**1. Crossfade was using state from two frames ago.** `analyzeFrame` passed `oldPeriod`/`oldGain`/`oldTapset` to `applyPrefilter`. Since `updatePrefilterState` rotates the state (`old ← current`, `current ← new`) after encoding, those fields actually contain the parameters from two frames earlier. libopus instead saves `st->prefilter_period`/`st->prefilter_gain`, uses those as the "old" side of the crossfade, and only then overwrites them (`celt_encoder.c:1555`, then `:2749`).

**2. Prefilter history only advanced while the filter was enabled.** `prefilterMem` was only updated inside the `if prefilterEnabled` block. With the filter off, the history froze, so when it came back on the comb filter was reading stale samples. libopus updates it unconditionally (`celt_encoder.c:1585`). I removed the temporary buffer and moved the update outside the conditional.

The same issue showed up in `shouldCancelPrefilter`, which does a dry run of the filter before deciding whether to enable it. Since it's supposed to simulate the real filter, it needs to follow the same state updates. Fixing it changes the decision in about 2.5% of frames, although I couldn't hear a noticeable difference in practice.

With those changes, the encoder no longer has any readers of the `old*` fields in `postFilterState` (the decoder still uses them), so I removed the unused writes.

Measured on a full 213 s track at 96 kbps stereo, counting 10 ms windows where the SNR against the original drops below 3 dB (21,303 windows):

|                | Bad windows |
|----------------|------------:|
| Before         | 56 (0.26%)  |
| After          | **2 (0.01%)** |
| libopus        | 2 (0.01%)   |

Classifying only OFF→ON prefilter transitions:

|                | Bad transitions |
|----------------|----------------:|
| Before         | 39/130 (30%)    |
| After          | 0/330           |

`opus_compare` on a 25 s clip: **1.4308 → 1.1787**

#### Reference issue

Part of the work on the CELT encoder.