### PR TITLE
Apply tf_estimate to the allocation trim

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -669,6 +669,7 @@ func chooseAllocationTrim(
 	mdct [2][]float32,
 	channelCount, lm, endBand int,
 	totalBits uint,
+	tfEstimate float32,
 ) int {
 	frameSampleCount := shortBlockSampleCount << lm
 	equivRate := int(totalBits) * sampleRate / frameSampleCount
@@ -728,6 +729,11 @@ func chooseAllocationTrim(
 	diff /= float32(channelCount * (endBand - 1))
 	tiltContrib := max32(-2.0, min32(2.0, (diff+1.0)/6.0))
 	trim -= tiltContrib
+
+	// A frame that wants finer time resolution wants its bits spread up the
+	// spectrum, so the reference backs the trim off by twice tf_estimate
+	// (celt_encoder.c:820). The Q shift there is a no-op in the float build.
+	trim -= 2 * tfEstimate
 
 	// Round and clamp to [0, 10].
 	trimIndex := int(trim + 0.5)

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -392,10 +392,10 @@ func TestAnalyzeFrameAppliesDCBlock(t *testing.T) {
 func TestChooseAllocationTrimDefault(t *testing.T) {
 	// Espectro plano a 128kbps → trim cerca de 5 (default).
 	logBandAmp := makeFlatLogBandAmp(0.0) // todas las bandas iguales
-	mdct := makeFlatMDCT(1.0)
+	mdct := makeFlatMDCT()
 	trim := chooseAllocationTrim(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50,
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 0,
 	)
 	assert.InDelta(t, 5, trim, 1, "flat spectrum at 128kbps should stay near default")
 }
@@ -403,10 +403,10 @@ func TestChooseAllocationTrimDefault(t *testing.T) {
 func TestChooseAllocationTrimLowBitrate(t *testing.T) {
 	// A 32kbps → base trim=4 (no 5).
 	logBandAmp := makeFlatLogBandAmp(0.0)
-	mdct := makeFlatMDCT(1.0)
+	mdct := makeFlatMDCT()
 	trim := chooseAllocationTrim(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 32*8*50,
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 32*8*50, 0,
 	)
 	assert.LessOrEqual(t, trim, 5, "low bitrate should bias trim downward")
 }
@@ -416,11 +416,11 @@ func TestChooseAllocationTrimSpectralTilt(t *testing.T) {
 	// (trim > 5 biases bits toward low bands). High-heavy → opposite.
 	lowHeavy := makeTiltedLogBandAmp(-1.0)  // bandas bajas con más energía
 	highHeavy := makeTiltedLogBandAmp(+1.0) // bandas altas con más energía
-	mdct := makeFlatMDCT(1.0)
+	mdct := makeFlatMDCT()
 	trimLow := chooseAllocationTrim([2][maxBands]float32{lowHeavy, lowHeavy},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50)
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 0)
 	trimHigh := chooseAllocationTrim([2][maxBands]float32{highHeavy, highHeavy},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50)
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 0)
 	assert.Greater(t, trimLow, trimHigh, "low-heavy spectrum should bias trim upward (more bits to lows)")
 }
 
@@ -429,14 +429,26 @@ func TestChooseAllocationTrimStereoCorrelated(t *testing.T) {
 	logBandAmp := makeFlatLogBandAmp(0.0)
 	mdct := makeSineMDCT(440) // mismo contenido en ambos canales
 	trimCorr := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdct}, 2, maxLM, maxBands, 128*8*50)
+		[2][]float32{mdct, mdct}, 2, maxLM, maxBands, 128*8*50, 0)
 
 	// L y R decorrelated → trim sin ajuste stereo.
 	mdctR := makeNoiseMDCT(42)
 	trimDecorr := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdctR}, 2, maxLM, maxBands, 128*8*50)
+		[2][]float32{mdct, mdctR}, 2, maxLM, maxBands, 128*8*50, 0)
 
 	assert.Less(t, trimCorr, trimDecorr, "correlated stereo should have lower trim than decorrelated")
+}
+
+func TestChooseAllocationTrimTFEstimate(t *testing.T) {
+	// A frame asking for finer time resolution gets its trim pulled down by
+	// twice tf_estimate, so bits move up the spectrum.
+	logBandAmp := makeFlatLogBandAmp(0.0)
+	mdct := makeFlatMDCT()
+	trimFlat := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 0)
+	trimTF := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 1.0)
+	assert.Equal(t, trimFlat-2, trimTF, "tf_estimate of 1.0 should drop the trim by 2")
 }
 
 // makeFlatLogBandAmp returns a per-band log amplitude array with every band
@@ -462,11 +474,11 @@ func makeTiltedLogBandAmp(slope float32) [maxBands]float32 {
 }
 
 // makeFlatMDCT returns an MDCT spectrum of the full frame with every bin set
-// to v. Cosine similarity between two identical flat spectra is 1.0.
-func makeFlatMDCT(v float32) []float32 {
+// to one. Cosine similarity between two identical flat spectra is 1.0.
+func makeFlatMDCT() []float32 {
 	mdct := make([]float32, (1<<maxLM)*int(bandEdges[maxBands]))
 	for i := range mdct {
-		mdct[i] = v
+		mdct[i] = 1
 	}
 
 	return mdct

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -356,6 +356,7 @@ func (e *Encoder) encodeDynamicAllocation(info *frameSideInfo, offsets [maxBands
 // enough budget left to signal it.
 func (e *Encoder) encodeAllocationTrim(
 	info *frameSideInfo, logBandAmp [2][maxBands]float32, mdct [2][]float32, totalBitsEighth uint,
+	tfEstimate float32,
 ) {
 	info.allocationTrim = defaultAllocationTrim
 	if e.rangeEncoder.TellFrac()+uint(allocationTrimBitCost<<bitResolution) <= totalBitsEighth {
@@ -364,6 +365,7 @@ func (e *Encoder) encodeAllocationTrim(
 			mdct,
 			info.channelCount, info.lm, info.endBand,
 			info.totalBits,
+			tfEstimate,
 		)
 		e.rangeEncoder.EncodeSymbolWithICDF(icdfAllocationTrim, uint32(info.allocationTrim))
 	}
@@ -743,7 +745,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	e.prevSpreadDecision = info.spread
 	e.encodeSpread(&info)
 	totalBitsEighth := e.encodeDynamicAllocation(&info, offsets)
-	e.encodeAllocationTrim(&info, analysis.logBandAmp, analysis.mdct, totalBitsEighth)
+	e.encodeAllocationTrim(&info, analysis.logBandAmp, analysis.mdct, totalBitsEighth, tfEstimate)
 
 	tellFrac := int(e.rangeEncoder.TellFrac())
 


### PR DESCRIPTION
#### Description

The last subtraction from `alloc_trim_analysis` is missing (`celt_encoder.c:820`):

```c
trim -= SHR16(surround_trim, DB_SHIFT-8);
trim -= 2*SHR16(tf_estimate, 14-8);
```

`SHR16(a, shift)` is just `(a)` in the float build (`celt/arch.h:311`), so this is effectively `trim -= 2*tf_estimate`. `surround_trim` is 0 outside surround, so that part doesn't apply here.

`tf_estimate` is never negative, so this term can only lower the trim. Without it, `chooseAllocationTrim` was consistently too high and saturated at 7 on tonal material. A frame asking for more temporal resolution wants its bits shifted towards the upper bands, which is exactly what this term does.

#### Measurement

I compared the trim decisions frame by frame against `opus_demo restricted-celt` at 96 kbps CBR stereo. I decoded the libopus bitstream with
the pion decoder so both sides use the same representation.

Trim index agreement:

| clip | before | after |
|---|---|---|
| tonal-harmonic | 32.8% | **99.7%** |
| mixed-music | 81.8% | **99.0%** |
| real music l (60 s) | 92.2% | **98.9%** |
| percussive | 95.3% | **98.7%** |
| dynamics | 100% | 100% |

On `tonal-harmonic`, pion was choosing 7 on 591/600 frames, while libopus spreads the decisions between 5, 6 and 7. On real music, the disagreement was always exactly +1.

SNR

This lowers round-trip SNR: −0.05 dB on real music, −0.13 dB on `mixed-music`, and −0.80 dB on `tonal-harmonic`.

I'm calling this out because it's the first fix in this series where the
number goes down.

What's happening is that pion was scoring slightly better than libopus because
of the bug. The trim moves bits between lower and upper bands, and with the
trim too high, pion was giving more bits to the lower bands — where most of the
signal energy is — so waveform SNR went up while the upper bands were getting
less than they should.

After the fix, pion lands much closer to libopus:

| clip | gap vs libopus before | gap after |
|---|---|---|
| tonal-harmonic | +0.759 | **−0.038** |
| mixed-music | +0.109 | **−0.019** |
| percussive | +0.044 | **−0.027** |
| real music | +0.070 | **+0.018** |

opus_compare on real music is basically unchanged (0.9228 → 0.9233). I also listened to the tonal clip, which is where the change is largest, and it sounds fine.

The corpus is synthetic and intentionally has no previous codec pass. Material that has already gone through Opus carries a 20 ms framing grid which can move the absolute SNR by ~1 dB depending on alignment, so I don't think it's useful for these measurements.

#### Reference issue

Part of #34.