### PR TITLE
Fix CELT pre-filter application and gating

### DIFF
--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -166,20 +166,25 @@ func applyPrefilterChannel(
 	ch int, state *analysisState, src, pre []float32,
 	prefilterEnabled bool, prefilterPeriod int, prefilterGain float32, prefilterTapset int,
 ) {
-	if prefilterEnabled {
-		dst := state.prefilterOut[ch][:len(src)]
-		// The crossfade starts from the previous frame's filter, which is
-		// still in prefilter.period/gain/tapset here — updatePrefilterState
-		// only rotates them in after the frame is encoded.
-		applyPrefilter(
-			dst, src,
-			state.prefilter.period, prefilterPeriod,
-			len(pre),
-			state.prefilter.gain, prefilterGain,
-			state.prefilter.tapset, prefilterTapset,
-		)
-		copy(pre, dst[postfilterHistorySampleCount:])
+	// libopus runs the comb filter on every frame, not just filtered ones
+	// (celt_encoder.c: run_prefilter). A frame that turns the pre-filter off
+	// still has to fade the previous frame's gain down to zero, or it leaves a
+	// step the decoder's post-filter cannot follow.
+	if !prefilterEnabled {
+		prefilterGain = 0
 	}
+	dst := state.prefilterOut[ch][:len(src)]
+	// The crossfade starts from the previous frame's filter, which is
+	// still in prefilter.period/gain/tapset here — updatePrefilterState
+	// only rotates them in after the frame is encoded.
+	applyPrefilter(
+		dst, src,
+		state.prefilter.period, prefilterPeriod,
+		len(pre),
+		state.prefilter.gain, prefilterGain,
+		state.prefilter.tapset, prefilterTapset,
+	)
+	copy(pre, dst[postfilterHistorySampleCount:])
 	// The history advances every frame, filtered or not (libopus updates
 	// prefilter_mem outside the pf_on branch); otherwise the comb filter
 	// picks up stale samples whenever it switches back on. It carries the

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -457,6 +457,11 @@ func (e *Encoder) choosePrefilter(
 		frameBytes, len(srcs), tfEstimate,
 		uint(frameBytes)*8, e.rangeEncoder.Tell(),
 	)
+	if enabled && shouldCancelPrefilter(
+		srcs, &e.analysis, frameSampleCount, pitchPeriod, quantizedGain, e.tapsetDecision,
+	) {
+		enabled, qq, quantizedGain = false, 0, 0
+	}
 
 	return enabled, pitchPeriod, qq, quantizedGain, e.tapsetDecision
 }

--- a/internal/celt/pitch.go
+++ b/internal/celt/pitch.go
@@ -85,9 +85,76 @@ func prefilterDecision(
 		return false, 0, 0
 	}
 
+	// Snap to the previous gain when the change is small: the post-filter
+	// crossfades between frames, so letting the gain flap by one quantizer
+	// step every frame modulates the output for no benefit.
+	if abs32(gain-prevGain) < 0.1 {
+		gain = prevGain
+	}
+
 	qq, quantizedGain = quantizePitchGain(gain)
 
 	return true, qq, quantizedGain
+}
+
+// shouldCancelPrefilter applies the comb filter to a scratch copy and reports
+// whether it actually reduced the signal. libopus runs the filter first and
+// reverts when the answer is no (celt_encoder.c: run_prefilter), because the
+// gain threshold alone lets through frames the filter makes worse.
+func shouldCancelPrefilter(
+	srcs [][]float32, state *analysisState, frameSampleCount, period int, gain float32, tapset int,
+) bool {
+	var before, after [2]float64
+	for ch, src := range srcs {
+		before[ch] = measureEnergy(src, postfilterHistorySampleCount, frameSampleCount)
+		dst := state.prefilterOut[ch][:len(src)]
+		// Must mirror what applyPrefilterChannel will run, crossfade endpoints
+		// included, or the decision is about a different filter.
+		applyPrefilter(
+			dst, src,
+			state.prefilter.period, period,
+			frameSampleCount,
+			state.prefilter.gain, gain,
+			state.prefilter.tapset, tapset,
+		)
+		after[ch] = measureEnergy(dst, postfilterHistorySampleCount, frameSampleCount)
+	}
+
+	return cancelPitch(len(srcs), gain, before, after)
+}
+
+// cancelPitch compares the sum of absolute samples before and after filtering
+// and reports whether the pre-filter should be reverted.
+func cancelPitch(channels int, gain float32, before, after [2]float64) bool {
+	if channels == 1 {
+		return after[0] > before[0]
+	}
+
+	gain64 := float64(gain)
+	thresh0 := 0.25*gain64*before[0] + 0.01*before[1]
+	thresh1 := 0.25*gain64*before[1] + 0.01*before[0]
+
+	// Revert if either channel got significantly worse.
+	if after[0]-before[0] > thresh0 || after[1]-before[1] > thresh1 {
+		return true
+	}
+
+	// Revert unless at least one channel got significantly better.
+	return before[0]-after[0] < thresh0 && before[1]-after[1] < thresh1
+}
+
+func measureEnergy(buf []float32, start, n int) float64 {
+	var sum float64
+	end := min(start+n, len(buf))
+	for i := start; i < end; i++ {
+		value := buf[i]
+		if value < 0 {
+			value = -value
+		}
+		sum += float64(value)
+	}
+
+	return sum
 }
 
 func absInt(x int) int {


### PR DESCRIPTION
#### Description

There are three things missing or lost from libopus's `run_prefilter`, all in the same mechanism.

**1. The comb filter wasn't running on frames where the pre-filter was off.**
This is the big one. libopus applies it unconditionally; it doesn't gate it on `pf_on`:
```c
comb_filter(in+c*(N+overlap)+overlap+offset, pre[c]+max_period+offset,
      st->prefilter_period, pitch_index, N-offset, -st->prefilter_gain, -gain1,
      st->prefilter_tapset, prefilter_tapset, mode->window, overlap, st->arch);
```

When the pre-filter is turned off, gain1 is 0, so this call crossfades the previous frame's gain down to 0 over the overlap. applyPrefilterChannel was only running the filter when it was enabled, so every on→off transition left a step that the decoder's post-filter couldn't follow. With the pre-filter enabled on roughly 25% of frames in tonal material, there are quite a few of these transitions.

**2. cancel_pitch was missing. libopus applies the filter, compares the sum of absolute values before and after, and reverts it if it didn't actually improve things.**

I had this ported and accidentally removed it in #194 when I rewrote choosePrefilter. The function became unused and disappeared along with the rest of pitch.go. My mistake, same kind of cleanup issue as #192.

**3. The gain hysteresis was missing:**
```c
if (ABS16(gain1-st->prefilter_gain)<QCONST16(.1f,15))
   gain1=st->prefilter_gain;
```

If the new gain is within 0.1 of the previous frame's gain, libopus keeps the previous value. Without this, the quantized gain could bounce by one step from frame to frame. Since the post-filter crossfades between frames, that ends up modulating the output for no real reason.

#### Impact

First of all: I don't think this is audible. I listened to the before and after and couldn't tell them apart. The error-tail metric from the quality harness (10 ms windows where the error is as large as the signal) is also unchanged: 1/21303 before and after on a 213 s music clip, and 3/1199 on tonal material. libopus gives 2/21304 and 3/1200 on the same material.

I expected the step at the on→off transitions to show up as an occasional click, but it doesn't — it falls inside the overlap and the MDCT smooths it out.

So this is mainly a port-fidelity fix with neutral perceptual impact, similar to #187. The point is that the decisions now match the reference and the pre-filter no longer subtracts where it should be adding, rather than claiming that the output simply sounds better.

#### Measurement

Round-trip SNR at 96 kbps CBR stereo, compared against opus_demo restricted-celt with the same configuration. The synthetic corpus is uncompressed source material; using already encoded material isn't useful for absolute numbers because its 20 ms codec framing can shift the SNR by ~1 dB depending on alignment.


| clip | before | after | libopus |
|---|---|---|---|
| tonal-harmonic | 21.4095 | **21.8170** | 21.0578 |
| percussive | 21.5946 | **21.7876** | 21.7436 |
| mixed-music | 19.6536 | **19.8205** | 19.7111 |
| stereo-wide | 19.9225 | **20.0548** | 19.8814 |
| sweep | 26.9318 | **27.0842** | 28.5924 |
| dynamics | 12.1354 | 12.1109 | 12.0556 |
| música real (213 s) | 14.9459 | **14.9717** | 14.9013 |

What I find more convincing than the SNR is the direction of the change. Before this, the pion pre-filter was subtracting where libopus was adding. After the fix, they agree:

| |pion pre-filter contribution | (libopus) |
|---|---|---|
| tonal-harmonic | −0.345 → **+0.063** | +0.100 |
| música real | −0.022 → **+0.004** | +0.018 |

Looking at the on/off decisions from the bitstream, pion previously enabled the pre-filter on 241 of 601 frames for tonal-harmonic, compared with 153 in libopus. After the fix it's 148, with 97.7% frame-by-frame agreement (96–98% on mixed-music as well).

Breaking down the three changes on tonal-harmonic:

crossfade: +0.346
cancel_pitch: +0.031
gain hysteresis: +0.021

dynamics gets 0.02 dB worse. I'm not hiding that — it's the only case that regresses, and I couldn't find a reason to treat it differently. The decisions there already match libopus.

sweep is still ~1.5 dB behind libopus for a separate reason: libopus has a tone_detect path that skips the pitch estimator entirely for pure single-tone signals (593 of 601 frames in this clip). That path never triggers on real music, so I'm leaving it out of this PR and just noting it here.

### Reference issue
Part of #34.