### PR TITLE
Use the transient channel for TF analysis

### DIFF
--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -251,19 +251,28 @@ var transientInverseTable = [128]int{ //nolint:gochecknoglobals
 // tone_freq/toneishness (the low-frequency-tone guard) and allow_weak_transients
 // (hybrid low-bitrate mode) aren't ported — pion has no tonality analysis or
 // hybrid mode yet, matching how signalBandwidth defaults to end-1 elsewhere.
-func detectTransient(pcm [][]float32, state *analysisState) bool {
-	return transientFrameMetric(pcm, state) > transientMaskThreshold
+// Besides the yes/no answer, transient_analysis produces two values later
+// stages consume: tfEstimate, a continuous "how transient is this" metric
+// derived from the same mask_metric, and tfChan, the channel that drove the
+// decision — the one tf_analysis then measures.
+func detectTransient(pcm [][]float32, state *analysisState) (bool, float32, int) {
+	maskMetric, tfChan := transientFrameMetric(pcm, state)
+	tfMax := max32(0, sqrtf(27*float32(maskMetric))-42)
+	tfEstimate := sqrtf(max32(0, 0.0069*min32(163, tfMax)-0.139))
+
+	return maskMetric > transientMaskThreshold, tfEstimate, tfChan
 }
 
-func transientFrameMetric(pcm [][]float32, state *analysisState) int {
+func transientFrameMetric(pcm [][]float32, state *analysisState) (metric, chosenChannel int) {
 	if len(pcm) == 0 {
-		return 0
+		return 0, 0
 	}
 
 	maskMetric := 0
+	tfChan := 0
 	for ch := range pcm {
 		if len(pcm[ch]) == 0 {
-			return 0
+			return 0, 0
 		}
 
 		n := shortBlockSampleCount + len(pcm[ch])
@@ -278,10 +287,11 @@ func transientFrameMetric(pcm [][]float32, state *analysisState) int {
 
 		if m := transientMaskMetric(probe, state.transientEnvelope[ch][:n]); m > maskMetric {
 			maskMetric = m
+			tfChan = ch
 		}
 	}
 
-	return maskMetric
+	return maskMetric, tfChan
 }
 
 // transientMaskMetric returns libopus's post/pre-echo masking metric for one

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -158,7 +158,7 @@ func TestDetectTransientSteadySine(t *testing.T) {
 	}
 	warmTransientState(&state, gen)
 
-	metric := transientFrameMetric(gen(4), &state)
+	metric, _ := transientFrameMetric(gen(4), &state)
 	t.Logf("steady 440 Hz sine metric=%d", metric)
 	assert.LessOrEqual(t, metric, transientMaskThreshold,
 		"a steady tone should not be detected as transient once history settles (metric=%d)", metric)
@@ -182,7 +182,7 @@ func TestDetectTransientWhiteNoiseNotFlagged(t *testing.T) {
 	}
 	warmTransientState(&state, gen)
 
-	metric := transientFrameMetric(gen(4), &state)
+	metric, _ := transientFrameMetric(gen(4), &state)
 	t.Logf("white noise metric=%d", metric)
 	assert.LessOrEqual(t, metric, transientMaskThreshold,
 		"stationary broadband noise should not be detected as transient (metric=%d)", metric)
@@ -203,7 +203,7 @@ func TestDetectTransientSpikeAfterSteadySignal(t *testing.T) {
 
 	spike := gen(4)
 	spike[0][480] += 1.0
-	metric := transientFrameMetric(spike, &state)
+	metric, _ := transientFrameMetric(spike, &state)
 	t.Logf("spike-after-steady metric=%d", metric)
 	assert.Greater(t, metric, transientMaskThreshold,
 		"a sharp mid-frame spike after steady content should be detected as transient (metric=%d)", metric)
@@ -224,7 +224,7 @@ func TestDetectTransientStereoSpikeOnOneChannel(t *testing.T) {
 
 	frame := gen(4)
 	frame[0][480] += 1.0 // right channel stays silent
-	metric := transientFrameMetric(frame, &state)
+	metric, _ := transientFrameMetric(frame, &state)
 	assert.Greater(t, metric, transientMaskThreshold,
 		"a spike on either stereo channel should be detected, even with the other channel silent (metric=%d)", metric)
 }
@@ -239,26 +239,28 @@ func TestDetectTransientColdStart(t *testing.T) {
 	for i := range pcm {
 		pcm[i] = float32(0.5 * math.Sin(2*math.Pi*440*float64(i)/sampleRate))
 	}
-	assert.True(t, detectTransient([][]float32{pcm}, &state),
+	isTransient, _, _ := detectTransient([][]float32{pcm}, &state)
+	assert.True(t, isTransient,
 		"a signal starting from zero history is a legitimate transient")
 }
 
 func TestDetectTransientEmpty(t *testing.T) {
 	state := newAnalysisState()
-	assert.False(t, detectTransient(nil, &state),
-		"empty PCM should be a defensive false")
-	assert.False(t, detectTransient([][]float32{}, &state),
-		"empty channels should be a defensive false")
+	nilTransient, _, _ := detectTransient(nil, &state)
+	assert.False(t, nilTransient, "empty PCM should be a defensive false")
+	emptyTransient, _, _ := detectTransient([][]float32{}, &state)
+	assert.False(t, emptyTransient, "empty channels should be a defensive false")
 	pcm := make([]float32, 0)
-	assert.False(t, detectTransient([][]float32{pcm}, &state),
-		"zero-length frame should be a defensive false")
+	zeroTransient, _, _ := detectTransient([][]float32{pcm}, &state)
+	assert.False(t, zeroTransient, "zero-length frame should be a defensive false")
 }
 
 func TestDetectTransientFrameSize2_5ms(t *testing.T) {
 	pcm := make([]float32, 120)
 	pcm[60] = 1.0
 	state := newAnalysisState()
-	_ = detectTransient([][]float32{pcm}, &state)
+	_, _, tfChan := detectTransient([][]float32{pcm}, &state)
+	assert.Zero(t, tfChan, "mono only has one channel to pick from")
 }
 
 func TestDCBlockRemovesConstantOffset(t *testing.T) {

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -361,7 +361,7 @@ func (e *Encoder) encodeAllocationTrim(
 	}
 }
 
-func (e *Encoder) choosePrefilter(pcm [][]float32, frameBytes int, transient bool) (bool, int, int, float32, int) {
+func (e *Encoder) choosePrefilter(pcm [][]float32, frameBytes int, tfEstimate float32) (bool, int, int, float32, int) {
 	// Run pitch detection on raw PCM — period is stable across pre-emphasis.
 	pitchPeriod, pitchGain := detectPitch(pcm[0])
 	pitchPeriod, pitchGain = removeDoubling(
@@ -372,7 +372,7 @@ func (e *Encoder) choosePrefilter(pcm [][]float32, frameBytes int, transient boo
 	enabled, qq, quantizedGain := prefilterDecision(
 		pitchPeriod, pitchGain,
 		e.analysis.prefilter.period, e.analysis.prefilter.gain,
-		frameBytes, len(pcm), transient,
+		frameBytes, len(pcm), tfEstimate,
 		uint(frameBytes)*8, e.rangeEncoder.Tell(),
 	)
 
@@ -575,9 +575,9 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 
 	e.rangeEncoder.Init()
 
-	transient := detectTransient(pcm, &e.analysis)
+	transient, tfEstimate, tfChan := detectTransient(pcm, &e.analysis)
 	prefilterEnabled, pitchPeriod, prefilterQq, prefilterGain, prefilterTapset := e.choosePrefilter(
-		pcm, frameBytes, transient,
+		pcm, frameBytes, tfEstimate,
 	)
 
 	analysis, err := analyzeFrame(
@@ -624,14 +624,16 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	// libopus disables variable tf resolution for very small frames; its
 	// fallback is tf_res = isTransient for every band, not zero.
 	if effectiveBytes >= 15*info.channelCount && e.complexity >= 2 {
+		// libopus measures tf resolution on the channel that drove the
+		// transient decision, so normalise that one rather than always
+		// channel 0. Handing tfAnalysis that channel directly keeps its
+		// own tf_chan index at 0.
 		normalized := normaliseBandsForEncoding(
-			&info, analysis.mdct[0], analysis.logBandAmp[0], e.normalisedBands[0][:0])
+			&info, analysis.mdct[tfChan], analysis.logBandAmp[tfChan], e.normalisedBands[tfChan][:0])
 		lambda := max(80, 20480/effectiveBytes+2)
-		// tfEstimate comes out of libopus's transient_analysis, which pion's
-		// detectTransient does not return; 0 is the value libopus starts from.
 		info.tfSelect = tfAnalysis(
 			normalized, info.lm, info.startBand, info.endBand, info.transient,
-			lambda, 0, 0, len(analysis.mdct[0]), &dr.importance, &info.tfChange,
+			lambda, tfEstimate, 0, len(analysis.mdct[tfChan]), &dr.importance, &info.tfChange,
 		)
 	} else {
 		for band := info.startBand; band < info.endBand; band++ {

--- a/internal/celt/pitch.go
+++ b/internal/celt/pitch.go
@@ -185,7 +185,7 @@ func tapsetFromSpread(spread int) int {
 //nolint:cyclop // Mirrors libopus threshold chain with multiple conditions.
 func prefilterDecision(
 	period int, gain float32, prevPeriod int, prevGain float32,
-	frameBytes, channels int, transient bool,
+	frameBytes, channels int, tfEstimate float32,
 	totalBits, tell uint,
 ) (enabled bool, qq int, quantizedGain float32) {
 	// Bitrate gate: need enough bytes for the ~15-bit post-filter header.
@@ -197,15 +197,16 @@ func prefilterDecision(
 		return false, 0, 0
 	}
 
-	// Strong transient without pitch continuity → disable.
-	if transient && absInt(period-prevPeriod)*10 > period {
-		return false, 0, 0
-	}
-
 	// Gain threshold: base 0.2, adjusted for continuity and bitrate.
 	threshold := float32(0.2)
 	if absInt(period-prevPeriod)*10 > period {
 		threshold += 0.2
+		// Only a very strong transient kills the prefilter outright; the
+		// threshold bump above already handles the merely-discontinuous
+		// case (celt_encoder.c:1503-1508).
+		if tfEstimate > 0.98 {
+			return false, 0, 0
+		}
 	}
 	if frameBytes < 25 {
 		threshold += 0.1

--- a/internal/celt/pitch_test.go
+++ b/internal/celt/pitch_test.go
@@ -180,33 +180,37 @@ func TestEncodePostFilterSkipsWhenStartBandNotZero(t *testing.T) {
 
 func TestPrefilterDecisionLowBitrate(t *testing.T) {
 	// frameBytes <= 12*channels → disabled.
-	enabled, _, _ := prefilterDecision(240, 0.9, 240, 0, 10, 1, false, 256, 1)
+	enabled, _, _ := prefilterDecision(240, 0.9, 240, 0, 10, 1, 0, 256, 1)
 	assert.False(t, enabled, "should be disabled at low bitrate")
 }
 
 func TestPrefilterDecisionWeakGain(t *testing.T) {
 	// gain < threshold (0.2) → disabled.
-	enabled, _, _ := prefilterDecision(240, 0.1, 240, 0, 100, 1, false, 800, 1)
+	enabled, _, _ := prefilterDecision(240, 0.1, 240, 0, 100, 1, 0, 800, 1)
 	assert.False(t, enabled, "should be disabled with weak gain")
 }
 
 func TestPrefilterDecisionStrongGain(t *testing.T) {
 	// Strong gain, stable pitch, enough bits → enabled.
-	enabled, qq, quantized := prefilterDecision(240, 0.8, 240, 0, 100, 1, false, 800, 1)
+	enabled, qq, quantized := prefilterDecision(240, 0.8, 240, 0, 100, 1, 0, 800, 1)
 	assert.True(t, enabled)
 	assert.Greater(t, qq, 0)
 	assert.Greater(t, quantized, float32(0))
 }
 
 func TestPrefilterDecisionTransientPitchChange(t *testing.T) {
-	// Transient with large pitch change → disabled.
-	enabled, _, _ := prefilterDecision(100, 0.9, 500, 0, 100, 1, true, 800, 1)
-	assert.False(t, enabled, "should be disabled on transient with pitch jump")
+	// Strong transient (tfEstimate > 0.98) with large pitch change → disabled.
+	enabled, _, _ := prefilterDecision(100, 0.9, 500, 0, 100, 1, 0.99, 800, 1)
+	assert.False(t, enabled, "should be disabled on strong transient with pitch jump")
+
+	// The same pitch jump on a milder transient only raises the gain threshold.
+	enabled, _, _ = prefilterDecision(100, 0.9, 500, 0, 100, 1, 0.5, 800, 1)
+	assert.True(t, enabled, "a mild transient should not kill the prefilter outright")
 }
 
 func TestPrefilterDecisionBitBudgetGate(t *testing.T) {
 	// tell+16 > totalBits → disabled.
-	enabled, _, _ := prefilterDecision(240, 0.9, 240, 0, 100, 1, false, 10, 1)
+	enabled, _, _ := prefilterDecision(240, 0.9, 240, 0, 100, 1, 0, 10, 1)
 	assert.False(t, enabled, "should be disabled when not enough bits for header")
 }
 

--- a/internal/celt/tf_analysis.go
+++ b/internal/celt/tf_analysis.go
@@ -70,9 +70,14 @@ func tfAnalysis(
 			}
 		}
 
+		// libopus sweeps LM + !isTransient - narrow levels: a narrow band has
+		// one resolution fewer to try, transient frame or not.
 		levels := lm
-		if !transient && !narrow {
+		if !transient {
 			levels++
+		}
+		if narrow {
+			levels--
 		}
 		for k := range levels {
 			b := k + 1


### PR DESCRIPTION
#### Description

`transient_analysis` in libopus produces three outputs, but we were only using one of them. The other two come from the same `mask_metric` we already calculate:

tf_max         = max(0, sqrt(27 * mask_metric) - 42)
tf_estimate = sqrt(max(0, 0.0069 * min(163, tf_max) - 0.139))
tf_chan        = the channel with the highest mask_metric

**`tf_chan`**: `tf_analysis` measures temporal resolution on a specific
channel, and libopus passes the channel that triggered the transient decision
(`celt_encoder.c:2259`). We were always using channel 0. I now pass the
selected channel directly, so the internal index stays at 0.

Measured at 96 kbps stereo on real music, the overall effect of this PR is
basically neutral: ±0.05 dB per band and 14.6653 → 14.6668 dB global SNR on a
full track. This is mainly about matching the libopus behavior, not improving
quality — just calling that out so it isn't read as a quality improvement.

**`tf_estimate`** is used as the bias for tf_analysis (:681) and also controls the prefilter cutoff (:1507). The latter was another divergence: we were disabling the prefilter when transient && pitch changed, effectively mask_metric > 200, while libopus uses tf_estimate > 0.98, which works out to mask_metric > 1504. So we were disabling the prefilter much more often than libopus does. The higher gain threshold already handles the case where the signal is simply
discontinuous.

There was also an off-by-one in the tfAnalysis loop. libopus runs LM + !isTransient - narrow levels, while we were doing LM + (!isTransient && !narrow), which adds one extra iteration on transient frames with narrow bands (width == 1, i.e. bands 0-7).

There's still one difference I haven't tracked down yet: our average tf_change is more negative than libopus (-6.2 vs -4.3), meaning we're choosing more temporal resolution than the reference does. I checked that importance follows dynalloc_analysis and that lambda matches, so the remaining difference seems to be somewhere in the L1 search or its input.

Reference issue
Part of the CELT encoder work.