### PR TITLE
Remove replace directive from playback example

### DIFF
--- a/examples/playback/go.mod
+++ b/examples/playback/go.mod
@@ -15,5 +15,3 @@ require (
 	golang.org/x/mobile v0.0.0-20190415191353-3e0bab5405d6 // indirect
 	golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756 // indirect
 )
-
-replace github.com/pion/opus => ./../..

--- a/examples/playback/go.sum
+++ b/examples/playback/go.sum
@@ -21,6 +21,8 @@ github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mewkiz/flac v1.0.7/go.mod h1:yU74UH277dBUpqxPouHSQIar3G1X/QIclVbFahSd1pU=
 github.com/mewkiz/pkg v0.0.0-20190919212034-518ade7978e2/go.mod h1:3E2FUC/qYUfM8+r9zAwpeHJzqRVVMIYnpzD/clwWxyA=
+github.com/pion/opus v0.1.0 h1:GgK/a3DNDrffKjUFsK39rZKqfv7bQ2S2eqRKt0BnqAE=
+github.com/pion/opus v0.1.0/go.mod h1:t5Xog2n682JnawoykACE6nKVmupFvmJvkpM7x6bTv6g=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
#### Description

`examples/playback/go.mod` contained `replace github.com/pion/opus => ./../..`, so the install command documented in `examples/playback/README.md` fails:

```
go: github.com/pion/opus/examples/playback@latest: The go.mod file for the
module providing named packages contains one or more replace directives.
It must not contain directives that would cause it to be interpreted
differently than if it were the main module.
```

This removes the directive so the example resolves the published `github.com/pion/opus` module, which is what the sibling `examples/decode-webm` module already does. The two added `go.sum` lines are required because the module hashes were never recorded while the dependency was replaced by a local path.

Verified inside `examples/playback` with `go mod tidy`, `go build ./...` and `go vet ./...` (all clean). The shared `Go mod tidy` workflow only checks the root module, so it is unaffected by this change.

#### Reference issue
Fixes #45
