### PR TITLE
Derive the VBR floor from the coded bin count

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -623,28 +623,62 @@ func TestConstrainedVBRPacketRoundTrip(t *testing.T) {
 }
 
 func TestVBRProducesVaryingPacketSizes(t *testing.T) {
-	enc, err := NewEncoder(WithVBR(true), WithConstrainedVBR(false))
+	enc, err := NewEncoder(WithChannels(2), WithBitrate(96000), WithVBR(true), WithConstrainedVBR(false))
 	require.NoError(t, err)
 
 	sizes := make(map[int]bool)
-	for i := range 20 {
-		pcm := make([]float32, encoderTestFrameSampleCount)
-		if i%2 == 0 {
-			for j := range pcm {
-				pcm[j] = float32(j%100) / 100
-			}
-		} else {
-			for j := range pcm {
-				pcm[j] = 0.0001
+	phase := 0.0
+	for i := range 6 {
+		pcm := make([]float32, encoderTestFrameSampleCount*2)
+		// The first frame is silence, which needs far fewer bits than the tone
+		// that follows it.
+		if i > 0 {
+			for j := range encoderTestFrameSampleCount {
+				v := float32(math.Sin(phase)) * 0.3
+				pcm[2*j] = v
+				pcm[2*j+1] = -v
+				phase += 2 * math.Pi * 440 / 48000
 			}
 		}
-		packet := make([]byte, 256)
-		n, err := enc.EncodeFloat32(pcm, packet)
-		require.NoError(t, err)
+		packet := make([]byte, 1500)
+		n, encErr := enc.EncodeFloat32(pcm, packet)
+		require.NoError(t, encErr)
 		sizes[n] = true
 	}
 
 	assert.Greater(t, len(sizes), 1, "VBR should produce varying packet sizes")
+}
+
+func TestVBRTracksTargetBitrate(t *testing.T) {
+	// The VBR target is clamped by a floor derived from the coded bin count.
+	// Deriving it from the byte budget instead pinned every frame near a
+	// quarter of the target, so VBR delivered about a third of the rate asked
+	// for. Guard the rate, not just the variation.
+	const bitrate = 96000
+	enc, err := NewEncoder(WithChannels(2), WithBitrate(bitrate), WithVBR(true), WithConstrainedVBR(false))
+	require.NoError(t, err)
+
+	frameBudget := bitrate / 50 / 8
+	total, frames := 0, 40
+	phase := 0.0
+	for range frames {
+		pcm := make([]float32, encoderTestFrameSampleCount*2)
+		for j := range encoderTestFrameSampleCount {
+			v := float32(math.Sin(phase)+0.5*math.Sin(phase*7.3)) * 0.3
+			pcm[2*j] = v
+			pcm[2*j+1] = -v
+			phase += 2 * math.Pi * 440 / 48000
+		}
+		packet := make([]byte, 1500)
+		n, encErr := enc.EncodeFloat32(pcm, packet)
+		require.NoError(t, encErr)
+		total += n
+	}
+
+	// Only the lower bound belongs here: what the floor bug broke was the rate
+	// being delivered, and the ceiling is the frame budget's own business.
+	avg := float64(total) / float64(frames)
+	assert.Greater(t, avg, 0.8*float64(frameBudget), "VBR undershoots the requested rate")
 }
 
 func TestVBRPacketRoundTripMultiFrame(t *testing.T) {

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -523,27 +523,32 @@ func (e *Encoder) computeIntensityAndDualStereo(
 // Simplified version of libopus compute_vbr() (celt_encoder.c, ~line 1605).
 // Not ported: tonality/activity boost, stereo saving, surround masking,
 // temporal VBR — these need the full analysis pipeline pion doesn't have yet.
+// vbrTFCalibration is the average tf_estimate the target is calibrated for,
+// so a typical frame gets no boost (celt_encoder.c compute_vbr).
+const vbrTFCalibration = 0.044
+
 func computeVBR(
 	baseTarget int, // 1/8-bit units
 	maxDepth float32,
 	totBoostBits int,
-	transient, constrainedVBR bool,
+	constrainedVBR bool,
 	channelCount int,
-	effectiveBytes int,
 	lm int,
+	tfEstimate float32,
 ) int {
 	target := baseTarget + totBoostBits - (19 << lm) // dynalloc calibration
-	if transient {
-		target += target >> 3
-	}
 
-	floorDepth := float32(channelCount*effectiveBytes*8) * maxDepth / 65536
-	if floorDepth < float32(target>>2) {
-		floorDepth = float32(target >> 2)
-	}
-	if float32(target) > floorDepth {
-		target = int(floorDepth)
-	}
+	// Transient boost, compensated for the average frame. The reference scales
+	// the target by tf_estimate rather than switching on the transient flag.
+	target += int((tfEstimate - vbrTFCalibration) * float32(target))
+
+	// The floor is the depth the spectrum can actually use: the coded bin count
+	// times the per-bin depth. The Q shift around it in celt_encoder.c is a
+	// no-op in the float build, so maxDepth goes in unscaled.
+	bins := int(bandEdges[maxBands-2]) << lm
+	floorDepth := int(float32(channelCount*bins<<bitResolution) * maxDepth)
+	floorDepth = max(floorDepth, target>>2)
+	target = min(target, floorDepth)
 
 	// Constrained VBR can't sustain a higher bitrate for long, so pull 1/3
 	// of the way back to baseTarget (libopus's fixed 0.67 factor).
@@ -559,8 +564,8 @@ func computeVBR(
 // tellFrac is e.rangeEncoder.TellFrac() at the point of the call. Mirrors
 // celt_encoder.c's VBR block around compute_vbr (~lines 2436-2530).
 func (e *Encoder) applyVBR(
-	frameBytes int, transient bool, dr dynallocResult,
-	effectiveBytes, lm, channelCount, tellFrac int,
+	frameBytes int, dr dynallocResult,
+	effectiveBytes, lm, channelCount, tellFrac int, tfEstimate float32,
 ) int {
 	vbrRate := frameBytes << 6 // libopus vbr_rate, 1/8-bit units
 
@@ -580,7 +585,7 @@ func (e *Encoder) applyVBR(
 	// bytes. libopus uses this pre-rounding value for the drift update below
 	// and the rounded value for the reservoir — they're not the same number.
 	rawTarget := computeVBR(
-		baseTarget, dr.maxDepth, dr.totBoostBits, transient, e.constrainedVBR, channelCount, effectiveBytes, lm,
+		baseTarget, dr.maxDepth, dr.totBoostBits, e.constrainedVBR, channelCount, lm, tfEstimate,
 	) + tellFrac
 
 	nbAvailableBytes := max(2, (rawTarget+(1<<5))>>6)
@@ -678,9 +683,9 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 		return 0, err
 	}
 	if patched {
-		transient = true
-		// The reference hands tf_analysis a fixed estimate for a patched
-		// frame, since the time-domain metric missed the transient.
+		// analyzeFrame already flipped info.transient; what is left is the
+		// fixed estimate the reference hands tf_analysis and the VBR target
+		// for a frame the time-domain metric missed.
 		tfEstimate = 0.2
 	}
 
@@ -748,7 +753,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	tellFrac := int(e.rangeEncoder.TellFrac())
 
 	if e.vbr {
-		effectiveBytes = e.applyVBR(frameBytes, transient, dr, effectiveBytes, info.lm, info.channelCount, tellFrac)
+		effectiveBytes = e.applyVBR(frameBytes, dr, effectiveBytes, info.lm, info.channelCount, tellFrac, tfEstimate)
 	}
 	info.totalBits = uint(effectiveBytes) * 8
 	shapeBits := (int(info.totalBits) << bitResolution) - tellFrac - 1


### PR DESCRIPTION
#### Description

In VBR, the encoder was only using **28–38% of the requested bitrate**. At 96 kbps it was averaging around 27 kbps.

The cause was the target floor in `compute_vbr`. libopus (`celt_encoder.c`) does:

```c
bins = eBands[nbEBands-2]<<LM;
floor_depth = (opus_int32)SHR32(MULT16_16((C*bins<<BITRES),maxDepth), DB_SHIFT);
floor_depth = IMAX(floor_depth, target>>2);
target = IMIN(target, floor_depth);
```

pion had:
```go
floorDepth := float32(channelCount*effectiveBytes*8) * maxDepth / 65536
```

There are two problems here. It was using effectiveBytes where libopus uses a bin count (eBands[19]<<LM = 480, not the byte budget), and it divided by 65536, which corresponds to the SHR32(..., DB_SHIFT) — an identity in the float build (arch.h:313).

Together, those made the floor several orders of magnitude too small, so IMIN(target, floor_depth) always reduced the target to target>>2: one quarter of the requested bitrate on every frame.

I also ported the transient boost, which was previously approximated as:
```go
if transient {
    target += target >> 3
}
```

libopus scales it using tf_estimate and compensates for the average:
```c
tf_calibration = QCONST16(0.044f,14);
target += (opus_int32)SHL32(MULT16_32_Q15(tf_estimate-tf_calibration, target),1);
```
SHL32 is also an identity in the float build, so this becomes:
```
target += (tf_estimate - 0.044) * target
```

#### Measurement

Average packet size over 200 music frames, compared against the requested bitrate:

| bitrate | target | before | after | libopus |
|---|---|---|---|---|
| 24000 | 60 B | 22.71 (37.9%) | **54.30 (90.5%)** | 53.50 |
| 48000 | 120 B | 37.80 (31.5%) | **111.97 (93.3%)** | 113.71 |
| 96000 | 240 B | 68.34 (28.5%) | **227.51 (94.8%)** | 244.03 |
| 128000 | 320 B | 88.61 (27.7%) | **304.47 (95.1%)** | — |

Constrained VBR was also under target at around 77–79%; it now reaches 94–95%.

The packet sizes still vary frame to frame as expected: there are 10–12 distinct sizes per bitrate, ranging from 51 to 60 bytes at 24 kbps.

#### What is still short

At 96 kbps, libopus averages 244 bytes, slightly above the nominal 240, while pion stops at 227.5.

That's a separate structural issue: pion currently gives CELT a budget equal to frameBytes, so unrestricted VBR can only undershoot the target, never exceed it. libopus separates the packet buffer limit from the nominal vbr_rate, allowing demanding frames to use more bits while the reservoir keeps the long-term average under control.

That also shows up in quality: VBR round-trip SNR against libopus changes by +0.19 dB at 24 kbps, −0.15 dB at 48 kbps, and −0.45 dB at 96 kbps. The direction follows the amount of bits being spent.

Separating those two budgets is a separate change, so I'm leaving it for another PR.

#### Tests

TestVBRTracksTargetBitrate catches the main issue: it averages 40 frames and requires the result to stay above 80% of the requested bitrate. With the old floor it was around 30%, so the test fails.

TestVBRProducesVaryingPacketSizes was still passing with the bug because the two synthetic tones happened to produce different packet sizes anyway. I rewrote it around a case where the variation actually depends on the target being correct: a silence frame versus tonal frames.

Reference issue
Part of #34.