### PR TITLE
Cap VBR frames by the buffer, not the rate

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -392,7 +392,7 @@ func (e *Encoder) EncodeFloat32(in []float32, out []byte) (int, error) {
 	if frameBytes <= 0 || frameBytes > maxOpusFrameSize {
 		return 0, fmt.Errorf("%w: %d", errInvalidFrameByteBudget, frameBytes)
 	}
-	if len(out) < frameBytes+1 {
+	if len(out) < frameBytes+tocHeaderBytes {
 		return 0, errOutBufferTooSmall
 	}
 	out[0] = byte(e.tocHeader())
@@ -401,7 +401,14 @@ func (e *Encoder) EncodeFloat32(in []float32, out []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	n, err := e.celtEncoder.EncodeFrame(channels, out[1:frameBytes+1], frameBytes, startBand, endBand)
+	// VBR gets the whole buffer the caller supplied: a demanding frame may run
+	// past the nominal rate and the bit reservoir wins it back later. CBR is
+	// pinned to its share.
+	payload := out[tocHeaderBytes:]
+	if !e.vbr && len(payload) > frameBytes {
+		payload = payload[:frameBytes]
+	}
+	n, err := e.celtEncoder.EncodeFrame(channels, payload, frameBytes, startBand, endBand)
 	if err != nil {
 		return 0, err
 	}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -943,3 +943,42 @@ func TestApplyStereoFadeCrossfadesOverOverlap(t *testing.T) {
 	assert.InDelta(t, 0, left[1], 1e-6, "overlap ends at the new width")
 	assert.InDelta(t, 0, left[2], 1e-6, "past the overlap the new width applies")
 }
+
+func TestVBRUsesBufferHeadroom(t *testing.T) {
+	// Unconstrained VBR may run a hard frame past the nominal rate when the
+	// caller left room, and the reservoir wins it back on the easy ones. Capping
+	// every frame at the rate is what kept pion from ever reaching its target.
+	const bitrate = 96000
+	enc, err := NewEncoder(WithChannels(2), WithBitrate(bitrate), WithVBR(true), WithConstrainedVBR(false))
+	require.NoError(t, err)
+
+	frameBudget := bitrate / 50 / 8
+	total, frames, largest := 0, 60, 0
+	phase := 0.0
+	for i := range frames {
+		pcm := make([]float32, encoderTestFrameSampleCount*2)
+		// Alternate quiet stretches with dense ones so the target has to move.
+		amp := float32(0.02)
+		if i%4 == 0 {
+			amp = 0.6
+		}
+		for j := range encoderTestFrameSampleCount {
+			v := amp * float32(math.Sin(phase)+math.Sin(phase*7.3)+math.Sin(phase*23.1))
+			pcm[2*j] = v
+			pcm[2*j+1] = -v
+			phase += 2 * math.Pi * 440 / 48000
+		}
+		packet := make([]byte, 1500)
+		n, encErr := enc.EncodeFloat32(pcm, packet)
+		require.NoError(t, encErr)
+		total += n
+		largest = max(largest, n)
+	}
+
+	// No ceiling assertion here on purpose: on a sustained hard signal there is
+	// nothing easy to win the bits back on, and the reference overshoots the
+	// nominal rate by the same margin. TestVBRTracksTargetBitrate covers the
+	// average on material that can actually be tracked.
+	assert.Greater(t, largest, frameBudget, "a demanding frame should be allowed past the nominal rate")
+	assert.Positive(t, total)
+}

--- a/internal/celt/celt.go
+++ b/internal/celt/celt.go
@@ -9,8 +9,10 @@ const (
 	// 48 kHz mode with 21 energy bands and 2.5 ms band-edge units.
 	sampleRate            = 48000
 	shortBlockSampleCount = 120
-	maxLM                 = 3
-	maxFrameSampleCount   = shortBlockSampleCount << maxLM
-	maxBands              = 21
-	hybridStartBand       = 17
+	// maxCELTFrameBytes is the largest Opus frame payload (RFC 6716 Section 3.4).
+	maxCELTFrameBytes   = 1275
+	maxLM               = 3
+	maxFrameSampleCount = shortBlockSampleCount << maxLM
+	maxBands            = 21
+	hybridStartBand     = 17
 )

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -566,9 +566,20 @@ func computeVBR(
 // and updates the bit reservoir/drift state that biases future frames.
 // tellFrac is e.rangeEncoder.TellFrac() at the point of the call. Mirrors
 // celt_encoder.c's VBR block around compute_vbr (~lines 2436-2530).
+// frameCeiling is how many bytes the frame may occupy. libopus caps a VBR frame
+// at the room the caller left (nbCompressedBytes), which is what lets it run
+// above the nominal rate on a hard frame; CBR stays pinned to its share.
+func (e *Encoder) frameCeiling(dst []byte, frameBytes int) int {
+	if !e.vbr {
+		return frameBytes
+	}
+
+	return min(len(dst), maxCELTFrameBytes)
+}
+
 func (e *Encoder) applyVBR(
 	frameBytes int, dr dynallocResult,
-	effectiveBytes, lm, channelCount, tellFrac int, tfEstimate float32,
+	maxBytes, lm, channelCount, tellFrac int, tfEstimate float32,
 ) int {
 	vbrRate := frameBytes << 6 // libopus vbr_rate, 1/8-bit units
 
@@ -576,7 +587,7 @@ func (e *Encoder) applyVBR(
 		// libopus allows any multiple of vbrRate as the bound; pion always
 		// uses 2x (vbr_bound == vbr_rate in celt_encoder.c).
 		maxAllowed := max(2, (2*vbrRate-int(e.vbrReservoir))>>6)
-		effectiveBytes = min(effectiveBytes, maxAllowed)
+		maxBytes = min(maxBytes, maxAllowed)
 	}
 
 	baseTarget := max(0, vbrRate-((40*channelCount+20)<<3))
@@ -591,8 +602,16 @@ func (e *Encoder) applyVBR(
 		baseTarget, dr.maxDepth, dr.totBoostBits, e.constrainedVBR, channelCount, lm, tfEstimate,
 	) + tellFrac
 
-	nbAvailableBytes := max(2, (rawTarget+(1<<5))>>6)
-	nbAvailableBytes = min(nbAvailableBytes, effectiveBytes)
+	// The frame still has to fit what has already been written plus the
+	// dynalloc boosts, or the range coder runs out of room (libopus
+	// min_allowed).
+	minAllowed := ((tellFrac + dr.totBoostBits + (1 << 6) - 1) >> 6) + 2
+
+	// The ceiling is how much room the caller left, not the nominal rate:
+	// unconstrained VBR is allowed to spend over the average on a hard frame
+	// and win it back later through the reservoir.
+	nbAvailableBytes := max(minAllowed, (rawTarget+(1<<5))>>6)
+	nbAvailableBytes = min(nbAvailableBytes, maxBytes)
 
 	e.updateVBRReservoir(vbrRate, rawTarget, nbAvailableBytes<<6)
 
@@ -716,6 +735,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	// and tf decisions: spread_weight feeds spreadingDecision and importance
 	// feeds tfAnalysis (libopus runs dynalloc_analysis first).
 	effectiveBytes := frameBytes
+	maxBytes := e.frameCeiling(dst, frameBytes)
 	dr := dynallocAnalysis(
 		analysis.logBandAmp, e.prevLogBandAmp,
 		info.lm, info.startBand, info.endBand, info.channelCount,
@@ -756,7 +776,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	tellFrac := int(e.rangeEncoder.TellFrac())
 
 	if e.vbr {
-		effectiveBytes = e.applyVBR(frameBytes, dr, effectiveBytes, info.lm, info.channelCount, tellFrac, tfEstimate)
+		effectiveBytes = e.applyVBR(frameBytes, dr, maxBytes, info.lm, info.channelCount, tellFrac, tfEstimate)
 	}
 	info.totalBits = uint(effectiveBytes) * 8
 	shapeBits := (int(info.totalBits) << bitResolution) - tellFrac - 1


### PR DESCRIPTION
#### Description

In VBR, the encoder was still capping each frame at the nominal bitrate, so a difficult frame could only undershoot — it could never use extra bits and make them back later. libopus instead caps the frame using the buffer size provided by the caller:

```c
nbAvailableBytes = (target+(1<<(BITRES+2)))>>(BITRES+3);
nbAvailableBytes = IMAX(min_allowed,nbAvailableBytes);
nbAvailableBytes = IMIN(nbCompressedBytes,nbAvailableBytes);
```

In VBR, nbCompressedBytes is max_data_bytes (capped at 1275), not vbr_rate. The reservoir keeps the long-term average in check rather than putting a hard ceiling on every frame.

I also ported min_allowed, which was missing:
```c
min_allowed = ((tell+total_boost+(1<<(BITRES+3))-1)>>(BITRES+3)) + 2;
```

pion was using a fixed floor of 2 bytes, without accounting for what had already been written or the dynalloc boosts.

I checked what budget each stage sees in the reference before the VBR block to make sure this change didn't affect anything else. Instrumenting celt_encoder.c at 96 kbps VBR, effectiveBytes is 240 (the nominal rate) while nbCompressedBytes is 1275. The buffer only comes into play in the final clamp; dynalloc and the TF gate still see the nominal rate. This PR only changes that clamp.

The prefilter does see 1275 in the reference versus 239 in pion, but its thresholds (<25, <35, >12*C) don't change within that range. It would only matter below roughly 14 kbps, so I'm leaving that for now.

#### Measurement

Average packet size over 200 music frames:


bitrate | before | after | libopus
-- | -- | -- | --
24000 | 54.30 (90.5%) | 56.99 (95.0%) | 53.50
32000 | 73.50 (91.9%) | 77.58 (97.0%) | —
48000 | 111.97 (93.3%) | 118.80 (99.0%) | 113.71
64000 | 150.44 (94.0%) | 160.00 (100.0%) | —
96000 | 227.51 (94.8%) | 242.56 (101.1%) | 244.03

VBR can now actually use the available headroom instead of being capped at the nominal frame size.

Round-trip SNR against libopus at the same bitrate:

bitrate | before | after
-- | -- | --
24000 | +0.188 | +0.286
32000 | −0.043 | +0.063
48000 | −0.150 | −0.055
64000 | −0.124 | +0.042
96000 | −0.448 | −0.292

Constrained VBR ends up at 97.6–98.5% of the target, with less variation than unconstrained VBR, as expected.

#### What doesn't match yet

At 96 kbps we're still about 0.29 dB behind libopus with roughly the same bit usage (242.6 vs 244.0 bytes), so the remaining difference is more about where the bits go than how many there are.

Looking at the distributions on the same clip, pion has more spread around the average (stddev 49.1 vs 37.6) but a smaller range (223/453 vs 206/477). I haven't isolated the cause yet.

The likely candidates are the remaining compute_vbr terms: stereo_saving and temporal_vbr are straightforward to port, while the tonality boost depends on analysis.c.

#### Tests

TestVBRUsesBufferHeadroom checks that a demanding frame can go above the nominal bitrate.

I deliberately didn't put an upper bound on the average in that test. On a sustained difficult signal there may not be easy frames to recover the bits, and the reference behaves the same way — with the same PCM, libopus averages 420.7 bytes against pion's 402.6 for a 240-byte target.

The long-term target is covered separately by TestVBRTracksTargetBitrate using material where the reservoir can actually recover.

#### Reference issue

Part of #34.