### PR TITLE
Optimize CELT pitch cross-correlation

### DIFF
--- a/internal/celt/pitch_search.go
+++ b/internal/celt/pitch_search.go
@@ -121,8 +121,33 @@ func pitchDownsample(x [][]float32, xLP []float32, length, factor int, scratch *
 }
 
 // celtPitchXcorr fills xcorr[i] with the inner product of x and y shifted by i.
+//
+// Eight lags are processed per outer iteration, each with its own independent
+// float64 accumulator. Every accumulator is a chain over j = 0..length-1 in the
+// same order and with the same precision as the single-lag version, so the
+// result is bit-identical: each lag's sum is untouched, we just interleave the
+// independent chains to break the serial dependency that keeps the single-lag
+// loop running at ADD latency.
 func celtPitchXcorr(x, y, xcorr []float32, length, maxPitch int) {
-	for i := range maxPitch {
+	i := 0
+	for ; i+7 < maxPitch; i += 8 {
+		var s0, s1, s2, s3, s4, s5, s6, s7 float64
+		yb := y[i : i+length+7]
+		for j := range length {
+			xj := float64(x[j])
+			s0 += xj * float64(yb[j])
+			s1 += xj * float64(yb[j+1])
+			s2 += xj * float64(yb[j+2])
+			s3 += xj * float64(yb[j+3])
+			s4 += xj * float64(yb[j+4])
+			s5 += xj * float64(yb[j+5])
+			s6 += xj * float64(yb[j+6])
+			s7 += xj * float64(yb[j+7])
+		}
+		xcorr[i], xcorr[i+1], xcorr[i+2], xcorr[i+3] = float32(s0), float32(s1), float32(s2), float32(s3)
+		xcorr[i+4], xcorr[i+5], xcorr[i+6], xcorr[i+7] = float32(s4), float32(s5), float32(s6), float32(s7)
+	}
+	for ; i < maxPitch; i++ {
 		var sum float64
 		for j := range length {
 			sum += float64(x[j]) * float64(y[i+j])

--- a/internal/celt/pitch_search.go
+++ b/internal/celt/pitch_search.go
@@ -132,17 +132,24 @@ func celtPitchXcorr(x, y, xcorr []float32, length, maxPitch int) {
 	i := 0
 	for ; i+7 < maxPitch; i += 8 {
 		var s0, s1, s2, s3, s4, s5, s6, s7 float64
-		yb := y[i : i+length+7]
+		yb := y[i : i+length]
+		y1 := y[i+1 : i+1+length]
+		y2 := y[i+2 : i+2+length]
+		y3 := y[i+3 : i+3+length]
+		y4 := y[i+4 : i+4+length]
+		y5 := y[i+5 : i+5+length]
+		y6 := y[i+6 : i+6+length]
+		y7 := y[i+7 : i+7+length]
 		for j := range length {
 			xj := float64(x[j])
 			s0 += xj * float64(yb[j])
-			s1 += xj * float64(yb[j+1])
-			s2 += xj * float64(yb[j+2])
-			s3 += xj * float64(yb[j+3])
-			s4 += xj * float64(yb[j+4])
-			s5 += xj * float64(yb[j+5])
-			s6 += xj * float64(yb[j+6])
-			s7 += xj * float64(yb[j+7])
+			s1 += xj * float64(y1[j])
+			s2 += xj * float64(y2[j])
+			s3 += xj * float64(y3[j])
+			s4 += xj * float64(y4[j])
+			s5 += xj * float64(y5[j])
+			s6 += xj * float64(y6[j])
+			s7 += xj * float64(y7[j])
 		}
 		xcorr[i], xcorr[i+1], xcorr[i+2], xcorr[i+3] = float32(s0), float32(s1), float32(s2), float32(s3)
 		xcorr[i+4], xcorr[i+5], xcorr[i+6], xcorr[i+7] = float32(s4), float32(s5), float32(s6), float32(s7)

--- a/internal/celt/pitch_test.go
+++ b/internal/celt/pitch_test.go
@@ -388,23 +388,23 @@ func TestCeltPitchXcorrMatchesScalarReference(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("len=%d/pitch=%d", tc.length, tc.maxPitch), func(t *testing.T) {
-			x := make([]float32, tc.length)
-			y := make([]float32, tc.length+tc.maxPitch)
-			for i := range x {
-				x[i] = rng()
+			input := make([]float32, tc.length)
+			window := make([]float32, tc.length+tc.maxPitch)
+			for i := range input {
+				input[i] = rng()
 			}
-			for i := range y {
-				y[i] = rng()
+			for i := range window {
+				window[i] = rng()
 			}
 
 			got := make([]float32, tc.maxPitch)
-			celtPitchXcorr(x, y, got, tc.length, tc.maxPitch)
+			celtPitchXcorr(input, window, got, tc.length, tc.maxPitch)
 
 			want := make([]float32, tc.maxPitch)
 			for i := range tc.maxPitch {
 				var sum float64
 				for j := range tc.length {
-					sum += float64(x[j]) * float64(y[i+j])
+					sum += float64(input[j]) * float64(window[i+j])
 				}
 				want[i] = float32(sum)
 			}

--- a/internal/celt/pitch_test.go
+++ b/internal/celt/pitch_test.go
@@ -4,6 +4,7 @@
 package celt
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -363,4 +364,69 @@ func TestEncoderResetClearsPrefilterState(t *testing.T) {
 	assert.Zero(t, encoder.analysis.prefilter.period)
 	assert.Zero(t, encoder.analysis.prefilter.gain)
 	assert.Zero(t, encoder.analysis.prefilter.tapset)
+}
+
+func TestCeltPitchXcorrMatchesScalarReference(t *testing.T) {
+	seed := uint32(987654321)
+	rng := func() float32 {
+		seed = seed*1664525 + 1013904223
+
+		return float32(int32(seed>>8)%2000)/2000 - 1
+	}
+
+	cases := []struct {
+		length, maxPitch int
+	}{
+		{0, 0},
+		{1, 1},
+		{3, 3},
+		{240, 244},
+		{240, 250},
+		{8, 16},
+		{31, 23},
+		{100, 100},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("len=%d/pitch=%d", tc.length, tc.maxPitch), func(t *testing.T) {
+			x := make([]float32, tc.length)
+			y := make([]float32, tc.length+tc.maxPitch)
+			for i := range x {
+				x[i] = rng()
+			}
+			for i := range y {
+				y[i] = rng()
+			}
+
+			got := make([]float32, tc.maxPitch)
+			celtPitchXcorr(x, y, got, tc.length, tc.maxPitch)
+
+			want := make([]float32, tc.maxPitch)
+			for i := range tc.maxPitch {
+				var sum float64
+				for j := range tc.length {
+					sum += float64(x[j]) * float64(y[i+j])
+				}
+				want[i] = float32(sum)
+			}
+
+			assert.Equal(t, want, got, "bit-identical vs scalar reference")
+		})
+	}
+}
+
+func BenchmarkCeltPitchXcorr(b *testing.B) {
+	const length, maxPitch = 240, 244
+	x := make([]float32, length)
+	y := make([]float32, length+maxPitch)
+	xcorr := make([]float32, maxPitch)
+	for i := range y {
+		y[i] = float32(i%17) / 17
+	}
+	for i := range x {
+		x[i] = float32(i%13) / 13
+	}
+	b.ResetTimer()
+	for range b.N {
+		celtPitchXcorr(x, y, xcorr, length, maxPitch)
+	}
 }


### PR DESCRIPTION
#### Description

I changed `celtPitchXcorr` to process eight lags per pass, keeping one `float64` accumulator per lag. The summation order for each lag stays unchanged, so the output remains bit-identical while the independent accumulators remove the serial dependency in the old loop.

I also added a scalar-reference test covering the encoder dimensions, the tail path, and edge cases. The local benchmark is about 35.3 us/op with zero allocations.

#### Reference issue
Part of the CELT encoder work tracked in #34.