### PR TITLE
Port CELT spreading decision from libopus

### DIFF
--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -396,58 +396,127 @@ func computeBandLogAmp(freq []float32, lm int, startBand int, endBand int) [maxB
 // energy gives a value near 0 (noise-like). This is the floating-point
 // equivalent of the per-band CDF step inside libopus spreading_decision
 // (celt_encoder.c). spreadWeight comes from dynallocAnalysis masking model.
+// bandSpreadMetric returns libopus's per-band tonality score (0-3) and the
+// high-band CDF contribution. It is a rough CDF of |x|²·N against three
+// thresholds: on a unit-norm band the average bin sits at 1/N, so x²·N near 1
+// means flat (noisy) and a long tail below the thresholds means tonal.
+func bandSpreadMetric(x []float32, band int) (score, hf int) {
+	n := len(x)
+	var tcount [3]int
+	for _, v := range x {
+		x2n := v * v * float32(n)
+		if x2n < 0.25 {
+			tcount[0]++
+		}
+		if x2n < 0.0625 {
+			tcount[1]++
+		}
+		if x2n < 0.015625 {
+			tcount[2]++
+		}
+	}
+
+	// Only the last four bands (8 kHz and up) feed the tapset.
+	if band > maxBands-4 {
+		hf = 32 * (tcount[1] + tcount[0]) / n
+	}
+	score = boolIndex(2*tcount[2] >= n) + boolIndex(2*tcount[1] >= n) + boolIndex(2*tcount[0] >= n)
+
+	return score, hf
+}
+
+// updateTapset folds the high-band CDF into the running average and picks the
+// pre-filter tapset, mirroring libopus spreading_decision (celt/bands.c:518).
+func updateTapset(hfSum, channelCount, endBand int, hfAverage, tapsetDecision *int) {
+	if hfSum != 0 {
+		hfSum /= channelCount * (4 - maxBands + endBand)
+	}
+	*hfAverage = (*hfAverage + hfSum) >> 1
+	hfSum = *hfAverage
+	switch *tapsetDecision {
+	case 2:
+		hfSum += 4
+	case 0:
+		hfSum -= 4
+	}
+	switch {
+	case hfSum > 22:
+		*tapsetDecision = 2
+	case hfSum > 18:
+		*tapsetDecision = 1
+	default:
+		*tapsetDecision = 0
+	}
+}
+
+// sweepSpreadMetric accumulates the weighted per-band tonality scores over
+// every coded band of every channel. Bands too narrow to give a usable CDF are
+// skipped, matching libopus.
+func sweepSpreadMetric(
+	channels [][]float32, scale, startBand, endBand int, spreadWeight [maxBands]int,
+) (sum, nbBands, hfSum int) {
+	for _, bands := range channels {
+		for band := startBand; band < endBand; band++ {
+			lo := scale * int(bandEdges[band])
+			n := scale * int(bandEdges[band+1]-bandEdges[band])
+			if n <= 8 || lo+n > len(bands) {
+				continue
+			}
+			score, hf := bandSpreadMetric(bands[lo:lo+n], band)
+			hfSum += hf
+			sum += score * spreadWeight[band]
+			nbBands += spreadWeight[band]
+		}
+	}
+
+	return sum, nbBands, hfSum
+}
+
+// spreadingDecision picks the spectral spreading level applied by expRotation,
+// mirroring libopus spreading_decision (celt/bands.c:470). It also updates the
+// pre-filter tapset, which the reference derives from the same statistics.
+//
+// Note the direction: a tonal spectrum (energy concentrated in few bins) needs
+// no spreading, while a flat, noise-like one asks for the most.
 func spreadingDecision(
-	mdct []float32, lm, startBand, endBand int,
-	prevAvg *float32, prevDecision int,
+	normalized [2][]float32,
+	lm, startBand, endBand, channelCount int,
+	average, hfAverage, tapsetDecision *int,
+	lastDecision int,
+	updateHF bool,
 	spreadWeight [maxBands]int,
 ) int {
 	scale := 1 << lm
-	var sum float32
-	nBands := 0
-
-	for band := startBand; band < endBand; band++ {
-		lo := scale * int(bandEdges[band])
-		hi := scale * int(bandEdges[band+1])
-		n := hi - lo
-		if n < 2 {
-			continue
-		}
-
-		weight := spreadWeight[band]
-		if weight == 0 {
-			continue
-		}
-
-		var energy, maxE float32
-		for i := lo; i < hi; i++ {
-			e := mdct[i] * mdct[i]
-			energy += e
-			if e > maxE {
-				maxE = e
-			}
-		}
-
-		mean := energy / float32(n)
-		if mean < 1e-30 || maxE < 1e-30 {
-			continue
-		}
-
-		// 0 when all bins are equal (noise), near 1 when one bin dominates (tonal).
-		tonality := 1 - mean/maxE
-		sum += tonality * float32(weight)
-		nBands += weight
+	// A last band this narrow carries no usable statistics.
+	if scale*int(bandEdges[endBand]-bandEdges[endBand-1]) <= 8 {
+		return spreadNone
 	}
 
-	if nBands == 0 {
-		return prevDecision
+	sum, nbBands, hfSum := sweepSpreadMetric(normalized[:channelCount], scale, startBand, endBand, spreadWeight)
+
+	if updateHF {
+		updateTapset(hfSum, channelCount, endBand, hfAverage, tapsetDecision)
+	}
+	if nbBands == 0 {
+		return lastDecision
 	}
 
-	avg := sum / float32(nBands)
-	// Recursive inter-frame average damps single-frame spikes.
-	avg = 0.5 * (avg + *prevAvg)
-	*prevAvg = avg
+	sum = (sum << 8) / nbBands
+	// Recursive averaging, then hysteresis around the previous decision.
+	sum = (sum + *average) >> 1
+	*average = sum
+	sum = (3*sum + (((3 - lastDecision) << 7) + 64) + 2) >> 2
 
-	return hysteresisDecision(avg, prevDecision, [3]float32{0.15, 0.40, 0.65})
+	switch {
+	case sum < 80:
+		return spreadAggressive
+	case sum < 256:
+		return spreadNormal
+	case sum < 384:
+		return spreadLight
+	default:
+		return spreadNone
+	}
 }
 
 // applyDCBlock applies a first-order IIR high-pass at dcBlockCutoffHz to

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -11,89 +11,117 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSpreadingDecisionTonalSignal(t *testing.T) {
-	// A spectrum with one dominant bin per band should read as tonal (high metric)
-	// and produce at least NORMAL spreading after warmup.
-	lm := maxLM
+// normalisedBands builds a [2][]float32 whoseeach band has unit norm, using per
+// bin values from gen.
+func normalisedBands(lm int, gen func(band, i, n int) float32) [2][]float32 {
 	scale := 1 << lm
-	mdct := make([]float32, scale*int(bandEdges[maxBands]))
-
+	buf := make([]float32, scale*int(bandEdges[maxBands]))
 	for band := range maxBands {
 		lo := scale * int(bandEdges[band])
-		hi := scale * int(bandEdges[band+1])
-		if hi > lo {
-			// put all energy in the first bin of each band
-			mdct[lo] = 1.0
+		n := scale * int(bandEdges[band+1]-bandEdges[band])
+		var norm float64
+		for i := range n {
+			v := gen(band, i, n)
+			buf[lo+i] = v
+			norm += float64(v) * float64(v)
+		}
+		if norm > 0 {
+			inv := float32(1 / math.Sqrt(norm))
+			for i := range n {
+				buf[lo+i] *= inv
+			}
 		}
 	}
 
-	var prevAvg float32
-	prev := defaultSpreadDecision
-	var decision int
-	for range 8 {
-		decision = spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, prev, uniformSpreadWeight())
-		prev = decision
+	return [2][]float32{buf, buf}
+}
+
+func runSpreading(bands [2][]float32, lm, frames int) int {
+	avg, hf, tapset := 0, 0, 0
+	decision := defaultSpreadDecision
+	for range frames {
+		decision = spreadingDecision(bands, lm, 0, maxBands, 1, &avg, &hf, &tapset,
+			decision, true, uniformSpreadWeight())
 	}
-	assert.GreaterOrEqual(t, decision, spreadNormal,
-		"spike-per-band spectrum should reach at least NORMAL after warmup (got %d)", decision)
+
+	return decision
+}
+
+func TestSpreadingDecisionTonalSignal(t *testing.T) {
+	// One dominant bin per band: almost every bin falls below all three CDF
+	// thresholds, so the metric saturates and no spreading is applied.
+	bands := normalisedBands(maxLM, func(_, i, _ int) float32 {
+		if i == 0 {
+			return 1.0
+		}
+
+		return 0
+	})
+	assert.Equal(t, spreadNone, runSpreading(bands, maxLM, 8),
+		"a spike per band is tonal and should end up at SPREAD_NONE")
 }
 
 func TestSpreadingDecisionNoiseSignal(t *testing.T) {
-	// A flat spectrum (uniform energy per bin) is noise-like and should settle
-	// at NONE or LIGHT after warmup.
-	lm := maxLM
-	scale := 1 << lm
-	mdct := make([]float32, scale*int(bandEdges[maxBands]))
-	for i := range mdct {
-		mdct[i] = 0.01
-	}
-
-	var prevAvg float32
-	prev := defaultSpreadDecision
-	var decision int
-	for range 8 {
-		decision = spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, prev, uniformSpreadWeight())
-		prev = decision
-	}
-	assert.LessOrEqual(t, decision, spreadLight,
-		"uniform-energy spectrum should settle at NONE or LIGHT after warmup (got %d)", decision)
+	// Flat band: every bin sits at 1/sqrt(N), so x²·N is 1 and clears every
+	// threshold. That is the noisiest reading and asks for full spreading.
+	bands := normalisedBands(maxLM, func(_, _, _ int) float32 { return 1 })
+	assert.Equal(t, spreadAggressive, runSpreading(bands, maxLM, 8),
+		"a flat band is noise-like and should end up at SPREAD_AGGRESSIVE")
 }
 
 func TestSpreadingDecisionRecursiveAvg(t *testing.T) {
-	// Two independent runs of N frames should produce the same avg value as a
-	// single run of 2N frames because the recursive average is stateless
-	// between calls.
-	lm := maxLM
-	scale := 1 << lm
-	mdct := make([]float32, scale*int(bandEdges[maxBands]))
-	for i := range mdct {
-		mdct[i] = 0.1 * float32(i%7+1)
-	}
+	// Half the bands tonal, half flat, so the metric lands mid-range and the
+	// recursive average needs several frames to converge.
+	bands := normalisedBands(maxLM, func(band, i, _ int) float32 {
+		if band%2 == 0 {
+			if i == 0 {
+				return 1.0
+			}
 
-	var avgA float32
-	prevA := defaultSpreadDecision
-	for range 4 {
-		prevA = spreadingDecision(mdct, lm, 0, maxBands, &avgA, prevA, uniformSpreadWeight())
-	}
+			return 0
+		}
 
-	var avgB float32
-	prevB := defaultSpreadDecision
+		return 1
+	})
+
+	avgA, hfA, tapA := 0, 0, 0
+	spreadingDecision(bands, maxLM, 0, maxBands, 1, &avgA, &hfA, &tapA,
+		defaultSpreadDecision, true, uniformSpreadWeight())
+
+	avgB, hfB, tapB := 0, 0, 0
+	prev := defaultSpreadDecision
 	for range 8 {
-		prevB = spreadingDecision(mdct, lm, 0, maxBands, &avgB, prevB, uniformSpreadWeight())
+		prev = spreadingDecision(bands, maxLM, 0, maxBands, 1, &avgB, &hfB, &tapB, prev, true, uniformSpreadWeight())
 	}
 
-	// After more frames the avg should converge further; after 8 frames it
-	// must not be identical to after 4.
-	assert.NotEqual(t, avgA, avgB, "recursive average should differ after different frame counts")
+	assert.NotEqual(t, avgA, avgB, "the recursive average should keep converging past the first frame")
 }
 
-func TestSpreadingDecisionSilentFrame(t *testing.T) {
-	lm := maxLM
-	mdct := make([]float32, (1<<lm)*int(bandEdges[maxBands]))
-	var prevAvg float32
-	// All zero input: should return prevDecision unchanged.
-	got := spreadingDecision(mdct, lm, 0, maxBands, &prevAvg, spreadNormal, uniformSpreadWeight())
-	assert.Equal(t, spreadNormal, got, "silent frame should return prevDecision")
+func TestSpreadingDecisionNarrowLastBand(t *testing.T) {
+	// libopus bails out to SPREAD_NONE when the last band is too narrow to
+	// carry usable statistics (celt/bands.c:484).
+	bands := normalisedBands(0, func(_, _, _ int) float32 { return 1 })
+	avg, hf, tapset := 0, 0, 0
+	got := spreadingDecision(bands, 0, 0, 2, 1, &avg, &hf, &tapset,
+		spreadNormal, true, uniformSpreadWeight())
+	assert.Equal(t, spreadNone, got, "a narrow last band should short-circuit to SPREAD_NONE")
+}
+
+func TestSpreadingDecisionUpdatesTapset(t *testing.T) {
+	// The high-band CDF drives tapset_decision, which the pre-filter reads.
+	bands := normalisedBands(maxLM, func(_, i, _ int) float32 {
+		if i == 0 {
+			return 1.0
+		}
+
+		return 0
+	})
+	avg, hf, tapset := 0, 0, 0
+	for range 8 {
+		spreadingDecision(bands, maxLM, 0, maxBands, 1, &avg, &hf, &tapset,
+			defaultSpreadDecision, true, uniformSpreadWeight())
+	}
+	assert.Equal(t, 2, tapset, "a tonal high band should push tapset to 2")
 }
 
 func TestAnalyzeFrameAdaptiveSpread(t *testing.T) {

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -45,7 +45,9 @@ type Encoder struct {
 	cwrsScratch       []uint32
 	normalisedBands   [2][]float32
 
-	prevSpreadAvg      float32
+	spreadAverage      int
+	hfAverage          int
+	tapsetDecision     int
 	prevSpreadDecision int
 	prevIntensityBand  int
 	// lastCodedBands feeds the band-skip hysteresis in computeAllocation
@@ -120,7 +122,9 @@ func (e *Encoder) Reset() {
 	}
 	e.cwrsScratch = make([]uint32, 0, cwrsMaxPulseCount+2)
 
-	e.prevSpreadAvg = 0
+	e.spreadAverage = 0
+	e.hfAverage = 0
+	e.tapsetDecision = 0
 	e.prevSpreadDecision = defaultSpreadDecision
 	e.prevIntensityBand = 0
 	e.lastCodedBands = 0
@@ -361,6 +365,42 @@ func (e *Encoder) encodeAllocationTrim(
 	}
 }
 
+// chooseSpread runs the spreading_decision estimator, or falls back to a flat
+// level. libopus only runs the estimator at complexity>=3 with long blocks and
+// enough of a byte budget (celt_encoder.c ~line 2317); below that it uses
+// SPREAD_NORMAL, or SPREAD_NONE at complexity 0 specifically.
+func (e *Encoder) chooseSpread(
+	info *frameSideInfo, normalized [2][]float32, spreadWeight [maxBands]int,
+	effectiveBytes int, prefilterEnabled bool,
+) int {
+	if info.transient || e.complexity < 3 || effectiveBytes < 10*info.channelCount {
+		if e.complexity == 0 {
+			return spreadNone
+		}
+
+		return spreadNormal
+	}
+
+	return spreadingDecision(
+		normalized, info.lm, info.startBand, info.endBand, info.channelCount,
+		&e.spreadAverage, &e.hfAverage, &e.tapsetDecision,
+		e.prevSpreadDecision, prefilterEnabled && !info.transient,
+		spreadWeight,
+	)
+}
+
+// normaliseChannels divides every band by its amplitude so each one carries
+// unit norm, which is the domain the analysis stages downstream expect.
+func (e *Encoder) normaliseChannels(info *frameSideInfo, analysis *analysisResult) [2][]float32 {
+	var out [2][]float32
+	for ch := range info.channelCount {
+		out[ch] = normaliseBandsForEncoding(
+			info, analysis.mdct[ch], analysis.logBandAmp[ch], e.normalisedBands[ch][:0])
+	}
+
+	return out
+}
+
 func (e *Encoder) choosePrefilter(pcm [][]float32, frameBytes int, tfEstimate float32) (bool, int, int, float32, int) {
 	// Run pitch detection on raw PCM — period is stable across pre-emphasis.
 	pitchPeriod, pitchGain := detectPitch(pcm[0])
@@ -376,7 +416,7 @@ func (e *Encoder) choosePrefilter(pcm [][]float32, frameBytes int, tfEstimate fl
 		uint(frameBytes)*8, e.rangeEncoder.Tell(),
 	)
 
-	tapset := tapsetFromSpread(e.prevSpreadDecision)
+	tapset := e.tapsetDecision
 	if enabled && shouldCancelPrefilter(pcm, e.mode.SampleRate(), &e.analysis, pitchPeriod, quantizedGain, tapset) {
 		return false, pitchPeriod, 0, 0, tapset
 	}
@@ -621,18 +661,19 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	offsets := dr.offsets
 	spreadWeight := dr.spreadWeight
 
+	// tf_analysis and spreading_decision both read the normalised bands, so
+	// build them once here (libopus normalise_bands, celt_encoder.c:2241).
 	// libopus disables variable tf resolution for very small frames; its
 	// fallback is tf_res = isTransient for every band, not zero.
+	normalized := e.normaliseChannels(&info, &analysis)
+
 	if effectiveBytes >= 15*info.channelCount && e.complexity >= 2 {
-		// libopus measures tf resolution on the channel that drove the
-		// transient decision, so normalise that one rather than always
-		// channel 0. Handing tfAnalysis that channel directly keeps its
-		// own tf_chan index at 0.
-		normalized := normaliseBandsForEncoding(
-			&info, analysis.mdct[tfChan], analysis.logBandAmp[tfChan], e.normalisedBands[tfChan][:0])
 		lambda := max(80, 20480/effectiveBytes+2)
+		// libopus measures tf resolution on the channel that drove the
+		// transient decision, not always channel 0. Handing tfAnalysis that
+		// channel directly keeps its own tf_chan index at 0.
 		info.tfSelect = tfAnalysis(
-			normalized, info.lm, info.startBand, info.endBand, info.transient,
+			normalized[tfChan], info.lm, info.startBand, info.endBand, info.transient,
 			lambda, tfEstimate, 0, len(analysis.mdct[tfChan]), &dr.importance, &info.tfChange,
 		)
 	} else {
@@ -643,22 +684,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	}
 	e.encodeTimeFrequencyChanges(&info)
 
-	// libopus only runs the full spreading_decision() estimator when
-	// complexity>=3 and the frame has long blocks and enough of a byte
-	// budget (celt_encoder.c ~line 2317); otherwise it uses a flat
-	// SPREAD_NORMAL, or SPREAD_NONE at complexity==0 specifically.
-	if info.transient || e.complexity < 3 || effectiveBytes < 10*info.channelCount {
-		if e.complexity == 0 {
-			info.spread = spreadNone
-		} else {
-			info.spread = spreadNormal
-		}
-	} else {
-		info.spread = spreadingDecision(
-			analysis.mdct[0], info.lm, info.startBand, info.endBand,
-			&e.prevSpreadAvg, e.prevSpreadDecision, spreadWeight,
-		)
-	}
+	info.spread = e.chooseSpread(&info, normalized, spreadWeight, effectiveBytes, prefilterEnabled)
 	e.prevSpreadDecision = info.spread
 	e.encodeSpread(&info)
 	totalBitsEighth := e.encodeDynamicAllocation(&info, offsets)
@@ -694,9 +720,9 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 				float64(analysis.logBandAmp[ch][band]+energyMeans[band])))
 		}
 	}
-	shape0 := normaliseBandsForEncoding(&info, analysis.mdct[0], analysis.logBandAmp[0], e.normalisedBands[0][:0])
+	shape0 := normalized[0]
 	if info.channelCount == 2 {
-		shape1 := normaliseBandsForEncoding(&info, analysis.mdct[1], analysis.logBandAmp[1], e.normalisedBands[1][:0])
+		shape1 := normalized[1]
 		_ = quantAllBandsStereo(&info, shape0, shape1, totalBits, &bandState,
 			e.pvqY, e.pvqAbsX, e.pvqSign, e.cwrsScratch)
 	} else {

--- a/internal/celt/pitch.go
+++ b/internal/celt/pitch.go
@@ -161,22 +161,6 @@ func quantizePitchGain(gain float32) (qq int, quantized float32) {
 	return qq, quantized
 }
 
-// tapsetFromSpread maps the spread decision to a pre-filter tapset.
-// AGGRESSIVE (tonal) → tapset 2 (strongest), NORMAL → 1, NONE → 0 (lightest).
-// This is a simplified version of libopus spreading_decision's hf_sum logic
-// (celt/bands.c) — the full HF tonality measure with ±4 hysteresis is left
-// for a future PR.
-func tapsetFromSpread(spread int) int {
-	switch spread {
-	case spreadAggressive:
-		return 2
-	case spreadNormal:
-		return 1
-	default:
-		return 0
-	}
-}
-
 // prefilterDecision implements the gain-threshold logic from libopus
 // run_prefilter (celt_encoder.c lines 1499-1540). Returns enabled=false when
 // the pre-filter would hurt more than help (low gain, low bitrate, strong

--- a/internal/celt/pitch_test.go
+++ b/internal/celt/pitch_test.go
@@ -214,13 +214,6 @@ func TestPrefilterDecisionBitBudgetGate(t *testing.T) {
 	assert.False(t, enabled, "should be disabled when not enough bits for header")
 }
 
-func TestTapsetFromSpread(t *testing.T) {
-	assert.Equal(t, 2, tapsetFromSpread(spreadAggressive))
-	assert.Equal(t, 1, tapsetFromSpread(spreadNormal))
-	assert.Equal(t, 0, tapsetFromSpread(spreadNone))
-	assert.Equal(t, 0, tapsetFromSpread(spreadLight))
-}
-
 func TestCancelPitchMono(t *testing.T) {
 	before := [2]float64{100}
 


### PR DESCRIPTION
#### Description

`spreadingDecision` was a reinvention rather than a port: it measured `1 - mean/maxE` over the **raw** MDCT of a single channel and mapped it through float thresholds. libopus builds a rough CDF of `|x|²·N` against three fixed thresholds (0.25, 0.0625, 0.015625) over the **normalised** bands of **both** channels, in integer arithmetic, and derives the pre-filter tapset from the same statistics (`celt/bands.c:470`).

**The direction was inverted.** In libopus a tonal spectrum — energy concentrated in a few bins — returns `SPREAD_NONE`, because it needs no rotation, while a flat, noise-like one returns `SPREAD_AGGRESSIVE`. Ours did the opposite, so on music (which is fairly tonal) it picked AGGRESSIVE 94% of the time: we were applying the strongest rotation to exactly the content that wants the least. The old unit tests encoded the inverted semantics (`assert.GreaterOrEqual(decision, spreadNormal)` for a tonal signal), so they passed; they are rewritten here.

| spread | before | after | libopus |
|---|---|---|---|
| NORMAL | 5.9% | 84.7% | 98.4% |
| AGGRESSIVE | 94.1% | 15.3% | 1.6% |

Two supporting changes:

- The normalised bands are now built once per frame and shared by `tf_analysis` and `spreading_decision`, which is what libopus does (`normalise_bands`, `celt_encoder.c:2241`). Previously only the tf channel was normalised at that point.

- `tapsetFromSpread` derived the pre-filter tapset from the spread level, with a comment noting the real HF measure was left for later. That measure is part of `spreading_decision` (`hf_average` plus ±4 hysteresis), so it now comes from the right place and the helper is gone along with its test.

Measured at 96 kbps stereo on real music, global SNR: 14.7973 → 14.8238 dB on a 25 s clip and 14.6668 → 14.6938 dB on a full 213 s track, with 10 ms windows below 3 dB SNR dropping from 3 to 2.

#### Reference issue

Part of the CELT encoder work.