### PR TITLE
Remove branches from CELT magnitude metrics

### DIFF
--- a/internal/celt/cwrs.go
+++ b/internal/celt/cwrs.go
@@ -4,7 +4,11 @@
 //nolint:varnamelen // CWRS notation follows RFC/reference vector names.
 package celt
 
-import "github.com/pion/opus/internal/rangecoding"
+import (
+	"math/bits"
+
+	"github.com/pion/opus/internal/rangecoding"
+)
 
 // The static CELT pulse cache tops out at getPulses(40) == 128.
 const cwrsMaxPulseCount = 128
@@ -325,9 +329,8 @@ func cwrsEncode(y []int, n, k int, scratch []uint32) uint32 {
 
 	for j := range n {
 		magnitude := y[j]
-		if magnitude < 0 {
-			magnitude = -magnitude
-		}
+		sign := magnitude >> (bits.UintSize - 1)
+		magnitude = (magnitude ^ sign) - sign
 		if magnitude > k {
 			return 0
 		}

--- a/internal/celt/pitch.go
+++ b/internal/celt/pitch.go
@@ -4,6 +4,8 @@
 //nolint:gosec // G602: slice indices are bounded by combFilterMinPeriod/MaxPeriod and len(pcm).
 package celt
 
+import "math"
+
 // removeDoubling checks whether the detected pitch period T0 is actually
 // an octave of the true fundamental. For each sub-multiple k in {2..15},
 // it evaluates T1 = (2*T0 + offset) / (2*k) and switches if the normalized
@@ -147,11 +149,7 @@ func measureEnergy(buf []float32, start, n int) float64 {
 	var sum float64
 	end := min(start+n, len(buf))
 	for i := start; i < end; i++ {
-		value := buf[i]
-		if value < 0 {
-			value = -value
-		}
-		sum += float64(value)
+		sum += math.Abs(float64(buf[i]))
 	}
 
 	return sum

--- a/internal/celt/pitch_test.go
+++ b/internal/celt/pitch_test.go
@@ -430,3 +430,31 @@ func BenchmarkCeltPitchXcorr(b *testing.B) {
 		celtPitchXcorr(x, y, xcorr, length, maxPitch)
 	}
 }
+
+func TestMeasureEnergyMatchesBranchingReference(t *testing.T) {
+	samples := []float32{-3.5, -1, -0.25, 0, 0.125, 1, 4.5}
+	cases := []struct {
+		name          string
+		start, length int
+	}{
+		{name: "full", start: 0, length: len(samples)},
+		{name: "range", start: 2, length: 3},
+		{name: "clamps end", start: 4, length: 100},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var want float64
+			end := min(tc.start+tc.length, len(samples))
+			for i := tc.start; i < end; i++ {
+				value := samples[i]
+				if value < 0 {
+					value = -value
+				}
+				want += float64(value)
+			}
+
+			assert.Equal(t, want, measureEnergy(samples, tc.start, tc.length))
+		})
+	}
+}


### PR DESCRIPTION
#### Description
I removed the absolute-value branches from `measureEnergy` and `cwrsEncode`. `measureEnergy` now uses the `math.Abs` intrinsic, while CWRS uses a sign mask sized with `bits.UintSize` so it works on both 32-bit and 64-bit builds.

The output stays bit-identical. I compared packet hashes against main over 30 seconds in mono/stereo, 24/96 kbps, and CBR/VBR; all eight match. On a varying 96 kbps stereo input, the median encode time went from 322117 to 315582 ns/op.

#### Reference issue
Part of the CELT encoder performance work; no separate issue.