### PR TITLE
Fix masking follower input in dynalloc analysis

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -827,8 +827,9 @@ func medianOf5(vals [5]float32) float32 {
 // dynallocAnalysis computes per-band boost offsets and spread weights.
 // Mirrors libopus celt_encoder.c:dynalloc_analysis.
 //
-// pion's logBandAmp = 0.5*log2(energy)-energyMeans; libopus bandLogE =
-// log2(energy). We convert internally so the follower thresholds match.
+// logBandAmp is libopus's bandLogE as-is: amp2Log2 takes the log of the band
+// amplitude, not the energy, and subtracts the same eMeans table. The noise
+// floor and follower thresholds below live in that domain.
 func dynallocAnalysis(
 	logBandAmp [2][maxBands]float32,
 	prevLogBandAmp [2][maxBands]float32,
@@ -841,19 +842,13 @@ func dynallocAnalysis(
 
 	var noiseFloor [maxBands]float32
 	for band := range endBand {
-		logN := float32(logN400[band]) / 8.0 // log2(band width)
-		noiseFloor[band] = 0.0625*logN +
+		noiseFloor[band] = 0.0625*float32(logN400[band]) +
 			0.5 + float32(9-lsbDepth) -
 			energyMeans[band] +
 			0.0062*float32((band+5)*(band+5))
 	}
 
-	var bandLogE [2][maxBands]float32
-	for ch := range channelCount {
-		for band := range endBand {
-			bandLogE[ch][band] = 2.0 * (logBandAmp[ch][band] + energyMeans[band])
-		}
-	}
+	bandLogE := logBandAmp
 
 	maxDepth := float32(-31.9)
 	for ch := range channelCount {
@@ -925,20 +920,23 @@ func dynallocAnalysis(
 		}
 	}
 
-	// follower tracks the previous frame's spectrum (bandLogE2 in libopus).
+	// bandLogE3 is libopus's bandLogE2, which below complexity 8 is just a
+	// copy of the current frame's bandLogE (celt_encoder.c:2211). logBandAmp
+	// already is that quantity — amp2Log2 takes the log of the amplitude —
+	// so it goes in as-is, mean-subtracted like the rest of the energies.
 	var follower [2][maxBands]float32
 	for ch := range channelCount {
 		var bandLogE3 [maxBands]float32
 		for band := range endBand {
-			bandLogE3[band] = 2.0 * (prevLogBandAmp[ch][band] + energyMeans[band])
+			bandLogE3[band] = bandLogE[ch][band]
 		}
 
-		// For LM==0, first 8 bands have 1 bin → unreliable. Take max with
-		// current bandLogE so at least 2 "bins" of context are used.
+		// For LM==0, first 8 bands have 1 bin → unreliable. Take max with the
+		// previous frame so at least 2 "bins" of context are used.
 		if lm == 0 {
 			for band := 0; band < endBand && band < 8; band++ {
-				if bandLogE[ch][band] > bandLogE3[band] {
-					bandLogE3[band] = bandLogE[ch][band]
+				if prevLogBandAmp[ch][band] > bandLogE3[band] {
+					bandLogE3[band] = prevLogBandAmp[ch][band]
 				}
 			}
 		}
@@ -956,7 +954,7 @@ func dynallocAnalysis(
 				follow[band] = prev
 			}
 		}
-		for band := last - 1; band > 0; band-- {
+		for band := last - 1; band >= 0; band-- {
 			next := follow[band+1] + 2.0
 			if next < follow[band] {
 				follow[band] = next
@@ -1071,48 +1069,39 @@ func dynallocAnalysis(
 		combined[0] += extra
 	}
 
-	// Cap at 4.0 log2 (≈ 24 dB) then divide by 8 to match libopus boost scale.
+	// The two SHR32s libopus applies here (celt_encoder.c:1240,1243) are the
+	// fixed-point Q-domain conversion — both no-ops in the float build — so the
+	// follower feeds the boost quanta unscaled.
 	totBoostBits := 0
-	boostCap := 2 * effectiveBytes / 3 * 8 * 8 // 2/3 of budget in 1/8-bit units
 	for band := startBand; band < endBand; band++ {
 		if combined[band] > 4.0 {
 			combined[band] = 4.0
 		}
-		scaled := combined[band] / 8.0
 		width := channelCount * (int(bandEdges[band+1] - bandEdges[band])) << lm
 
 		var boost int
 		var boostBits int
 		switch {
 		case width < 6:
-			boost = int(scaled)
+			boost = int(combined[band])
 			boostBits = boost * width << bitResolution
 		case width > 48:
-			boost = int(scaled * 8)
+			boost = int(combined[band] * 8)
 			boostBits = (boost * width << bitResolution) / 8
 		default:
-			boost = int(scaled * float32(width) / 6.0)
+			boost = int(combined[band] * float32(width) / 6.0)
 			boostBits = boost * 6 << bitResolution
 		}
 
-		if totBoostBits+boostBits > boostCap {
-			// Clamp to remaining budget.
-			remaining := max(0, boostCap-totBoostBits)
-			// convert remaining bits back to boost quanta
-			switch {
-			case width < 6:
-				boost = remaining >> bitResolution / max(1, width)
-			case width > 48:
-				boost = remaining << 3 / max(1, width) >> bitResolution
-			default:
-				boost = remaining >> bitResolution / 6
-			}
-			if boost < 0 {
-				boost = 0
-			}
-			boostBits = remaining
-		}
+		// CBR keeps dynalloc under 2/3 of the frame. libopus hands the leftover
+		// budget to this band as the offset and stops boosting entirely.
+		if (totBoostBits+boostBits)>>bitResolution>>3 > 2*effectiveBytes/3 {
+			capBits := (2 * effectiveBytes / 3) << bitResolution << 3
+			offsets[band] = capBits - totBoostBits
+			totBoostBits = capBits
 
+			break
+		}
 		offsets[band] = boost
 		totBoostBits += boostBits
 	}


### PR DESCRIPTION
#### Description

Comparing `tf_analysis` state frame by frame against an instrumented libopus build, `metric[]` and `lambda` matched almost exactly, but `importance[]` did not:

|                                      | libopus        | pion  |
|--------------------------------------|----------------|-------|
| `importance == 13` (follower ≈ 0)    | 94.2% of bands | 52.7% |
| Tail up to 208 (the maximum)         | ~0%            | 47%   |

`importance = floor(0.5 + 13 * 2^min(follower, 4))`, so we were treating a large number of bands as much more prominent than libopus does. That feeds both the `tf_analysis` Viterbi weights and the dynamic allocation band boosts.

There were five separate issues in `dynallocAnalysis`:

**`bandLogE` was in the wrong domain.** We built it as `2.0 * (logBandAmp + energyMeans)`, effectively `2 * log2(amplitude)`, while libopus's `bandLogE` is `log2(amplitude) - eMeans`. `amp2Log2` already returns the log of the band amplitude, so `logBandAmp` is the right quantity and doesn't need the extra conversion. This had our band energies reading about 15 log2 units above the reference.

**`bandLogE3` had three problems at once.** It was built from `2.0 * (prevLogBandAmp + energyMeans)`. This corresponds to libopus's `bandLogE2`, which below complexity 8 is a copy of the current frame's `bandLogE` (`celt_encoder.c:2211`), not the previous frame. It also inherited the same scaling error.

**`noiseFloor` was dividing `logN400` by 8.** libopus uses `0.0625 * logN[i]` with `logN` as stored, and our table contains the same values. The extra division made the floor 8x too small, so it was effectively never doing anything.

**The follower backward pass skipped band 0.** We used `band > 0`, while libopus runs all the way down to `i >= 0`.

**Dynalloc boosts were never actually emitted.** We calculated `boost` as `combined[band] / 8.0`. In libopus, the corresponding `SHR32(follower[i], 8)` and `SHR32(follower[i], DB_SHIFT-8)` (`celt_encoder.c:1240,1243`) are fixed-point Q-domain conversions and both become no-ops in the float build. With the extra `/8`, every boost truncated to zero, so dynamic allocation was effectively disabled:

| band | Boost before | Boost after    | libopus |
|------|--------------|----------------|---------|
| 1    | 0.000        | 7.834          | 8.288   |
| 2    | 0.000        | 6.029          | 5.602   |
| 6    | 0.000        | 3.645 (approx) | 3.645   |

The cap path also differed. When adding a boost would exceed 2/3 of the frame, libopus assigns `cap - tot_boost` to that band and stops there.

After the fixes, `bandLogE`, the combined follower excess, and the `importance == 13` rate all track libopus closely, band by band. For example, on band 0: `bandLogE` is 2.14 vs 2.16, follower excess is 0.0099 vs 0.0104, and the `importance == 13` rate is 96.2% vs 95.9%.

`tf_res = 1` per frame also moves from 3.70 to 3.32 (libopus: 2.88).

Measured at 96 kbps stereo on real music:

|        | 25 s clip  | Full 213 s track | Bad 10 ms windows |
|--------|------------|------------------|-------------------|
| Before | 14.7973 dB | 14.6668 dB       | 3                 |
| After  | 14.8834 dB | 14.7858 dB       | 1                 |

One thing worth calling out for review: fixing only the other four issues gives a slightly higher SNR on the short clip if the `bandLogE` conversion is left as it was. But that's accidental compensation from another wrong domain. In that version, band 0 is over-boosted to 17.85 dB, while libopus gives 17.44 dB. With the conversion fixed, we land at 17.45 dB.

So the slightly better aggregate number from the partial fix was coming from two errors cancelling each other out.

#### Reference issue
Part of the CELT encoder work.