### PR TITLE
Keep the pitch period when the pre-filter is off

### DIFF
--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -466,10 +466,16 @@ func (e *Encoder) updatePrefilterState(
 	info *frameSideInfo, enabled bool,
 	period int, gain float32, qq int, tapset int,
 ) {
+	// libopus stores the searched period and tapset whether or not the filter
+	// ran (celt_encoder.c:2768); only the gain goes to zero. Resetting the
+	// period instead traps the filter off: the next frame's continuity check
+	// compares against it, so a reset always looks like a pitch jump and adds
+	// 0.2 to the enable threshold, which a mid-strength pitch never clears.
+	e.analysis.prefilter.period = period
+	e.analysis.prefilter.tapset = tapset
+	e.analysis.prefilter.gain = 0
 	if enabled {
-		e.analysis.prefilter.period = period
 		e.analysis.prefilter.gain = gain
-		e.analysis.prefilter.tapset = tapset
 
 		info.postFilter = postFilter{
 			enabled: true,
@@ -478,10 +484,6 @@ func (e *Encoder) updatePrefilterState(
 			qq:      qq,
 			tapset:  tapset,
 		}
-	} else {
-		e.analysis.prefilter.period = combFilterMinPeriod
-		e.analysis.prefilter.gain = 0
-		e.analysis.prefilter.tapset = 0
 	}
 }
 


### PR DESCRIPTION
#### Description

`updatePrefilterState` was resetting the period to `combFilterMinPeriod` when the pre-filter was turned off. libopus always keeps the selected period, regardless of `pf_on` (`celt_encoder.c:2768`):

```c
st->prefilter_period = pitch_index;
st->prefilter_gain = gain1;          /* gain1 is already 0 if pf_on==0 */
st->prefilter_tapset = prefilter_tapset;
```

The gain already matched — libopus sets it to 0 in the same branch that turns the filter off — but the period and tapset did not.

This matters because the next frame uses that period in the continuity check in `run_prefilter:`
```c
if (abs(pitch_index-st->prefilter_period)*10>pitch_index)
   pf_threshold += QCONST16(.2f,15);
```

With the period reset to 15, any real pitch is far enough away that the `+0.2` always kicks in. The threshold goes from 0.2 to 0.4, and a medium-strength pitch never reaches it. The filter stays off, the period gets reset again, and the next frame starts in the same state. It's basically a self-sustaining loop.

It's easiest to see this when the gain sits right in the middle. On a mono bass clip with decorrelated noise in L/R, the raw gain is around 0.32-0.35 on most frames: above the base 0.2 threshold, but below the inflated 0.4 one. libopus turns the pre-filter on in 416/600 frames; pion was only turning it on in 68.

#### Measurement

I compared the pre-filter decisions frame by frame against `opus_demo restricted-celt` at 96 kbps CBR stereo, using the pion decoder to read the libopus bitstream so both sides are compared in the same representation.


| clip | pre-filter on/off | period | gain |
|---|---|---|---|
| stereo-wide | 41.3% → **100%** | 38.8% → **100%** | 38.7% → **100%** |
| música real (60 s) | 90.0% → **99.7%** | 90.0% → **99.7%** | 89.4% → **99.7%** |
| percussive | 90.5% → **99.3%** | 85.3% → **94.2%** | 83.3% → **92.5%** |
| tonal-harmonic | 97.8% → **99.2%** | 97.8% → **99.2%** | 97.3% → **99.2%** |

It also affects decisions that depend on the pre-filter because they now see a
different residual:


| clip | tf_change | dual stereo |
|---|---|---|
| stereo-wide | 72.0% → **100%** | 83.0% → **100%** |
| música real | 96.3% → **99.8%** | 100% |
| percussive | 84.2% → **90.2%** | 100% |


SNR

Same as the trim PR: the SNR number goes down in some cases because the previous implementation was benefiting from the bug, but it gets much closer to the reference.

On `stereo-wide`, SNR drops by 0.19 dB, but the gap against libopus goes from +0.173 to −0.018 dB. On real music, SNR improves by 0.013 dB.

With this change, pion is within ±0.06 dB of libopus on every clip in the corpus except the sinusoidal sweep, which is a separate issue caused by the `tone_detect` path that hasn't been ported yet.

#### Reference issue

Part of #34.