### PR TITLE
Feat/temporal vbr

### DIFF
--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -53,6 +53,9 @@ type Encoder struct {
 	tapsetDecision     int
 	prevSpreadDecision int
 	prevIntensityBand  int
+	// specAvg tracks the running spectral level the temporal-VBR term compares
+	// each frame against (st->spec_avg in celt_encoder.c).
+	specAvg float32
 	// stereoSaving estimates how many bits mid/side is saving over plain
 	// stereo; the VBR target spends less when the channels are redundant.
 	stereoSaving float32
@@ -138,6 +141,7 @@ func (e *Encoder) Reset() {
 	e.prevSpreadDecision = defaultSpreadDecision
 	e.prevIntensityBand = 0
 	e.stereoSaving = 0
+	e.specAvg = 0
 	e.lastCodedBands = 0
 	e.consecTransient = 0
 	e.analysis.prefilter = postFilterState{}
@@ -543,6 +547,7 @@ func computeVBR(
 	lm int,
 	tfEstimate float32,
 	intensity, lastCodedBands int, stereoSaving float32,
+	equivRate int, temporalVBR float32,
 ) int {
 	target := baseTarget
 
@@ -589,6 +594,14 @@ func computeVBR(
 		target = baseTarget + int(0.67*float32(target-baseTarget))
 	}
 
+	// Temporal VBR only applies to frames that are not asking for finer time
+	// resolution, and it fades out as the rate approaches 96 kb/s, where there
+	// are enough bits that leveling them out stops paying.
+	if tfEstimate < 0.2 {
+		amount := 0.0000031 * float32(max(0, min(32000, 96000-equivRate)))
+		target += int(temporalVBR * amount * float32(target))
+	}
+
 	return max(min(target, 2*baseTarget), 0)
 }
 
@@ -599,6 +612,34 @@ func computeVBR(
 // frameCeiling is how many bytes the frame may occupy. libopus caps a VBR frame
 // at the room the caller left (nbCompressedBytes), which is what lets it run
 // above the nominal rate on a hard frame; CBR stays pinned to its share.
+// temporalVBR measures how far the frame's spectral level sits above or below
+// the running average, following a decaying envelope so a brief dip does not
+// register. The VBR target leans on it to spend more on a frame that is
+// louder than its neighbors (celt_encoder.c).
+func (e *Encoder) temporalVBR(
+	logBandAmp [2][maxBands]float32, startBand, endBand, channelCount, lm int, transient bool,
+) float32 {
+	follow := float32(-10.0)
+	var frameAvg float32
+	var offset float32
+	if transient {
+		offset = 0.5 * float32(lm)
+	}
+	for band := startBand; band < endBand; band++ {
+		follow = max32(follow-1.0, logBandAmp[0][band]-offset)
+		if channelCount == 2 {
+			follow = max32(follow, logBandAmp[1][band]-offset)
+		}
+		frameAvg += follow
+	}
+	frameAvg /= float32(endBand - startBand)
+
+	tvbr := min32(3.0, max32(-1.5, frameAvg-e.specAvg))
+	e.specAvg += 0.02 * tvbr
+
+	return tvbr
+}
+
 func (e *Encoder) frameCeiling(dst []byte, frameBytes int) int {
 	if !e.vbr {
 		return frameBytes
@@ -608,10 +649,15 @@ func (e *Encoder) frameCeiling(dst []byte, frameBytes int) int {
 }
 
 func (e *Encoder) applyVBR(
-	frameBytes int, dr dynallocResult,
-	maxBytes, lm, channelCount, tellFrac int, tfEstimate float32, intensity int,
+	info *frameSideInfo, logBandAmp [2][maxBands]float32, dr dynallocResult,
+	frameBytes, maxBytes, tellFrac int, tfEstimate float32, intensity int,
 ) int {
+	lm, channelCount := info.lm, info.channelCount
+	temporalVBR := e.temporalVBR(logBandAmp, info.startBand, info.endBand, channelCount, lm, info.transient)
 	vbrRate := frameBytes << 6 // libopus vbr_rate, 1/8-bit units
+	// equiv_rate at the CELT layer: the frame's byte share expressed as a rate,
+	// net of the per-packet overhead (celt_encoder.c:1926).
+	equivRate := frameBytes*8*50<<(3-lm) - (40*channelCount+20)*((400>>lm)-50)
 
 	if e.constrainedVBR {
 		// libopus allows any multiple of vbrRate as the bound; pion always
@@ -631,6 +677,7 @@ func (e *Encoder) applyVBR(
 	rawTarget := computeVBR(
 		baseTarget, dr.maxDepth, dr.totBoostBits, e.constrainedVBR, channelCount, lm, tfEstimate,
 		intensity, e.lastCodedBands, e.stereoSaving,
+		equivRate, temporalVBR,
 	) + tellFrac
 
 	// The frame still has to fit what has already been written plus the
@@ -812,7 +859,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 
 	if e.vbr {
 		effectiveBytes = e.applyVBR(
-			frameBytes, dr, maxBytes, info.lm, info.channelCount, tellFrac, tfEstimate, targetIntensity)
+			&info, analysis.logBandAmp, dr, frameBytes, maxBytes, tellFrac, tfEstimate, targetIntensity)
 	}
 	info.totalBits = uint(effectiveBytes) * 8
 	shapeBits := (int(info.totalBits) << bitResolution) - tellFrac - 1


### PR DESCRIPTION
#### Description

This is the last missing term from `compute_vbr`, and it is fully portable.

libopus compares the frame's spectral level against a running average and spends more bits on frames that stand out (`celt_encoder.c`):

```c
celt_glog follow=-QCONST32(10.0f, DB_SHIFT-5);
celt_glog offset = shortBlocks?HALF32(SHL32(LM, DB_SHIFT-5)):0;
for(i=start;i<end;i++)
{
   follow = MAXG(follow-QCONST32(1.0f, DB_SHIFT-5), SHR32(bandLogE[i],5)-offset);
   if (C==2) follow = MAXG(follow, SHR32(bandLogE[i+nbEBands],5)-offset);
   frame_avg += follow;
}
frame_avg /= (end-start);
temporal_vbr = SUB32(SHL32(frame_avg, 5),st->spec_avg);
temporal_vbr = MING(GCONST(3.f), MAXG(-GCONST(1.5f), temporal_vbr));
st->spec_avg += MULT16_32_Q15(QCONST16(.02f, 15), temporal_vbr);
```

It then applies the result by scaling the target:
```c
if (!has_surround_mask && tf_estimate < QCONST16(.2f, 14))
{
   amount = MULT16_16_Q15(QCONST16(.0000031f, 30), IMAX(0, IMIN(32000, 96000-bitrate)));
   tvbr_factor = SHR32(MULT16_16(SHR32(temporal_vbr, DB_SHIFT-10), amount), 10);
   target += (opus_int32)MULT16_32_Q15(tvbr_factor, target);
}
```

The Q-domain shifts in both blocks are identities in the float build, so the calculation is effectively in direct log2 units and the factor becomes:
```
temporal_vbr * amount
```

amount naturally goes to zero as the bitrate approaches 96 kb/s. Once there are enough bits available, shifting bits between frames based on their spectral level is no longer worth paying for.

I verified the port by instrumenting both implementations on the same clip: frame_avg, spec_avg, and temporal_vbr match frame by frame to the fifth or sixth decimal place. Over 3000 frames, the average temporal_vbr is 0.0634 in pion vs 0.0629 in libopus.

#### Measurement

Packet size and round-trip SNR in VBR over 3000 frames of music:

bitrate | without this term | with this term | libopus
-- | -- | -- | --
24000 | 52.14 B / 6.1694 dB | 52.21 B / 6.2959 dB | 53.50 B / 6.3764 dB
48000 | 111.33 B / 9.7837 dB | 111.55 B / 9.8859 dB | 113.71 B / 10.0016 dB
96000 | 241.81 B / 14.9433 dB | 241.81 B / 14.9469 dB | 244.03 B / 15.0810 dB

The bit usage barely changes (+0.07 and +0.22 bytes per frame), while SNR improves by +0.127 dB at 24 kb/s and +0.102 dB at 48 kb/s.

That's exactly what this term is supposed to do: it doesn't really ask for more bits, it moves them toward the frames that can make better use of them.

At 96 kb/s it has essentially no effect, as expected since the factor is nearly zero there.

CBR is unchanged: 15.0721 dB at 96 kb/s, identical to before.

VBR status after this change

bitrate | pion | libopus | pion / libopus bytes | SNR gap
-- | -- | -- | -- | --
24000 | 52.21 B / 6.2959 | 53.50 B / 6.3764 | 97.6% | −0.081
48000 | 111.55 B / 9.8859 | 113.71 B / 10.0016 | 98.1% | −0.116
96000 | 241.81 B / 14.9469 | 244.03 B / 15.0810 | 99.1% | −0.134

pion is now spending between 1% and 2.4% fewer bytes than libopus and scores between 0.08 and 0.13 dB lower, roughly in proportion to the difference in bitrate.

At this point, the only remaining compute_vbr term is the tonality boost, which requires analysis.c. In this particular reference configuration it does not actually apply either: analysis->valid is 0, confirmed through instrumentation.

#### Reference issue

Part of #34.