### PR TITLE
Add missing SPDX header to intensity stereo test

### DIFF
--- a/internal/celt/intensity_stereo_test.go
+++ b/internal/celt/intensity_stereo_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
 package celt
 
 import (


### PR DESCRIPTION
#### Description

`internal/celt/intensity_stereo_test.go` landed in #181 without the SPDX
copyright and license header, so the REUSE check in `lint / test` fails on
every branch built on top of main. Adds the two standard lines.

#### Reference issue
Fixes #...
