### PR TITLE
Narrow the stereo image at low bitrate

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -90,6 +90,7 @@ type Encoder struct {
 	bandwidth      Bandwidth
 	maxBandwidth   Bandwidth
 	silkDCBlockMem float32
+	stereoWidth    int
 }
 
 // EncoderOption configures an Encoder during construction.
@@ -249,6 +250,7 @@ func NewEncoder(opts ...EncoderOption) (*Encoder, error) {
 		lossRate:       0,
 		bandwidth:      BandwidthAuto,
 		maxBandwidth:   BandwidthFullband,
+		stereoWidth:    stereoWidthFull,
 	}
 
 	for _, opt := range opts {
@@ -384,6 +386,7 @@ func (e *Encoder) EncodeFloat32(in []float32, out []byte) (int, error) {
 	}
 
 	channels := splitChannels(in, e.channels, frameSamples)
+	e.narrowStereo(channels)
 
 	frameBytes := e.frameBytes()
 	if frameBytes <= 0 || frameBytes > maxOpusFrameSize {
@@ -563,4 +566,85 @@ func (e *Encoder) frameBytes() int {
 
 func (e *Encoder) frameSampleCount() int {
 	return int(int64(celtSampleRate) * frame20msNS / 1000000000)
+}
+
+const (
+	// stereoWidthFull is Q14 unity: the image is left alone.
+	stereoWidthFull = 1 << 14
+	// Below stereoWidthMinRate the image is collapsed to mono; above
+	// stereoWidthMaxRate it is untouched. In between it narrows gradually.
+	stereoWidthMinRate = 16000
+	stereoWidthMaxRate = 32000
+)
+
+// equivalentRate expresses the configured bitrate as the rate an ideal encoder
+// would need for the same quality, which is what libopus compares against its
+// stereo-width and mode thresholds (compute_equiv_rate, src/opus_encoder.c).
+// The frame-rate term is a no-op here because every frame is 20 ms.
+func (e *Encoder) equivalentRate() int {
+	equiv := e.bitrate
+	// CBR costs about 8%.
+	if !e.vbr {
+		equiv -= equiv / 12
+	}
+	equiv = equiv * (90 + e.complexity) / 100
+	// Below complexity 5 CELT drops the pitch filter, worth about 10%.
+	if e.complexity < silkComplexityInterpolationThreshold+1 {
+		equiv = equiv * 9 / 10
+	}
+
+	return equiv
+}
+
+// stereoWidthQ14 returns how much of the stereo image to keep, in Q14.
+// Mirrors the schedule in libopus opus_encode_native.
+func stereoWidthQ14(equivRate int) int {
+	switch {
+	case equivRate > stereoWidthMaxRate:
+		return stereoWidthFull
+	case equivRate < stereoWidthMinRate:
+		return 0
+	default:
+		return stereoWidthFull - 2048*(stereoWidthMaxRate-equivRate)/(equivRate-14000)
+	}
+}
+
+// applyStereoFade narrows the stereo image toward mono by scaling the side
+// signal, crossfading from the previous frame's width across the MDCT overlap
+// so the change does not land as a step. Mirrors libopus stereo_fade
+// (src/opus_encoder.c). At low bitrates the side channel is not worth its bits,
+// and narrowing it beats letting the allocator starve both channels.
+func applyStereoFade(left, right []float32, prevWidth, width float32, window []float32) {
+	g1 := 1 - prevWidth
+	g2 := 1 - width
+	overlap := min(len(window), len(left))
+	for i := range overlap {
+		w := window[i] * window[i]
+		g := w*g2 + (1-w)*g1
+		diff := 0.5 * (left[i] - right[i]) * g
+		left[i] -= diff
+		right[i] += diff
+	}
+	for i := overlap; i < len(left); i++ {
+		diff := 0.5 * (left[i] - right[i]) * g2
+		left[i] -= diff
+		right[i] += diff
+	}
+}
+
+// narrowStereo applies the low-bitrate stereo width reduction to the split
+// channels and advances the width state.
+func (e *Encoder) narrowStereo(channels [][]float32) {
+	if len(channels) != 2 {
+		return
+	}
+	width := stereoWidthQ14(e.equivalentRate())
+	if e.stereoWidth < stereoWidthFull || width < stereoWidthFull {
+		applyStereoFade(
+			channels[0], channels[1],
+			float32(e.stereoWidth)/stereoWidthFull, float32(width)/stereoWidthFull,
+			celt.OverlapWindow(),
+		)
+	}
+	e.stereoWidth = width
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -861,3 +861,51 @@ func freqEnergy(samples []float32, freq float64) float64 {
 
 	return math.Sqrt(re*re+im*im) / float64(len(samples))
 }
+
+func TestStereoWidthQ14Schedule(t *testing.T) {
+	// Above 32 kb/s the image is untouched, below 16 kb/s it collapses to mono,
+	// and in between it narrows monotonically.
+	assert.Equal(t, stereoWidthFull, stereoWidthQ14(33000))
+	assert.Equal(t, 0, stereoWidthQ14(15000))
+
+	prev := 0
+	for rate := stereoWidthMinRate; rate <= stereoWidthMaxRate; rate += 250 {
+		got := stereoWidthQ14(rate)
+		assert.GreaterOrEqual(t, got, prev, "width must not narrow as the rate grows: rate=%d", rate)
+		assert.LessOrEqual(t, got, stereoWidthFull, "rate=%d", rate)
+		prev = got
+	}
+}
+
+func TestApplyStereoFadeCollapsesToMono(t *testing.T) {
+	// Width zero on both ends means every sample pair becomes its own average.
+	left := []float32{1, 1, 1, 1}
+	right := []float32{-1, -1, -1, -1}
+	applyStereoFade(left, right, 0, 0, nil)
+	for i := range left {
+		assert.InDelta(t, 0, left[i], 1e-6, "sample %d", i)
+		assert.InDelta(t, 0, right[i], 1e-6, "sample %d", i)
+	}
+}
+
+func TestApplyStereoFadeFullWidthIsIdentity(t *testing.T) {
+	left := []float32{0.5, -0.25, 0.75, 0}
+	right := []float32{-0.5, 0.25, 0, 0.75}
+	wantL := append([]float32(nil), left...)
+	wantR := append([]float32(nil), right...)
+	applyStereoFade(left, right, 1, 1, nil)
+	assert.Equal(t, wantL, left)
+	assert.Equal(t, wantR, right)
+}
+
+func TestApplyStereoFadeCrossfadesOverOverlap(t *testing.T) {
+	// Coming from full width down to mono, the first sample keeps the old
+	// width and the tail past the overlap is fully narrowed.
+	window := []float32{0, 1}
+	left := []float32{1, 1, 1}
+	right := []float32{-1, -1, -1}
+	applyStereoFade(left, right, 1, 0, window)
+	assert.InDelta(t, 1, left[0], 1e-6, "overlap starts at the previous width")
+	assert.InDelta(t, 0, left[1], 1e-6, "overlap ends at the new width")
+	assert.InDelta(t, 0, left[2], 1e-6, "past the overlap the new width applies")
+}

--- a/internal/celt/synthesis.go
+++ b/internal/celt/synthesis.go
@@ -872,3 +872,10 @@ func minFloat32(a, b float32) float32 {
 
 	return b
 }
+
+// OverlapWindow returns the MDCT overlap window (celt_mode->window in libopus).
+// The encoder-side gain crossfades in src/opus_encoder.c are shaped by it, and
+// those run before the CELT layer sees the samples.
+func OverlapWindow() []float32 {
+	return celtWindow120[:]
+}


### PR DESCRIPTION
#### Description

libopus narrows the stereo image when the bitrate isn't high enough to afford full stereo (`src/opus_encoder.c`, inside `opus_encode_native`):

```c
if (equiv_rate > 32000)      st->silk_mode.stereoWidth_Q14 = 16384;
else if (equiv_rate < 16000) st->silk_mode.stereoWidth_Q14 = 0;
else st->silk_mode.stereoWidth_Q14 = 16384 - 2048*(opus_int32)(32000-equiv_rate)/(equiv_rate-14000);
...
stereo_fade(pcm_buf, pcm_buf, g1, g2, celt_mode->overlap, frame_size, st->channels, celt_mode->window, st->Fs);
```

stereo_fade scales the side signal: at width 0, each pair of samples becomes their average, effectively turning the input into mono. The transition between the previous and new width is weighted by the MDCT window, so a bitrate change doesn't introduce a hard step.

pion didn't have any of this. This PR ports the three pieces: compute_equiv_rate (the part used by the CELT-only path), the stereo-width calculation, and stereo_fade.

This matters at lower bitrates because the side channel doesn't pay for itself. Narrowing the stereo image deliberately is better than letting the allocator spread too few bits across both channels.

#### How I found it

I was chasing an alloc_trim mismatch that only showed up at 24 and 32 kbps (72.6% and 95.5% agreement, compared to 99.8% from 48 kbps up). The inter-channel correlation term in the trim wasn't matching, and I found that libopus's X value changed with bitrate while pion's didn't: all 400 frames differed at 24 kbps and none did at 96 kbps.

I disabled the prefilter on both sides and ruled out the band boundaries. The raw MDCT was already different on the first frame, which put the problem before CELT itself — and that's where I found the stereo fade.

The numbers line up: with CBR and complexity 5, compute_equiv_rate gives 20900 at 24 kbps and 27867 at 32 kbps, both inside the transition range. At 48 kbps it gives 41800, already above 32000, which is exactly where the disagreement disappeared.

#### Measurement
Frame-by-frame agreement against opus_demo restricted-celt, 3000 music frames per bitrate:

| bitrate | trim before | trim after | transient | tf_change | pre-filter |
|---|---|---|---|---|---|
| 24000 | 72.6% | **99.0%** | 99.8% → **100%** | 98.5% → **100%** | 98.1% → **99.7%** |
| 32000 | 95.5% | **99.5%** | 100% | 98.9% → **100%** | 99.3% → **99.7%** |
| 48000 | 99.8% | 99.8% | 100% | 100% | 99.7% |
| 96000 | 99.9% | 99.9% | 100% | 99.7% | 99.7% |

The effect carries into transient analysis, TF analysis, and the prefilter because all of them operate on the same input signal.

Round-trip SNR against libopus at the same bitrate:

| bitrate | pion | libopus | gap |
|---|---|---|---|
| 24000 | 7.0676 | 7.0540 | +0.014 |
| 32000 | 8.4080 | 8.3973 | +0.011 |
| 48000 | 10.1179 | 10.1027 | +0.015 |
| 96000 | 15.0721 | 15.0736 | −0.002 |

One thing worth noting: the fade changes the signal going into the codec, so SNR against the original naturally drops compared to not applying it. That's inherent to the feature, and libopus does the same. The useful comparison here is against the reference, not against the pre-change encoder.

#### Tests

Four tests cover the stereo-width scaling (monotonicity and both extremes), full width as an identity operation, zero width collapsing to mono, and the crossfade starting at the old width and ending at the new one.

Reference issue

Part of #34.