### PR TITLE
Measure the VBR target against the nominal rate

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -263,6 +263,7 @@ func NewEncoder(opts ...EncoderOption) (*Encoder, error) {
 	encoder.celtEncoder.SetConstrainedVBR(encoder.constrainedVBR)
 	encoder.celtEncoder.SetLossRate(encoder.lossRate)
 	encoder.celtEncoder.SetComplexity(encoder.complexity)
+	encoder.celtEncoder.SetBitrate(encoder.bitrate)
 	encoder.silkEncoder.SetUseInterpolatedNLSFs(encoder.complexity >= silkComplexityInterpolationThreshold)
 
 	return encoder, nil
@@ -270,7 +271,12 @@ func NewEncoder(opts ...EncoderOption) (*Encoder, error) {
 
 // SetBitrate updates the target bitrate in bits per second.
 func (e *Encoder) SetBitrate(bps int) error {
-	return WithBitrate(bps)(e)
+	if err := WithBitrate(bps)(e); err != nil {
+		return err
+	}
+	e.celtEncoder.SetBitrate(e.bitrate)
+
+	return nil
 }
 
 // SetComplexity updates the encoder complexity on the standard Opus 0..10

--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -646,12 +646,8 @@ func chooseAllocationTrim(
 	logBandAmp [2][maxBands]float32,
 	mdct [2][]float32,
 	channelCount, lm, endBand int,
-	totalBits uint,
-	tfEstimate float32, intensity int, stereoSaving *float32,
+	tfEstimate float32, intensity int, stereoSaving *float32, equivRate int,
 ) int {
-	frameSampleCount := shortBlockSampleCount << lm
-	equivRate := int(totalBits) * sampleRate / frameSampleCount
-
 	// bitrate base, trim=5 default, 4 at low bitrate, interpolated 64-80kbps.
 	trim := float32(5.0)
 	if equivRate < 64000 {

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -395,7 +395,7 @@ func TestChooseAllocationTrimDefault(t *testing.T) {
 	mdct := makeFlatMDCT()
 	trim := chooseAllocationTrim(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 0, 0, new(float32),
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 0, 0, new(float32), 128000,
 	)
 	assert.InDelta(t, 5, trim, 1, "flat spectrum at 128kbps should stay near default")
 }
@@ -406,7 +406,7 @@ func TestChooseAllocationTrimLowBitrate(t *testing.T) {
 	mdct := makeFlatMDCT()
 	trim := chooseAllocationTrim(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 32*8*50, 0, 0, new(float32),
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 0, 0, new(float32), 32000,
 	)
 	assert.LessOrEqual(t, trim, 5, "low bitrate should bias trim downward")
 }
@@ -418,10 +418,10 @@ func TestChooseAllocationTrimSpectralTilt(t *testing.T) {
 	highHeavy := makeTiltedLogBandAmp(+1.0) // bandas altas con más energía
 	mdct := makeFlatMDCT()
 	trimLow := chooseAllocationTrim([2][maxBands]float32{lowHeavy, lowHeavy},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 0, 0, new(float32),
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 0, 0, new(float32), 128000,
 	)
 	trimHigh := chooseAllocationTrim([2][maxBands]float32{highHeavy, highHeavy},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 0, 0, new(float32),
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 0, 0, new(float32), 128000,
 	)
 	assert.Greater(t, trimLow, trimHigh, "low-heavy spectrum should bias trim upward (more bits to lows)")
 }
@@ -431,13 +431,13 @@ func TestChooseAllocationTrimStereoCorrelated(t *testing.T) {
 	logBandAmp := makeFlatLogBandAmp(0.0)
 	mdct := makeSineMDCT(440) // mismo contenido en ambos canales
 	trimCorr := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdct}, 2, maxLM, maxBands, 128*8*50, 0, 0, new(float32),
+		[2][]float32{mdct, mdct}, 2, maxLM, maxBands, 0, 0, new(float32), 128000,
 	)
 
 	// L y R decorrelated → trim sin ajuste stereo.
 	mdctR := makeNoiseMDCT(42)
 	trimDecorr := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdctR}, 2, maxLM, maxBands, 128*8*50, 0, 0, new(float32),
+		[2][]float32{mdct, mdctR}, 2, maxLM, maxBands, 0, 0, new(float32), 128000,
 	)
 
 	assert.Less(t, trimCorr, trimDecorr, "correlated stereo should have lower trim than decorrelated")
@@ -449,10 +449,10 @@ func TestChooseAllocationTrimTFEstimate(t *testing.T) {
 	logBandAmp := makeFlatLogBandAmp(0.0)
 	mdct := makeFlatMDCT()
 	trimFlat := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 0, 0, new(float32),
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 0, 0, new(float32), 128000,
 	)
 	trimTF := chooseAllocationTrim([2][maxBands]float32{logBandAmp, logBandAmp},
-		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 128*8*50, 1.0, 0, new(float32))
+		[2][]float32{mdct, mdct}, 1, maxLM, maxBands, 1.0, 0, new(float32), 128000)
 	assert.Equal(t, trimFlat-2, trimTF, "tf_estimate of 1.0 should drop the trim by 2")
 }
 

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -74,6 +74,10 @@ type Encoder struct {
 	constrainedVBR bool
 	lossRate       int
 	complexity     int
+	// bitrate is the nominal target the caller asked for. The reference caps
+	// equiv_rate with it, which is what keeps a VBR frame's rate-derived
+	// decisions from tracking the output buffer instead of the target.
+	bitrate int
 
 	// VBR bit reservoir state (celt_encoder.c), all in 1/8-bit units.
 	vbrReservoir int32
@@ -158,6 +162,11 @@ func (e *Encoder) SetVBR(vbr bool) {
 
 func (e *Encoder) SetConstrainedVBR(cvbr bool) {
 	e.constrainedVBR = cvbr
+}
+
+// SetBitrate sets the nominal target bitrate in bits per second.
+func (e *Encoder) SetBitrate(bps int) {
+	e.bitrate = bps
 }
 
 // SetLossRate sets the expected packet loss rate (0-100 percent).
@@ -367,7 +376,7 @@ func (e *Encoder) encodeDynamicAllocation(info *frameSideInfo, offsets [maxBands
 // enough budget left to signal it.
 func (e *Encoder) encodeAllocationTrim(
 	info *frameSideInfo, logBandAmp [2][maxBands]float32, mdct [2][]float32, totalBitsEighth uint,
-	tfEstimate float32, intensity int,
+	tfEstimate float32, intensity, equivRate int,
 ) {
 	info.allocationTrim = defaultAllocationTrim
 	if e.rangeEncoder.TellFrac()+uint(allocationTrimBitCost<<bitResolution) <= totalBitsEighth {
@@ -375,8 +384,7 @@ func (e *Encoder) encodeAllocationTrim(
 			logBandAmp,
 			mdct,
 			info.channelCount, info.lm, info.endBand,
-			info.totalBits,
-			tfEstimate, intensity, &e.stereoSaving,
+			tfEstimate, intensity, &e.stereoSaving, equivRate,
 		)
 		e.rangeEncoder.EncodeSymbolWithICDF(icdfAllocationTrim, uint32(info.allocationTrim))
 	}
@@ -508,16 +516,12 @@ func (e *Encoder) updatePrefilterState(
 // computeIntensityAndDualStereo returns the intensity band and dual stereo flag
 // for the current frame. Intensity band includes ±1 hysteresis to avoid oscillation.
 func (e *Encoder) computeIntensityAndDualStereo(
-	info *frameSideInfo, normalized [2][]float32,
+	info *frameSideInfo, normalized [2][]float32, equivRate int,
 ) (targetIntensity, targetDualStereo int) {
 	if info.channelCount != 2 {
 		return 0, 0
 	}
 
-	// equiv_rate is the frame budget expressed as a steady bit rate, net of the
-	// per-packet overhead the reference charges (celt_encoder.c:1926).
-	frameBytes := int(info.totalBits) / 8
-	equivRate := frameBytes*8*50<<(3-info.lm) - (40*info.channelCount+20)*((400>>info.lm)-50)
 	raw := intensityBandForRate(equivRate/1000, e.prevIntensityBand)
 	e.prevIntensityBand = raw
 
@@ -609,6 +613,66 @@ func computeVBR(
 // and updates the bit reservoir/drift state that biases future frames.
 // tellFrac is e.rangeEncoder.TellFrac() at the point of the call. Mirrors
 // celt_encoder.c's VBR block around compute_vbr (~lines 2436-2530).
+// equivalentRate expresses the frame's byte budget as a steady bit rate, net of
+// the per-packet overhead the reference charges, and never above the nominal
+// target (celt_encoder.c:1926). In VBR the budget is the whole output buffer,
+// so without the cap every rate-derived decision would read as if the encoder
+// were running at hundreds of kb/s.
+func (e *Encoder) equivalentRate(maxBytes, lm, channelCount int) int {
+	overhead := (40*channelCount + 20) * ((400 >> lm) - 50)
+	equiv := maxBytes*8*50<<(3-lm) - overhead
+	if e.bitrate > 0 {
+		equiv = min(equiv, e.bitrate-overhead)
+	}
+
+	return equiv
+}
+
+// settleFrameBudget fixes how many bytes the frame gets — running the VBR
+// target when it applies — and returns what is left for the band shapes after
+// the header and the anti-collapse reservation.
+func (e *Encoder) settleFrameBudget(
+	info *frameSideInfo, logBandAmp [2][maxBands]float32, dr dynallocResult,
+	effectiveBytes, rateBytes, maxBytes int, tfEstimate float32, intensity int,
+) (int, int) {
+	tellFrac := int(e.rangeEncoder.TellFrac())
+	if e.vbr {
+		effectiveBytes = e.applyVBR(info, logBandAmp, dr, rateBytes, maxBytes, tellFrac, tfEstimate, intensity)
+	}
+	info.totalBits = uint(effectiveBytes) * 8
+
+	shapeBits := (int(info.totalBits) << bitResolution) - tellFrac - 1
+	info.antiCollapseRsv = 0
+	if info.transient && info.lm >= 2 && shapeBits >= (info.lm+2)<<bitResolution {
+		info.antiCollapseRsv = 1 << bitResolution
+	}
+
+	return effectiveBytes, shapeBits - info.antiCollapseRsv
+}
+
+// frameBudget returns the byte budget the rate-derived decisions are measured
+// against, and the ceiling the frame may actually occupy.
+func (e *Encoder) frameBudget(
+	dst []byte, frameBytes, frameSamples, lm, channelCount int,
+) (rateBytes, maxBytes, equivRate int) {
+	rateBytes = e.rateBytes(frameBytes, frameSamples)
+	maxBytes = e.frameCeiling(dst, frameBytes)
+
+	return rateBytes, maxBytes, e.equivalentRate(maxBytes, lm, channelCount)
+}
+
+// rateBytes is the byte budget the VBR target is measured against. The
+// reference derives it straight from the nominal bitrate (celt_encoder.c:1904),
+// so it covers the whole frame's share including the packet header byte that
+// the CBR payload budget leaves out; the reservoir absorbs the difference.
+func (e *Encoder) rateBytes(frameBytes, frameSamples int) int {
+	if !e.vbr || e.bitrate <= 0 {
+		return frameBytes
+	}
+
+	return e.bitrate * frameSamples / (sampleRate * 8)
+}
+
 // frameCeiling is how many bytes the frame may occupy. libopus caps a VBR frame
 // at the room the caller left (nbCompressedBytes), which is what lets it run
 // above the nominal rate on a hard frame; CBR stays pinned to its share.
@@ -655,9 +719,7 @@ func (e *Encoder) applyVBR(
 	lm, channelCount := info.lm, info.channelCount
 	temporalVBR := e.temporalVBR(logBandAmp, info.startBand, info.endBand, channelCount, lm, info.transient)
 	vbrRate := frameBytes << 6 // libopus vbr_rate, 1/8-bit units
-	// equiv_rate at the CELT layer: the frame's byte share expressed as a rate,
-	// net of the per-packet overhead (celt_encoder.c:1926).
-	equivRate := frameBytes*8*50<<(3-lm) - (40*channelCount+20)*((400>>lm)-50)
+	equivRate := e.equivalentRate(maxBytes, lm, channelCount)
 
 	if e.constrainedVBR {
 		// libopus allows any multiple of vbrRate as the bound; pion always
@@ -812,8 +874,8 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	// Compute dynalloc offsets, spread_weight and importance BEFORE the spread
 	// and tf decisions: spread_weight feeds spreadingDecision and importance
 	// feeds tfAnalysis (libopus runs dynalloc_analysis first).
-	effectiveBytes := frameBytes
-	maxBytes := e.frameCeiling(dst, frameBytes)
+	rateBytes, maxBytes, equivRate := e.frameBudget(dst, frameBytes, frameSamples, info.lm, info.channelCount)
+	effectiveBytes := rateBytes
 	dr := dynallocAnalysis(
 		analysis.logBandAmp, e.prevLogBandAmp,
 		info.lm, info.startBand, info.endBand, info.channelCount,
@@ -852,22 +914,12 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	// The reference settles the intensity band before both the trim and the VBR
 	// target, and both read it (celt_encoder.c:2404). It also derives it from
 	// the nominal rate, not from the post-VBR frame size.
-	targetIntensity, targetDualStereo := e.computeIntensityAndDualStereo(&info, normalized)
-	e.encodeAllocationTrim(&info, analysis.logBandAmp, analysis.mdct, totalBitsEighth, tfEstimate, targetIntensity)
+	targetIntensity, targetDualStereo := e.computeIntensityAndDualStereo(&info, normalized, equivRate)
+	e.encodeAllocationTrim(
+		&info, analysis.logBandAmp, analysis.mdct, totalBitsEighth, tfEstimate, targetIntensity, equivRate)
 
-	tellFrac := int(e.rangeEncoder.TellFrac())
-
-	if e.vbr {
-		effectiveBytes = e.applyVBR(
-			&info, analysis.logBandAmp, dr, frameBytes, maxBytes, tellFrac, tfEstimate, targetIntensity)
-	}
-	info.totalBits = uint(effectiveBytes) * 8
-	shapeBits := (int(info.totalBits) << bitResolution) - tellFrac - 1
-	info.antiCollapseRsv = 0
-	if info.transient && info.lm >= 2 && shapeBits >= (info.lm+2)<<bitResolution {
-		info.antiCollapseRsv = 1 << bitResolution
-	}
-	shapeBits -= info.antiCollapseRsv
+	effectiveBytes, shapeBits := e.settleFrameBudget(
+		&info, analysis.logBandAmp, dr, effectiveBytes, rateBytes, maxBytes, tfEstimate, targetIntensity)
 	info.allocation = e.computeAllocationMono(&info, shapeBits, targetIntensity, targetDualStereo)
 	e.encodeFineEnergy(&info, info.allocation.fineQuant, targetLogE)
 


### PR DESCRIPTION
#### Description

There were two places where the VBR path was using the frame budget while the reference uses the requested bitrate.

**1. `equiv_rate`.** This feeds the intensity band, trim, and temporal VBR factor. libopus caps it with the nominal bitrate (`celt_encoder.c:1926`):

```c
equiv_rate = ((opus_int32)nbCompressedBytes*8*50 << (3-LM)) - (40*C+20)*((400>>LM) - 50);
if (st->bitrate!=OPUS_BITRATE_MAX)
   equiv_rate = IMIN(equiv_rate, st->bitrate - (40*C+20)*((400>>LM) - 50));
```

In VBR, nbCompressedBytes is the output buffer size, so without that IMIN every rate-dependent decision would see a bitrate corresponding to hundreds of kb/s. pion was always deriving equiv_rate from the frame budget.

Instrumenting the reference at 24 kb/s:

VBR: equiv=24000 with nbComp=1275
CBR: equiv=23600 with nbComp=59

In CBR, st->bitrate is OPUS_BITRATE_MAX, so the cap does not apply.

pion was returning 23600 in both cases. That put VBR 24 kb/s into the previous intensity-table entry: band 9 instead of the reference's band 10.

**2. vbr_rate.** The base used to calculate the target comes directly from the bitrate (celt_encoder.c:1904):
```c
vbr_rate = bitrate_to_bits(st->bitrate, mode->Fs, frame_size)<<BITRES;
effectiveBytes = vbr_rate>>(3+BITRES);
```

This is the integer portion of the frame — 60 bytes at 24 kb/s — including the header byte that the CBR payload budget excludes. The reservoir absorbs the difference.

pion was using the 59-byte payload budget instead, one byte less per frame.

For this, the CELT layer needs to know the nominal bitrate, so I added SetBitrate alongside the existing setters.

#### Measurement

Intensity-band agreement against opus_demo, over 3000 frames:

mode | before | after
-- | -- | --
VBR 24 kb/s | 0.0% | 100%
VBR 96 kb/s | 100% | 100%
CBR 24 and 96 | 100% | 100%


The 24 kb/s VBR case was a complete mismatch: the reference selected band 10 for all 3000 frames while pion selected band 9.

This also affects the bands that are actually coded:

Packet size and SNR in VBR:

bitrate | before | after | libopus
-- | -- | -- | --
24000 | 51.44 B / 6.1840 dB | 52.44 B / 6.2953 dB | 53.50 B / 6.3764 dB
48000 | 111.55 B / 9.8859 dB | 112.56 B / 9.9074 dB | 113.71 B / 10.0016 dB
96000 | 241.81 B / 14.9433 dB | 242.81 B / 14.9785 dB | 244.03 B / 15.0810 dB

mode | before | after
-- | -- | --
VBR 24 kb/s | 90.7% | 95.9%
VBR 96 kb/s | 99.9% | 100%

CBR remains unchanged, verified at 24, 48, and 96 kb/s: 7.0676 / 10.1179 / 15.0721 dB, identical digit for digit.

#### What remains

In VBR, pion is now within roughly 0.5–2% of libopus in bytes and 0.08–0.10 dB in SNR.

In CBR, it remains essentially matched: +0.014 / +0.015 / −0.002 dB at 24, 48, and 96 kb/s.

The only metric still below 99% is the number of coded bands at 24 kb/s: 95.9% in VBR and 96.9% in CBR. Since it happens in both modes, this is not a VBR-path issue and should be addressed separately.

#### Reference issue

Part of #34.