### PR TITLE
Spread the dynalloc mask in log2, not dB

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -862,16 +862,17 @@ func dynallocAnalysis(
 			}
 			sig[band] = mask[band]
 		}
-		// Forward: -6 dB/Bark → -0.996 log2.
+		// The reference spreads the mask by 2 and 3 in the same log2 domain as
+		// bandLogE, not in dB (celt_encoder.c: dynalloc_analysis, GCONST is the
+		// identity in the float build).
 		for band := 1; band < endBand; band++ {
-			if mask[band-1]-0.996 > mask[band] {
-				mask[band] = mask[band-1] - 0.996
+			if mask[band-1]-2.0 > mask[band] {
+				mask[band] = mask[band-1] - 2.0
 			}
 		}
-		// Backward: -9 dB/Bark → -1.495 log2.
 		for band := endBand - 2; band >= 0; band-- {
-			if mask[band+1]-1.495 > mask[band] {
-				mask[band] = mask[band+1] - 1.495
+			if mask[band+1]-3.0 > mask[band] {
+				mask[band] = mask[band+1] - 3.0
 			}
 		}
 		// SMR → shift → spread_weight = 32 >> shift.

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -549,6 +549,25 @@ func TestDynallocSpreadWeightMaskedBandReduced(t *testing.T) {
 	assert.Less(t, dr.spreadWeight[5], 32, "band far from peak should have reduced weight")
 }
 
+func TestDynallocSpreadWeightMaskDecayRate(t *testing.T) {
+	// The mask spreads by 2 per band upward and 3 downward, in the same log2
+	// domain as bandLogE. A peak of 4 stops masking two bands up, so the weight
+	// recovers there; reading those constants as dB would halve the step and
+	// leave the band masked.
+	logBandAmp := makeFlatLogBandAmp(0.0)
+	logBandAmp[10] = 4.0
+	prev := makeFlatLogBandAmp(0.0)
+	dr := dynallocAnalysis(
+		[2][maxBands]float32{logBandAmp, logBandAmp},
+		[2][maxBands]float32{prev, prev},
+		maxLM, 0, maxBands, 1, 120, false,
+	)
+	assert.Greater(t, dr.spreadWeight[12], dr.spreadWeight[11],
+		"weight should recover two bands above the peak")
+	assert.Less(t, dr.spreadWeight[9], dr.spreadWeight[8],
+		"the band just below the peak stays masked")
+}
+
 func TestDynallocLowBitrateGated(t *testing.T) {
 	// Below 30+5*LM bytes → dynalloc disabled, all offsets zero.
 	logBandAmp := makeFlatLogBandAmp(0.0)

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -126,7 +126,10 @@ func (e *Encoder) Reset() {
 	e.cwrsScratch = make([]uint32, 0, cwrsMaxPulseCount+2)
 	e.pitchBuf = make([]float32, 0, (combFilterMaxPeriod+maxFrameSampleCount)>>1)
 
-	e.spreadAverage = 0
+	// libopus seeds tonal_average at 256 (celt_encoder.c:3091), the midpoint
+	// of the spreading metric — starting at zero biases the first frames
+	// toward aggressive spreading.
+	e.spreadAverage = 256
 	e.hfAverage = 0
 	e.tapsetDecision = 0
 	e.prevSpreadDecision = defaultSpreadDecision


### PR DESCRIPTION
#### Description

Two things in the `spreading_decision` path, both around `spread_weight`.

**1. The mask constants were converted to dB.** libopus (`celt_encoder.c`, `dynalloc_analysis`) does:

```c
for (i=1;i<end;i++)    mask[i] = MAXG(mask[i], mask[i-1] - GCONST(2.f));
for (i=end-2;i>=0;i--) mask[i] = MAXG(mask[i], mask[i+1] - GCONST(3.f));
```

pion had 0.996 and 1.495, with comments saying "-6 dB/Bark" and "-9 dB/Bark". I had read the 2.0 and 3.0 as decibels and divided them by 6.0206.

But mask is in the same domain as bandLogE, which is log2. In the float build celt_log2_db is directly celt_log2 (mathops.h:351), and GCONST(x) is just the identity (arch.h:304). So the 2.0 and 3.0 should be used as-is.

With the smaller values, the mask propagated too far, making each band more masked than it should be. That increased the shift, which made spread_weight = 32 >> shift smaller. On a real-music clip this gave nbBands 768 where libopus had 832, and the difference carried through to the final spreading decision.

**2. tonal_average starts at 256, not 0 (celt_encoder.c:3091). That's the midpoint of the metric. Starting at 0 biases the first frames towards more aggressive spreading.**

#### Measurement

I compared the spread decision frame by frame against opus_demo restricted-celt at 96 kbps CBR stereo:


| clip | before | after |
|---|---|---|
| música real (60 s) | 94.7% | **100.0%** |
| mixed-music | 83.3% | **99.0%** |
| tonal-harmonic | 96.8% | **100.0%** |
| dynamics | 99.3% | **100.0%** |
| stereo-wide | 99.5% | **100.0%** |
| percussive | 93.5% | 97.3% |

The mask constants are the main change. With only that fix, real music goes from 94.7% to 99.8%; initializing tonal_average to 256 closes the remaining difference to 100%.

I also checked the intermediate values. Instrumenting both implementations on the same clip, sum, nbBands, and the final value after hysteresis now match exactly frame by frame. Before the fix, the first frame was 320/768 vs 352/832.

Round-trip SNR is effectively unchanged (−0.005 to +0.013 dB depending on the clip), which makes sense since this only changes decisions that were already very close.

Test

TestDynallocSpreadWeightMaskDecayRate covers the mask decay. With a peak of 4 in one band, the weight should recover two bands later. With the old constants, the decay was half as fast and the band remained masked, so the test
fails.

Reference issue

Part of #34.