### PR TITLE
Optimize CELT pitch and spread metrics

### DIFF
--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -512,25 +512,27 @@ func computeBandLogAmp(freq []float32, lm int, startBand int, endBand int) [maxB
 // means flat (noisy) and a long tail below the thresholds means tonal.
 func bandSpreadMetric(x []float32, band int) (score, hf int) {
 	n := len(x)
-	var tcount [3]int
+	var tcount0, tcount1, tcount2 int
 	for _, v := range x {
 		x2n := v * v * float32(n)
 		if x2n < 0.25 {
-			tcount[0]++
+			tcount0++
 		}
 		if x2n < 0.0625 {
-			tcount[1]++
+			tcount1++
 		}
 		if x2n < 0.015625 {
-			tcount[2]++
+			tcount2++
 		}
 	}
 
 	// Only the last four bands (8 kHz and up) feed the tapset.
 	if band > maxBands-4 {
-		hf = 32 * (tcount[1] + tcount[0]) / n
+		hf = 32 * (tcount1 + tcount0) / n
 	}
-	score = boolIndex(2*tcount[2] >= n) + boolIndex(2*tcount[1] >= n) + boolIndex(2*tcount[0] >= n)
+	score = boolIndex(2*tcount2 >= n) +
+		boolIndex(2*tcount1 >= n) +
+		boolIndex(2*tcount0 >= n)
 
 	return score, hf
 }

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -624,3 +624,15 @@ func uniformSpreadWeight() [maxBands]int {
 
 	return w
 }
+
+func TestBandSpreadMetricThresholds(t *testing.T) {
+	samples := []float32{0, 0.05, 0.1, 0.2}
+
+	score, hf := bandSpreadMetric(samples, maxBands-1)
+	assert.Equal(t, 3, score)
+	assert.Equal(t, 56, hf)
+
+	score, hf = bandSpreadMetric(samples, maxBands-4)
+	assert.Equal(t, 3, score)
+	assert.Zero(t, hf)
+}

--- a/internal/celt/pitch_search.go
+++ b/internal/celt/pitch_search.go
@@ -268,11 +268,15 @@ func innerProdLag(x []float32, base, n, lag int) float32 {
 }
 
 func dualInnerProdLag(x []float32, base, n, lagA, lagB int) (a, b float32) {
+	current := x[base : base+n]
+	lagASamples := x[base-lagA : base-lagA+n]
+	lagBSamples := x[base-lagB : base-lagB+n]
+
 	var sa, sb float64
-	for j := range n {
-		v := float64(x[base+j])
-		sa += v * float64(x[base+j-lagA])
-		sb += v * float64(x[base+j-lagB])
+	for i, sample := range current {
+		value := float64(sample)
+		sa += value * float64(lagASamples[i])
+		sb += value * float64(lagBSamples[i])
 	}
 
 	return float32(sa), float32(sb)

--- a/internal/celt/pitch_test.go
+++ b/internal/celt/pitch_test.go
@@ -458,3 +458,39 @@ func TestMeasureEnergyMatchesBranchingReference(t *testing.T) {
 		})
 	}
 }
+
+func TestDualInnerProdLagMatchesScalarReference(t *testing.T) {
+	samples := make([]float32, 24)
+	for i := range samples {
+		samples[i] = float32(i%7-3) / 3
+	}
+
+	cases := []struct {
+		name                     string
+		base, length, lagA, lagB int
+	}{
+		{name: "near samples", base: 5, length: 8, lagA: 1, lagB: 3},
+		{name: "distant samples", base: 10, length: 10, lagA: 2, lagB: 7},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var wantA, wantB float64
+			for i := range tc.length {
+				value := float64(samples[tc.base+i])
+				wantA += value * float64(samples[tc.base+i-tc.lagA])
+				wantB += value * float64(samples[tc.base+i-tc.lagB])
+			}
+
+			gotA, gotB := dualInnerProdLag(
+				samples,
+				tc.base,
+				tc.length,
+				tc.lagA,
+				tc.lagB,
+			)
+			assert.Equal(t, float32(wantA), gotA)
+			assert.Equal(t, float32(wantB), gotB)
+		})
+	}
+}


### PR DESCRIPTION
#### Description
I removed repeated composite-index bounds checks from `dualInnerProdLag` by slicing the three input windows before the loop. I also keep the three `bandSpreadMetric` counters in local variables instead of an indexed array.

Both changes are bit-identical. I compared packet hashes against main over 30 seconds in mono/stereo, 24/96 kbps, and CBR/VBR; all eight match. On a varying 96 kbps stereo input, the median encode time went from 313167 to 305901 ns/op.

#### Reference issue
Part of the CELT encoder performance work; no separate issue.