### PR TITLE
Compute the CELT L1 metric without branching

### DIFF
--- a/internal/celt/tf_analysis.go
+++ b/internal/celt/tf_analysis.go
@@ -3,15 +3,17 @@
 
 package celt
 
+import "math"
+
 // l1Metric is libopus's l1_metric: the L1 norm of a band, biased so that a
 // coarser time resolution has to win by a margin before it is chosen.
 func l1Metric(x []float32, lm int, bias float32) float32 {
 	var l1 float32
 	for _, v := range x {
-		if v < 0 {
-			v = -v
-		}
-		l1 += v
+		// math.Abs instead of branching on the sign: the signs of MDCT
+		// coefficients are unpredictable, so the branch mispredicts about half
+		// the time and costs more than the whole rest of the loop.
+		l1 += float32(math.Abs(float64(v)))
 	}
 
 	return l1 + float32(lm)*bias*l1


### PR DESCRIPTION
#### Description

`l1Metric` runs once per band per frame from `tfAnalysis`, and its `abs` is a real conditional jump — `UCOMISS` then `JLS` in the generated code. The signs of MDCT coefficients are unpredictable, so that branch mispredicts about half the time and ends up costing more than the multiply-accumulate it guards.

`math.Abs` is an intrinsic on amd64 and compiles to a sign-bit clear, no branch. The value is identical: a float32 widened to float64, negated-or-not, and narrowed back is exact.

**6% faster end-to-end** on a 30 s music clip at 96 kbps stereo, and the bitstream does not change — I hashed every packet across mono/stereo, 24 and 96 kbps, CBR and VBR, and all eight digests match master.

#### Why this was easy to miss

A micro-benchmark says this change is worth nothing. Calling `l1Metric` in a loop over the same buffer lets the branch predictor memorise the sign pattern, and then the branch is free:

| | same buffer | fresh buffer each call |
|---|---|---|
| branch | 1072 ns | 3673 ns |
| branchless | 953 ns | 962 ns |

1.12x against 3.8x. Real audio is the second column — the signs change every frame. Worth knowing for anything else on this path.

I also tried the explicit bit twiddle (`math.Float32frombits(math.Float32bits(v) &^ (1 << 31))`). It measured a hair slower than `math.Abs` and reads much worse, so it is not in this patch.

#### Reference issue
Part of the CELT encoder performance work; no separate issue.