### PR TITLE
Reuse the public encode path's frame buffers

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -47,7 +47,22 @@ const (
 	minBitrate     = 6000
 	maxBitrate     = 510000
 	frame20msNS    = 20000000
+	// encodeFrameSamples is the one frame length the public encode path takes,
+	// and encodeMaxChannels the widest layout, so together they bound its
+	// per-frame working buffers.
+	encodeFrameSamples = celtSampleRate * frame20msNS / 1000000000
+	encodeMaxChannels  = 2
 )
+
+// encodeScratch holds what Encode and EncodeFloat32 would otherwise allocate on
+// every call. The CELT layer already reuses its own analysis buffers; without
+// this the wrapper around it still churned ~16 kB per frame, which at 50 frames
+// a second is a lot of garbage for a server carrying many streams at once.
+type encodeScratch struct {
+	pcm      [encodeFrameSamples * encodeMaxChannels]float32
+	deinter  [encodeMaxChannels][encodeFrameSamples]float32
+	channels [encodeMaxChannels][]float32
+}
 
 // celtOnlyFullband20msConfig is the TOC config number (bits 3..7) for
 // CELT-only, fullband, 20 ms frames per RFC 6716 Table 2. The mono/stereo bit
@@ -91,6 +106,7 @@ type Encoder struct {
 	maxBandwidth   Bandwidth
 	silkDCBlockMem float32
 	stereoWidth    int
+	scratch        encodeScratch
 }
 
 // EncoderOption configures an Encoder during construction.
@@ -369,7 +385,7 @@ func (e *Encoder) Encode(in []byte, out []byte) (int, error) {
 		return 0, fmt.Errorf("%w: got %d samples, want %d", errInvalidFrameSize, len(in)/2, expectedSamples)
 	}
 
-	pcm := make([]float32, len(in)/2)
+	pcm := e.scratch.pcm[:len(in)/2]
 	for i := range pcm {
 		sample := int16(binary.LittleEndian.Uint16(in[i*2:])) //nolint:gosec // G115: little-endian s16 round-trip.
 		pcm[i] = float32(sample) / 32768
@@ -391,7 +407,7 @@ func (e *Encoder) EncodeFloat32(in []float32, out []byte) (int, error) {
 		return 0, fmt.Errorf("%w: got %d samples, want %d", errInvalidFrameSize, len(in), frameSamples*e.channels)
 	}
 
-	channels := splitChannels(in, e.channels, frameSamples)
+	channels := e.splitChannels(in, e.channels, frameSamples)
 	e.narrowStereo(channels)
 
 	frameBytes := e.frameBytes()
@@ -555,8 +571,8 @@ func (e *Encoder) autoSelectBandwidth() Bandwidth {
 
 // splitChannels splits interleaved PCM into per-channel slices.
 // For mono, it returns the input directly without allocation.
-func splitChannels(in []float32, numChannels, frameSamples int) [][]float32 {
-	ch := make([][]float32, numChannels)
+func (e *Encoder) splitChannels(in []float32, numChannels, frameSamples int) [][]float32 {
+	ch := e.scratch.channels[:numChannels]
 	if numChannels == 1 {
 		ch[0] = in
 
@@ -564,10 +580,11 @@ func splitChannels(in []float32, numChannels, frameSamples int) [][]float32 {
 	}
 
 	for c := range numChannels {
-		ch[c] = make([]float32, frameSamples)
+		buf := e.scratch.deinter[c][:frameSamples]
 		for i := range frameSamples {
-			ch[c][i] = in[i*numChannels+c]
+			buf[i] = in[i*numChannels+c]
 		}
+		ch[c] = buf
 	}
 
 	return ch

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -982,3 +982,51 @@ func TestVBRUsesBufferHeadroom(t *testing.T) {
 	assert.Greater(t, largest, frameBudget, "a demanding frame should be allowed past the nominal rate")
 	assert.Positive(t, total)
 }
+
+// TestEncodeDoesNotAllocate guards the reuse in encodeScratch. The CELT layer
+// was already allocation-free per frame, but nothing measured the public entry
+// points, so the wrapper around it churned ~16 kB a frame unnoticed.
+func TestEncodeDoesNotAllocate(t *testing.T) {
+	enc, err := NewEncoder(WithChannels(2), WithBitrate(96000))
+	require.NoError(t, err)
+
+	in := make([]byte, encoderTestFrameSampleCount*2*2)
+	for i := range in {
+		in[i] = byte(i * 7)
+	}
+	out := make([]byte, 1500)
+	var encErr error
+	allocs := testing.AllocsPerRun(50, func() {
+		_, encErr = enc.Encode(in, out)
+	})
+	require.NoError(t, encErr)
+	assert.Zerof(t, allocs, "Encode allocated %v times per frame", allocs)
+
+	pcm := make([]float32, encoderTestFrameSampleCount*2)
+	for i := range pcm {
+		pcm[i] = float32(i%800) / 8000
+	}
+	allocs = testing.AllocsPerRun(50, func() {
+		_, encErr = enc.EncodeFloat32(pcm, out)
+	})
+	require.NoError(t, encErr)
+	assert.Zerof(t, allocs, "EncodeFloat32 allocated %v times per frame", allocs)
+}
+
+func BenchmarkEncode(b *testing.B) {
+	enc, err := NewEncoder(WithChannels(2), WithBitrate(96000))
+	require.NoError(b, err)
+
+	in := make([]byte, encoderTestFrameSampleCount*2*2)
+	for i := range in {
+		in[i] = byte(i * 7)
+	}
+	out := make([]byte, 1500)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := enc.Encode(in, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
#### Description

#211 got the CELT layer to zero allocations per frame, but nothing was measuring the public entry points, and they were still allocating on every call:

| | before | after |
|---|---|---|
| `Encode` | 4 allocs, 16460 B/op | 0 allocs |
| `EncodeFloat32` | 3 allocs, 8243 B/op | 0 allocs |

Three sites, all of them per-frame scratch that can just live on the encoder: the s16 conversion buffer in `Encode`, and the outer slice plus one buffer per channel in `splitChannels`. They move into an `encodeScratch` on `Encoder`, the same shape as the `encoderScratch` #211 added inside `celt`.

At 50 frames a second that was roughly 800 kB/s of garbage per stream, which matters for the kind of caller pion has — an SFU holding many streams open at once, where this is pure GC pressure in the steady state.

`splitChannels` keeps aliasing the caller's slice for mono rather than copying it, as before. The CELT layer copies what it needs out of the channel buffers (`preemphasisChannel` copies into its own scratch), so reusing them across frames does not disturb any history it keeps.

#### Verification

Output is bit-identical to main: encoding a 30 s clip and hashing every packet matches across mono/stereo, 24 and 96 kbps, CBR and VBR — all eight the same digest on both branches.

`TestEncodeDoesNotAllocate` is the guard, since the gap here was not a bad change but an unmeasured path. `BenchmarkEncode` goes in alongside it; the package had a decode benchmark but no encode one.

#### Reference issue

Follow-up to #211; no separate issue.