### PR TITLE
Fix/dynalloc vbr

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -826,7 +826,7 @@ func dynallocAnalysis(
 	prevLogBandAmp [2][maxBands]float32,
 	lm, startBand, endBand, channelCount int,
 	effectiveBytes int,
-	isTransient bool,
+	isTransient, vbr, constrainedVBR bool,
 ) dynallocResult {
 	var offsets [maxBands]int
 	var spreadWeight [maxBands]int
@@ -1037,8 +1037,10 @@ func dynallocAnalysis(
 			13*math.Pow(2, float64(minFloat32(combined[band], 4)))))
 	}
 
-	// Halve non-transient frames (CBR path); boost low bands, reduce high.
-	if !isTransient {
+	// CBR and constrained VBR halve the dynalloc contribution on a steady
+	// frame; unconstrained VBR keeps it whole, because there the boost also
+	// raises the frame's own target instead of competing for a fixed budget.
+	if (!vbr || constrainedVBR) && !isTransient {
 		for band := startBand; band < endBand; band++ {
 			combined[band] *= 0.5
 		}
@@ -1085,9 +1087,12 @@ func dynallocAnalysis(
 			boostBits = boost * 6 << bitResolution
 		}
 
-		// CBR keeps dynalloc under 2/3 of the frame. libopus hands the leftover
-		// budget to this band as the offset and stops boosting entirely.
-		if (totBoostBits+boostBits)>>bitResolution>>3 > 2*effectiveBytes/3 {
+		// CBR — and a constrained-VBR frame that is not a transient — keeps
+		// dynalloc under 2/3 of the frame. Unconstrained VBR has no such cap:
+		// there the boost total also raises the frame's own target, so capping
+		// it here would quietly hold the whole frame below the asked rate.
+		capped := !vbr || (constrainedVBR && !isTransient)
+		if capped && (totBoostBits+boostBits)>>bitResolution>>3 > 2*effectiveBytes/3 {
 			capBits := (2 * effectiveBytes / 3) << bitResolution << 3
 			offsets[band] = capBits - totBoostBits
 			totBoostBits = capBits

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -532,7 +532,7 @@ func TestDynallocFlatSpectrumNoBoost(t *testing.T) {
 	dr := dynallocAnalysis(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
 		[2][maxBands]float32{prev, prev},
-		maxLM, 0, maxBands, 1, 120, false,
+		maxLM, 0, maxBands, 1, 120, false, false, false,
 	)
 	for band := range maxBands {
 		assert.Equal(t, 0, dr.offsets[band], "flat spectrum band %d should get no boost", band)
@@ -547,7 +547,7 @@ func TestDynallocIsolatedPeakGetsBoost(t *testing.T) {
 	dr := dynallocAnalysis(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
 		[2][maxBands]float32{prev, prev},
-		maxLM, 0, maxBands, 1, 120, false,
+		maxLM, 0, maxBands, 1, 120, false, false, false,
 	)
 	assert.Greater(t, dr.offsets[10], 0, "isolated peak should get boost")
 }
@@ -560,7 +560,7 @@ func TestDynallocSpreadWeightMaskedBandReduced(t *testing.T) {
 	dr := dynallocAnalysis(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
 		[2][maxBands]float32{prev, prev},
-		maxLM, 0, maxBands, 1, 120, false,
+		maxLM, 0, maxBands, 1, 120, false, false, false,
 	)
 	// Bands far from the peak should have reduced weight.
 	assert.Less(t, dr.spreadWeight[5], 32, "band far from peak should have reduced weight")
@@ -577,7 +577,7 @@ func TestDynallocSpreadWeightMaskDecayRate(t *testing.T) {
 	dr := dynallocAnalysis(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
 		[2][maxBands]float32{prev, prev},
-		maxLM, 0, maxBands, 1, 120, false,
+		maxLM, 0, maxBands, 1, 120, false, false, false,
 	)
 	assert.Greater(t, dr.spreadWeight[12], dr.spreadWeight[11],
 		"weight should recover two bands above the peak")
@@ -593,7 +593,7 @@ func TestDynallocLowBitrateGated(t *testing.T) {
 	dr := dynallocAnalysis(
 		[2][maxBands]float32{logBandAmp, logBandAmp},
 		[2][maxBands]float32{prev, prev},
-		maxLM, 0, maxBands, 1, 10, false, // 10 bytes < 30+15=45
+		maxLM, 0, maxBands, 1, 10, false, false, false, // 10 bytes < 30+15=45
 	)
 	for band := range maxBands {
 		assert.Equal(t, 0, dr.offsets[band], "low bitrate should gate dynalloc")

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -879,7 +879,7 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	dr := dynallocAnalysis(
 		analysis.logBandAmp, e.prevLogBandAmp,
 		info.lm, info.startBand, info.endBand, info.channelCount,
-		effectiveBytes, info.transient,
+		effectiveBytes, info.transient, e.vbr, e.constrainedVBR,
 	)
 	offsets := dr.offsets
 	spreadWeight := dr.spreadWeight


### PR DESCRIPTION
#### Description

There were two `dynalloc_analysis` gates that pion was applying unconditionally, while libopus only applies them in CBR or constrained VBR.

**1. The halving.** (`celt_encoder.c`)

```c
/* For non-transient CBR/CVBR frames, halve the dynalloc contribution */
if ((!vbr || constrained_vbr)&&!isTransient)
{
   for (i=start;i<end;i++)
      follower[i] = HALF32(follower[i]);
}
```

pion was doing this for every non-transient frame. The comment that was already there said "(CBR path)", but the condition wasn't actually encoded.

**2. The 2/3 cap.**
```c
/* For CBR and non-transient CVBR frames, limit dynalloc to 2/3 of the bits */
if ((!vbr || (constrained_vbr&&!isTransient))
      && (tot_boost+boost_bits)>>BITRES>>3 > 2*effectiveBytes/3)
```

Same issue here.

In unconstrained VBR, the total dynalloc boost isn't competing for a fixed per-frame budget. It feeds into compute_vbr as:
```
target += tot_boost - (19<<LM)
```

and can therefore increase the size of the frame itself.

Capping it there was effectively forcing difficult frames to stay below the requested bitrate.

I found this by comparing follower frame by frame against an instrumented libopus build. pion was giving exactly half the reference value:

```
0.767569 vs 1.535139
0.697981 vs 1.395965
0.017404 vs 0.034807
```
#### Measurement

Packet size in VBR at 24 kb/s, compared against opus_demo restricted-celt:

clip | before | after
-- | -- | --
real music (60 s) | 97.9% | 100.0%
mixed-music | 89.7% | 100.1%
tonal-harmonic | 96.6% | 100.1%
stereo-wide | 94.6% | 99.8%
percussive | 90.8% | 96.3%
dynamics | 100.0% | 100.0%


With the rates matched, round-trip SNR in VBR against libopus is:

bitrate | before | after | pion / libopus bytes
-- | -- | -- | --
24000 | −0.081 | +0.012 | 53.5 / 53.50
48000 | −0.116 | +0.003 | 113.7 / 113.71
96000 | −0.134 | −0.005 | 243.9 / 244.03

CBR is unchanged. Both gates leave the CBR path exactly as it was, verified at 24, 48, and 96 kb/s: 7.0676 / 10.1179 / 15.0721 dB, identical digit for digit.

The only clip that remains far off is the sine sweep at 81.6%. That's the tone_detect case that hasn't been ported yet; libopus takes a different path there for the prefilter.

#### Reference issue

Part of #34.