### PR TITLE
Fix TF resolution sweep for narrow bands

### DIFF
--- a/internal/celt/tf_analysis.go
+++ b/internal/celt/tf_analysis.go
@@ -70,14 +70,11 @@ func tfAnalysis(
 			}
 		}
 
-		// libopus sweeps LM + !isTransient - narrow levels: a narrow band has
-		// one resolution fewer to try, transient frame or not.
+		// libopus sweeps LM + !(isTransient||narrow) levels: the extra
+		// resolution is only tried on a wide band of a non-transient frame.
 		levels := lm
-		if !transient {
+		if !transient && !narrow {
 			levels++
-		}
-		if narrow {
-			levels--
 		}
 		for k := range levels {
 			b := k + 1


### PR DESCRIPTION
#### Description
I misread the loop bound when porting this in #187. libopus runs

```c
for (k=0;k<LM+!(isTransient||narrow);k++) 
```
so the extra resolution is only swept when the frame is not transient and the band is not narrow. I read it as LM + !isTransient - narrow, which takes one resolution away from narrow bands on transient frames too. The code before #187 was right; this restores it and states the condition the way the reference does.

The effect shows up on bands 0-7 (width 1) in transient frames: they could only reach best_level = LM-1, so metric topped out at 2*(LM-1) where the reference reaches 2*LM. On a transient frame at 20 ms that is 4 instead of 6, which then feeds the tf_select decision and, through it, recombine and the per-partition bit budgets.

Comparing per-frame against an instrumented libopus build on real music, metric now matches the reference on 63.7% of frames instead of 59.4%, and the tf_select costs on 63.9% instead of 59.7%. Global SNR at 96 kbps stereo: 14.9194 → 14.9228 dB on a 25 s clip and 14.8309 → 14.8345 dB on a full track.

Reference issue
Part of the CELT encoder work.