### PR TITLE
Apply intensity stereo downmix when qn is 1

### DIFF
--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -599,13 +599,29 @@ func quantBandStereo(
 		} else {
 			stereoSplit(x, y, n)
 		}
-	} else if bandBits > 2<<bitResolution && *remainingBits > 2<<bitResolution {
+	} else {
+		// Bands at or above the intensity threshold get qn=1 and always
+		// collapse to the downmix, whether or not the phase bit fits
+		// (libopus compute_theta, celt/bands.c:874-899). The side is negated
+		// first when the channels are anti-correlated, so they add instead
+		// of canceling. inner < 0 is the same test as libopus' itheta>8192:
+		// both say the side carries more energy than the mid.
 		inner := float32(0)
 		for i := range n {
 			inner += x[i] * y[i]
 		}
 		invert = inner < 0
-		state.rangeEncoder.EncodeSymbolLogP(2, uint32(boolIndex(invert)))
+		if invert {
+			for i := range n {
+				y[i] = -y[i]
+			}
+		}
+		intensityStereo(x, y, n, state.bandEnergy[0][band], state.bandEnergy[1][band])
+		if bandBits > 2<<bitResolution && *remainingBits > 2<<bitResolution {
+			state.rangeEncoder.EncodeSymbolLogP(2, uint32(boolIndex(invert)))
+		} else {
+			invert = false
+		}
 	}
 	qalloc := int(state.rangeEncoder.TellFrac()) - tell
 	bandBits -= qalloc


### PR DESCRIPTION
#### Description

Bands at or above the `intensity` threshold force `qn = 1` (`bands.c:733`, mirrored in `encode_bands.go:581`) and are therefore encoded using intensity stereo.

In that path, libopus always collapses the band to an energy-weighted downmix (`bands.c:885`). pion was only calculating the phase flag and writing the bit, leaving `x` as the raw left channel. The decoder reconstructs both channels from that data, so the upper bands ended up with the shape of the left channel duplicated on both sides.

There are two other details in the same path that were missing: libopus negates the side signal before the downmix when the channels are anti-correlated, so they add instead of cancelling out, and it performs the downmix even when there isn't enough room for the `inv` bit.

Measured at 96 kbps stereo on real music, for the 12–15.6 kHz band (the first band above `intensity` in this material):

|                      | Before   | After       | libopus |
|----------------------|----------|-------------|---------|
| SNR                  | 0.55 dB  | **5.42 dB** | 5.83 dB |
| Shape correlation    | 0.5566   | **0.8562**  | 0.8694  |

Global clip SNR: 14.38 → 14.56 dB.

Bands below `intensity` are unchanged.

Since the encoded symbols themselves don't change and only the decoded content does, this didn't affect `FinalRange` or any of the bitstream sync tests — same kind of issue as #176 and #177.

#### Reference issue
Part of the CELT encoder work.