### PR TITLE
Fit the TOC byte inside the bitrate budget

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -557,8 +557,15 @@ func splitChannels(in []float32, numChannels, frameSamples int) [][]float32 {
 	return ch
 }
 
+// tocHeaderBytes is the single table-of-contents byte every packet starts with.
+const tocHeaderBytes = 1
+
+// frameBytes returns the CELT payload budget. The packet carries a TOC byte in
+// front of it, so the payload gets one byte less than the frame's share of the
+// bitrate — otherwise every packet overshoots the target by a byte, which is
+// 400 bps at 20 ms.
 func (e *Encoder) frameBytes() int {
-	return int(int64(e.bitrate) * frame20msNS / 1000000000 / 8)
+	return int(int64(e.bitrate)*frame20msNS/1000000000/8) - tocHeaderBytes
 }
 
 func (e *Encoder) frameSampleCount() int {


### PR DESCRIPTION
#### Description

`frameBytes()` returns the amount of bitrate available to the frame, and that value is used as the CELT payload budget — but the packet also has the TOC byte at the front:

```go
out[0] = byte(e.tocHeader())
n, err := e.celtEncoder.EncodeFrame(channels, out[1:frameBytes+1], frameBytes, ...)
```

So each packet was actually frameBytes+1 bytes instead of frameBytes.

Measured over 200 frames at each bitrate, before the change:

| bitrate | target | pion output |
|---|---|---|
| 24000 | 60 | 61.00 |
| 32000 | 80 | 81.00 |
| 48000 | 120 | 121.00 |
| 64000 | 160 | 161.00 |
| 96000 | 240 | 241.00 |
| 128000 | 320 | 321.00 |

It's exactly one extra byte per frame, or 400 bps at 20 ms: 1.7% above the target at 24 kbps and 0.4% at 96 kbps. So a CBR 24 kbps stream was actually sending 24.4 kbps.

libopus passes CELT the payload size without the TOC byte. I verified this by instrumenting run_prefilter at 24 kbps: nbAvailableBytes is 59 in libopus where pion was using 60.

The fix is to subtract the TOC byte from the payload budget. After the change, the packet sizes match the target exactly at all six bitrates.

#### Side effect

frameBytes is also the budget used by the allocator, so this shifts some of the rate-dependent decisions as well. That's expected — they should now match libopus at the same bitrate.

In particular, the equiv_rate used by the intensity-band and trim decisions now matches the reference.

#### Reference issue

Part of #34.