### PR TITLE
Fix allocation trim spectral tilt scaling

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -683,10 +683,12 @@ func chooseAllocationTrim(
 		trim = 4.0 + float32(1.0/16.0)*frac
 	}
 
-	// --- Stereo correlation: average |cosine similarity| over first 8 bands.
-	// libopus uses inner product of normalised bands; we use cosine similarity
-	// of raw MDCT (scale-invariant, same result). Correlated channels →
-	// logXC < 0 → trim decreases → more bits to lows.
+	// --- Stereo correlation over the first 8 bands. libopus uses inner
+	// products of normalised bands; cosine similarity of raw MDCT is the same
+	// thing and scale-invariant. Correlated channels → logXC < 0 → trim
+	// decreases → more bits to lows. The per-band cosines are summed signed
+	// and only the average is taken absolute (celt_encoder.c:790), so bands
+	// that are out of phase cancel instead of piling on.
 	if channelCount == 2 {
 		scale := 1 << lm
 		var corrSum float32
@@ -700,10 +702,10 @@ func chooseAllocationTrim(
 				r2 += mdct[1][i] * mdct[1][i]
 			}
 			if l2 > 1e-30 && r2 > 1e-30 {
-				corrSum += abs32(dot) / sqrtf(l2*r2)
+				corrSum += dot / sqrtf(l2*r2)
 			}
 		}
-		avgCorr := corrSum / 8.0
+		avgCorr := abs32(corrSum / 8.0)
 		if avgCorr > 1.0 {
 			avgCorr = 1.0
 		}
@@ -714,22 +716,18 @@ func chooseAllocationTrim(
 	// --- Spectral tilt: weighted sum of bandLogE.
 	// (2+2*i-end) is negative for low bands, positive for high.
 	// Positive diff (high-freq heavy) → trim decreases → more bits to highs.
-	// pion's logBandAmp is 0.5*log2(energy)-energyMeans (relative to the
-	// per-band mean); libopus's bandLogE is log2(energy) in absolute dB. The
-	// *2 cancels the 0.5 factor; *6.02 converts log2 to dB to match libopus's
-	// Q7 domain. libopus adds a +16 dB offset (QCONST32(1.f, DB_SHIFT-5)) to
-	// center the clamp around typical absolute bandLogE values; pion's
-	// mean-relative domain is already centered at 0, so the offset is dropped.
-	const dbPerLog2 = 6.0206 // 20/log2(10)
+	// logBandAmp is log2(amplitude)-energyMeans, the same quantity libopus
+	// calls bandLogE (amp2Log2 takes the log of the amplitude, not the
+	// energy), so it goes in unscaled: the Q-domain shifts around this in
+	// celt_encoder.c:817 are all no-ops in the float build.
 	var diff float32
 	for ch := range channelCount {
-		for i := range endBand {
-			diff += logBandAmp[ch][i] * 2.0 * dbPerLog2 * float32(2+2*i-endBand)
+		for i := range endBand - 1 {
+			diff += logBandAmp[ch][i] * float32(2+2*i-endBand)
 		}
 	}
 	diff /= float32(channelCount * (endBand - 1))
-	tiltContrib := diff * 4.0 / 6.0
-	tiltContrib = max32(-2.0, min32(2.0, tiltContrib))
+	tiltContrib := max32(-2.0, min32(2.0, (diff+1.0)/6.0))
 	trim -= tiltContrib
 
 	// Round and clamp to [0, 10].


### PR DESCRIPTION
#### Description

There are three issues in `chooseAllocationTrim`, which follows `alloc_trim_analysis` (`celt_encoder.c:775-830`).

**1. The spectral tilt term was ~48x too large.** It was hitting the ±2 clamp in about 98% of frames, so the analysis was effectively contributing a constant value.

The code comment assumed libopus's `bandLogE` was `log2(energy)` and applied an extra `*2 * 6.0206` conversion. But `amp2Log2` operates on amplitude, which is the same quantity as our `logBandAmp`, so no conversion is needed. In the float build, the surrounding Q-domain shifts are all no-ops, making the formula effectively:

`trim -= clamp(-2, 2, (diff + 1.0) / 6)`

**2. Inter-channel correlation was taking the absolute value in the wrong place.** libopus sums the signed per-band cosine values and then takes `ABS16` of the average (`:790`). We were taking the absolute value per band, so bands that were out of phase added together instead of cancelling out, overestimating the correlation.

**3. There was an off-by-one in the tilt loop.** libopus uses `i < end-1`.

Measured at 96 kbps stereo on real music, against libopus at the same complexity:

| trim | Before | After  | libopus |
|------|--------|--------|---------|
| 0    | 7.3%   | 4.2%   | 6.3%    |
| 1    | 47.4%  | 23.2%  | 25.1%   |
| 2    | 43.6%  | 50.6%  | 46.8%   |
| 3    | 0.6%   | 20.7%  | 20.5%   |
| 4    | 0.2%   | 1.4%   | 1.3%    |

Mean trim: 1.419 → 1.919 (libopus: 1.854).

Global clip SNR: 14.56 → 14.80 dB. The low bands gain up to 0.9 dB while the high bands give up a little, which matches the rebalancing done by the reference.

The remaining difference comes from two terms that aren't ported yet: `tf_estimate` (currently passed as 0) and `tonality_slope` from `analysis.c`.

#### Reference issue

Part of the CELT encoder work.