### PR TITLE
Keep PVQ pulse energy in float32

### DIFF
--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -104,7 +104,7 @@ func quantAllBandsMono(
 	totalBits int,
 	state *bandEncodeState,
 	yScratch []int,
-	absXScratch, signScratch []float32,
+	yFloatScratch, absXScratch, signScratch []float32,
 	cwrsScratch []uint32,
 ) []byte {
 	blocks := 1
@@ -197,7 +197,7 @@ func quantAllBandsMono(
 			lowbandScratch,
 			fill,
 			state,
-			yScratch, absXScratch, signScratch, cwrsScratch,
+			yScratch, yFloatScratch, absXScratch, signScratch, cwrsScratch,
 		)
 		collapseMasks[band] = byte(mask)
 		balance += info.allocation.pulses[band] + tell
@@ -225,7 +225,7 @@ func quantBandMono(
 	fill uint,
 	state *bandEncodeState,
 	yScratch []int,
-	absXScratch, signScratch []float32,
+	yFloatScratch, absXScratch, signScratch []float32,
 	cwrsScratch []uint32,
 ) uint {
 	fullBand := x
@@ -380,7 +380,7 @@ func quantBandMono(
 				lowbandScratch,
 				fill,
 				state,
-				yScratch, absXScratch, signScratch, cwrsScratch,
+				yScratch, yFloatScratch, absXScratch, signScratch, cwrsScratch,
 			)
 			rebalance = midBits - (rebalance - *remainingBits)
 			if rebalance > 3<<bitResolution && itheta != 0 {
@@ -403,7 +403,7 @@ func quantBandMono(
 				lowbandScratch,
 				fill>>blocks,
 				state,
-				yScratch, absXScratch, signScratch, cwrsScratch,
+				yScratch, yFloatScratch, absXScratch, signScratch, cwrsScratch,
 			) << collapseShift
 		} else {
 			collapseMask = quantBandMono(
@@ -423,7 +423,7 @@ func quantBandMono(
 				lowbandScratch,
 				fill>>blocks,
 				state,
-				yScratch, absXScratch, signScratch, cwrsScratch,
+				yScratch, yFloatScratch, absXScratch, signScratch, cwrsScratch,
 			) << collapseShift
 			rebalance = sideBits - (rebalance - *remainingBits)
 			if rebalance > 3<<bitResolution && itheta != 16384 {
@@ -446,7 +446,7 @@ func quantBandMono(
 				lowbandScratch,
 				fill,
 				state,
-				yScratch, absXScratch, signScratch, cwrsScratch,
+				yScratch, yFloatScratch, absXScratch, signScratch, cwrsScratch,
 			)
 		}
 	} else {
@@ -460,7 +460,7 @@ func quantBandMono(
 			*remainingBits -= currentBits
 		}
 		if q != 0 {
-			collapseMask = algQuant(x, n, getPulses(q), spread, blocks, state.rangeEncoder, gain, yScratch, absXScratch, signScratch, cwrsScratch)
+			collapseMask = algQuant(x, n, getPulses(q), spread, blocks, state.rangeEncoder, gain, yScratch, yFloatScratch, absXScratch, signScratch, cwrsScratch)
 		} else {
 			mask := uint(1<<blocks) - 1
 			fill &= mask
@@ -583,7 +583,7 @@ func quantBandStereo(
 	fill uint,
 	state *bandEncodeState,
 	yScratch [2][]int,
-	absXScratch, signScratch [2][]float32,
+	yFloatScratch, absXScratch, signScratch [2][]float32,
 	cwrsScratch []uint32,
 	thetaRound int,
 ) uint {
@@ -698,7 +698,7 @@ func quantBandStereo(
 		collapseMask := quantBandMono(
 			band, x, n, midBits, spread, blocks, tfChange,
 			lowband, remainingBits, lm, nil, 0, 1, lowbandScratch, fill, state,
-			yScratch[0], absXScratch[0], signScratch[0], cwrsScratch,
+			yScratch[0], yFloatScratch[0], absXScratch[0], signScratch[0], cwrsScratch,
 		)
 		rebalance = midBits - (rebalance - *remainingBits)
 		if rebalance > 3<<bitResolution && itheta != 0 {
@@ -707,7 +707,7 @@ func quantBandStereo(
 		collapseMask |= quantBandMono(
 			band, y, n, sideBits, spread, blocks, tfChange,
 			nil, remainingBits, lm, nil, 0, gain*side, nil, fill>>blocks, state,
-			yScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
+			yScratch[1], yFloatScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
 		)
 		if n != 2 {
 			stereoMerge(x, y, mid, n)
@@ -724,7 +724,7 @@ func quantBandStereo(
 	collapseMask := quantBandMono(
 		band, y, n, sideBits, spread, blocks, tfChange,
 		nil, remainingBits, lm, nil, 0, gain*side, nil, fill>>blocks, state,
-		yScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
+		yScratch[1], yFloatScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
 	)
 	rebalance = sideBits - (rebalance - *remainingBits)
 	if rebalance > 3<<bitResolution && itheta != 16384 {
@@ -733,7 +733,7 @@ func quantBandStereo(
 	collapseMask |= quantBandMono(
 		band, x, n, midBits, spread, blocks, tfChange,
 		lowband, remainingBits, lm, nil, 0, 1, lowbandScratch, fill, state,
-		yScratch[0], absXScratch[0], signScratch[0], cwrsScratch,
+		yScratch[0], yFloatScratch[0], absXScratch[0], signScratch[0], cwrsScratch,
 	)
 	if n != 2 {
 		stereoMerge(x, y, mid, n)
@@ -848,7 +848,7 @@ func quantAllBandsStereo(
 	totalBits int,
 	state *bandEncodeState,
 	yScratch [2][]int,
-	absXScratch, signScratch [2][]float32,
+	yFloatScratch, absXScratch, signScratch [2][]float32,
 	cwrsScratch []uint32,
 ) []byte {
 	channelCount := 2
@@ -954,7 +954,7 @@ func quantAllBandsStereo(
 				lowbandScratch,
 				xMask,
 				state,
-				yScratch[0], absXScratch[0], signScratch[0], cwrsScratch,
+				yScratch[0], yFloatScratch[0], absXScratch[0], signScratch[0], cwrsScratch,
 			)
 			var lowbandY []float32
 			if effectiveLowband >= 0 {
@@ -977,7 +977,7 @@ func quantAllBandsStereo(
 				lowbandScratch,
 				yMask,
 				state,
-				yScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
+				yScratch[1], yFloatScratch[1], absXScratch[1], signScratch[1], cwrsScratch,
 			)
 		} else {
 			bx := x[bandStart:bandEnd]
@@ -987,7 +987,7 @@ func quantAllBandsStereo(
 					band, bx, by, bandWidth, bandBits, info.spread, blocks,
 					info.allocation.intensity, info.tfChange[band], lowband,
 					&remainingBits, info.lm, 1, lowbandScratch, mask, state,
-					yScratch, absXScratch, signScratch, cwrsScratch, round,
+					yScratch, yFloatScratch, absXScratch, signScratch, cwrsScratch, round,
 				)
 			}
 			if state.thetaRDO && band < info.allocation.intensity {

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -43,6 +43,7 @@ type Encoder struct {
 	pvqY              [2][]int
 	pvqAbsX           [2][]float32
 	pvqSign           [2][]float32
+	pvqYFloat         [2][]float32
 	cwrsScratch       []uint32
 	normalizedBands   [2][]float32
 	pitchBuf          []float32
@@ -135,6 +136,7 @@ func (e *Encoder) Reset() {
 	e.bandCollapseMasks = make([]byte, 0, 2*maxBands)
 	for ch := range 2 {
 		e.pvqY[ch] = make([]int, 0, maxBandSize<<maxLM)
+		e.pvqYFloat[ch] = make([]float32, 0, maxBandSize<<maxLM)
 		e.pvqAbsX[ch] = make([]float32, 0, maxBandSize<<maxLM)
 		e.pvqSign[ch] = make([]float32, 0, maxBandSize<<maxLM)
 		e.normalizedBands[ch] = make([]float32, 0, maxFrameSampleCount)
@@ -971,11 +973,15 @@ func (e *Encoder) EncodeFrame(pcm [][]float32, dst []byte, frameBytes, startBand
 	shape0 := normalized[0]
 	if info.channelCount == 2 {
 		shape1 := normalized[1]
-		_ = quantAllBandsStereo(&info, shape0, shape1, totalBits, &bandState,
-			e.pvqY, e.pvqAbsX, e.pvqSign, e.cwrsScratch)
+		_ = quantAllBandsStereo(
+			&info, shape0, shape1, totalBits, &bandState,
+			e.pvqY, e.pvqYFloat, e.pvqAbsX, e.pvqSign, e.cwrsScratch,
+		)
 	} else {
-		_ = quantAllBandsMono(&info, shape0, totalBits, &bandState,
-			e.pvqY[0], e.pvqAbsX[0], e.pvqSign[0], e.cwrsScratch)
+		_ = quantAllBandsMono(
+			&info, shape0, totalBits, &bandState,
+			e.pvqY[0], e.pvqYFloat[0], e.pvqAbsX[0], e.pvqSign[0], e.cwrsScratch,
+		)
 	}
 
 	if info.antiCollapseRsv > 0 {

--- a/internal/celt/encoder_test.go
+++ b/internal/celt/encoder_test.go
@@ -219,6 +219,7 @@ func TestQuantBandStereoN1(t *testing.T) {
 		[2][]int{make([]int, 1), make([]int, 1)},
 		[2][]float32{make([]float32, 1), make([]float32, 1)},
 		[2][]float32{make([]float32, 1), make([]float32, 1)},
+		[2][]float32{make([]float32, 1), make([]float32, 1)},
 		make([]uint32, cwrsMaxPulseCount+2),
 		0,
 	)
@@ -239,6 +240,7 @@ func TestQuantBandStereoN2(t *testing.T) {
 		spreadNormal, 1, maxBands, 0, nil,
 		&remaining, 3, 1.0, make([]float32, 4), 1, &state,
 		[2][]int{make([]int, 2), make([]int, 2)},
+		[2][]float32{make([]float32, 2), make([]float32, 2)},
 		[2][]float32{make([]float32, 2), make([]float32, 2)},
 		[2][]float32{make([]float32, 2), make([]float32, 2)},
 		make([]uint32, cwrsMaxPulseCount+2),

--- a/internal/celt/hadamard_regression_test.go
+++ b/internal/celt/hadamard_regression_test.go
@@ -91,7 +91,7 @@ func quantBandMonoCorrelation(t *testing.T, band, n, bandBits, blocks, tfChange 
 		quantBandMono(
 			band, shape, n, bandBits, spreadNormal, blocks, tfChange,
 			lowband, &remainingBits, maxLM, nil, 0, 1, make([]float32, n), (1<<blocks)-1, &state,
-			make([]int, n+3), make([]float32, n+3), make([]float32, n+3),
+			make([]int, n+3), make([]float32, n+3), make([]float32, n+3), make([]float32, n+3),
 			make([]uint32, cwrsMaxPulseCount+2),
 		)
 

--- a/internal/celt/pvq.go
+++ b/internal/celt/pvq.go
@@ -155,13 +155,20 @@ func expRotation(x []float32, length int, direction int, stride int, pulses int,
 // pvqSearch finds the nearest PVQ lattice point to x with k pulses and writes
 // it into yScratch[:n]. I clear y before the greedy loop because the scratch
 // slice is reused across frames and stale values from a wider band would
-// corrupt the pulse counts. All three scratch slices must have cap >= n.
-func pvqSearch(x []float32, n, k int, yScratch []int, absXScratch, signScratch []float32) []int {
+// corrupt the pulse counts. All scratch slices must have cap >= n.
+func pvqSearch(
+	x []float32,
+	n, k int,
+	yScratch []int,
+	yFloatScratch, absXScratch, signScratch []float32,
+) []int {
 	y := yScratch[:n:n]
+	yf := yFloatScratch[:n:n]
 	absX := absXScratch[:n:n]
 	sign := signScratch[:n:n]
 	clear(y)
 	for i := range n {
+		yf[i] = 1
 		if x[i] >= 0 {
 			absX[i] = x[i]
 			sign[i] = 1
@@ -177,16 +184,17 @@ func pvqSearch(x []float32, n, k int, yScratch []int, absXScratch, signScratch [
 		bestIdx := 0
 		for i := range n {
 			newDot := dot + absX[i]
-			newEner := ener + float32(2*y[i]+1)
+			newEner := ener + yf[i]
 			score := (newDot * newDot) / newEner
 			if score > bestScore {
 				bestScore = score
 				bestIdx = i
 			}
 		}
-		y[bestIdx]++
 		dot += absX[bestIdx]
-		ener += float32(2*y[bestIdx] - 1)
+		ener += yf[bestIdx]
+		yf[bestIdx] += 2
+		y[bestIdx]++
 	}
 
 	for i := range n {
@@ -208,12 +216,12 @@ func algQuant(
 	rangeEncoder *rangecoding.Encoder,
 	gain float32,
 	yScratch []int,
-	absXScratch, signScratch []float32,
+	yFloatScratch, absXScratch, signScratch []float32,
 	cwrsScratch []uint32,
 ) uint {
 	expRotation(x, n, 1, blocks, k, spread)
 
-	iy := pvqSearch(x, n, k, yScratch, absXScratch, signScratch)
+	iy := pvqSearch(x, n, k, yScratch, yFloatScratch, absXScratch, signScratch)
 	encodePulses(iy, n, k, rangeEncoder, cwrsScratch)
 
 	energy := 0

--- a/internal/celt/pvq_test.go
+++ b/internal/celt/pvq_test.go
@@ -56,9 +56,10 @@ func TestPVQSearchBasic(t *testing.T) {
 	// Target with energy in first few dimensions
 	x := []float32{3, 2, 1, 0}
 	yScratch := make([]int, len(x))
+	yFloat := make([]float32, len(x))
 	absX := make([]float32, len(x))
 	sign := make([]float32, len(x))
-	iy := pvqSearch(x, len(x), 3, yScratch, absX, sign)
+	iy := pvqSearch(x, len(x), 3, yScratch, yFloat, absX, sign)
 
 	pulses := 0
 	for _, v := range iy {
@@ -78,9 +79,10 @@ func TestPVQSearchBasic(t *testing.T) {
 func TestPVQSearchZeroPulses(t *testing.T) {
 	x := []float32{1, 2, 3}
 	yScratch := make([]int, len(x))
+	yFloat := make([]float32, len(x))
 	absX := make([]float32, len(x))
 	sign := make([]float32, len(x))
-	iy := pvqSearch(x, len(x), 0, yScratch, absX, sign)
+	iy := pvqSearch(x, len(x), 0, yScratch, yFloat, absX, sign)
 	for _, v := range iy {
 		assert.Equal(t, 0, v)
 	}
@@ -101,10 +103,11 @@ func TestAlgQuantRoundTrip(t *testing.T) {
 	xEnc := make([]float32, n)
 	copy(xEnc, original)
 	yScratch := make([]int, n)
+	yFloat := make([]float32, n)
 	absX := make([]float32, n)
 	sign := make([]float32, n)
 	cwrsScratch := make([]uint32, cwrsMaxPulseCount+2)
-	mask := algQuant(xEnc, n, pulseCount, spread, 1, &enc, gain, yScratch, absX, sign, cwrsScratch)
+	mask := algQuant(xEnc, n, pulseCount, spread, 1, &enc, gain, yScratch, yFloat, absX, sign, cwrsScratch)
 	assert.NotZero(t, mask)
 
 	bits := enc.Done()
@@ -135,6 +138,41 @@ func TestStereoMerge(t *testing.T) {
 	assert.InDelta(t, 1, vectorEnergy(y), 0.000001)
 }
 
+func TestPVQSearchMatchesScalarReference(t *testing.T) {
+	wide := make([]float32, 48)
+	for i := range wide {
+		wide[i] = float32(i%9-4) / 4
+	}
+
+	cases := []struct {
+		name       string
+		input      []float32
+		pulseCount int
+	}{
+		{name: "zero pulses", input: []float32{1, -2, 3}, pulseCount: 0},
+		{name: "mixed signs", input: []float32{3, -2, 1, -0.5}, pulseCount: 5},
+		{name: "repeated pulse", input: []float32{8, 1, -0.5, 0.25}, pulseCount: 12},
+		{name: "wide band", input: wide, pulseCount: 48},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := len(tc.input)
+			got := pvqSearch(
+				tc.input,
+				n,
+				tc.pulseCount,
+				make([]int, n),
+				make([]float32, n),
+				make([]float32, n),
+				make([]float32, n),
+			)
+			want := pvqSearchScalarReference(tc.input, n, tc.pulseCount)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
 func vectorEnergy(x []float32) float64 {
 	energy := float64(0)
 	for _, value := range x {
@@ -142,4 +180,44 @@ func vectorEnergy(x []float32) float64 {
 	}
 
 	return energy
+}
+
+func pvqSearchScalarReference(input []float32, n, pulseCount int) []int {
+	vector := make([]int, n)
+	absX := make([]float32, n)
+	sign := make([]float32, n)
+	for i := range n {
+		if input[i] >= 0 {
+			absX[i] = input[i]
+			sign[i] = 1
+		} else {
+			absX[i] = -input[i]
+			sign[i] = -1
+		}
+	}
+
+	var dot, ener float32
+	for range pulseCount {
+		bestScore := float32(-1)
+		bestIdx := 0
+		for i := range n {
+			newDot := dot + absX[i]
+			newEner := ener + float32(2*vector[i]+1)
+			score := (newDot * newDot) / newEner
+			if score > bestScore {
+				bestScore = score
+				bestIdx = i
+			}
+		}
+		vector[bestIdx]++
+		dot += absX[bestIdx]
+		ener += float32(2*vector[bestIdx] - 1)
+	}
+	for i := range n {
+		if sign[i] < 0 {
+			vector[i] = -vector[i]
+		}
+	}
+
+	return vector
 }


### PR DESCRIPTION
#### Description
I keep `2*y[i]+1` in a float32 scratch buffer during PVQ search instead of converting the pulse count for every candidate. The scratch is initialized alongside `absX` and the sign vector, then only the selected position changes after each pulse.

The output stays bit-identical. The PVQ test compares against the old scalar search, and packet hashes match main over 30 seconds in mono/stereo, 24/96 kbps, and CBR/VBR. On a varying 96 kbps stereo input, the median encode time went from 307473 to 303920 ns/op.

#### Reference issue
Part of the CELT encoder performance work; no separate issue.