### PR TITLE
Return the constrained VBR reservoir underflow

### DIFF
--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -753,18 +753,21 @@ func (e *Encoder) applyVBR(
 	nbAvailableBytes := max(minAllowed, (rawTarget+(1<<5))>>6)
 	nbAvailableBytes = min(nbAvailableBytes, maxBytes)
 
-	e.updateVBRReservoir(vbrRate, rawTarget, nbAvailableBytes<<6)
+	// A reservoir that has gone negative means the last frames spent under the
+	// rate; the reference hands those bits back here instead of dropping them,
+	// which is what keeps constrained VBR on target over time.
+	nbAvailableBytes += e.updateVBRReservoir(vbrRate, rawTarget, nbAvailableBytes<<6)
 
-	return nbAvailableBytes
+	return min(nbAvailableBytes, maxBytes)
 }
 
 // updateVBRReservoir tracks the VBR bit surplus/deficit for this frame and
 // updates the drift correction that biases baseTarget on future frames.
 // All three args are in 1/8-bit units (see applyVBR), matching libopus's
 // vbr_reservoir/vbr_drift/vbr_offset in celt_encoder.c.
-func (e *Encoder) updateVBRReservoir(vbrRate, rawTarget, roundedTarget int) {
+func (e *Encoder) updateVBRReservoir(vbrRate, rawTarget, roundedTarget int) int {
 	if !e.vbr {
-		return
+		return 0
 	}
 
 	var alpha float32
@@ -776,7 +779,7 @@ func (e *Encoder) updateVBRReservoir(vbrRate, rawTarget, roundedTarget int) {
 	}
 
 	if !e.constrainedVBR {
-		return
+		return 0
 	}
 
 	e.vbrReservoir += int32(roundedTarget - vbrRate)
@@ -785,9 +788,13 @@ func (e *Encoder) updateVBRReservoir(vbrRate, rawTarget, roundedTarget int) {
 	e.vbrDrift += int32(alpha * driftDelta)
 	e.vbrOffset = -e.vbrDrift
 
+	adjust := 0
 	if e.vbrReservoir < 0 {
+		adjust = int(-e.vbrReservoir) >> 6
 		e.vbrReservoir = 0
 	}
+
+	return adjust
 }
 
 // EncodeFrame encodes one CELT frame from float PCM into dst.


### PR DESCRIPTION
#### Description

When the constrained VBR reservoir becomes negative, the reference returns those bits to the current frame (`celt_encoder.c`):

```c
if (st->constrained_vbr && st->vbr_reservoir < 0)
{
/* We're under the min value -- increase rate */
int adjust = (-st->vbr_reservoir)/(8<<BITRES);

nbAvailableBytes += silence?0:adjust;

st->vbr_reservoir = 0;

}
```

pion would simply clamp to zero and lose them. A negative reservoir means that previous frames spent less than the target rate, so this loop is precisely what keeps the average at the target; without it, the mode falls short and never recovers.


#### Measurement

Constrained VBR over 60 seconds of music, against `opus_demo restricted-celt -cvbr`:


| bitrate | SNR before | SNR after | bytes pion before | after | libopus |
|---|---|---|---|---|---|
| 24000 | −0.208 | **+0.017** | 57.50 | **61.00** | 61.0 |
| 48000 | −0.101 | **+0.007** | 115.88 | **121.01** | 121.0 |
| 96000 | −0.224 | **+0.007** | 235.06 | **241.02** | 241.1 |

The other modes remain unchanged, verified: CBR 7.0676 and 15.0721 dB, unrestricted VBR 6.3886 and 15.0756, identical to before the change.

#### Mode Status

With this, all four paths are now on par with the reference on the same material:


| mode | 24 kb/s | 48 kb/s | 96 kb/s |
|---|---|---|---|
| CBR | +0.014 | +0.015 | −0.002 |
| VBR | +0.012 | +0.003 | −0.005 |
| CVBR | +0.017 | +0.007 | +0.007 |
| mono VBR | +0.001 | −0.005 | −0.044 |


#### Reference issue

Part of #34.