### PR TITLE
Use math.Exp2 in CELT encoder

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -1034,7 +1034,7 @@ func dynallocAnalysis(
 	}
 	for band := startBand; band < endBand; band++ {
 		importance[band] = int(math.Floor(0.5 +
-			13*math.Pow(2, float64(minFloat32(combined[band], 4)))))
+			13*math.Exp2(float64(minFloat32(combined[band], 4)))))
 	}
 
 	// CBR and constrained VBR halve the dynalloc contribution on a steady

--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -83,7 +83,7 @@ func normaliseBandsForEncoding(
 	for band := info.startBand; band < info.endBand; band++ {
 		start := scale * int(bandEdges[band])
 		end := scale * int(bandEdges[band+1])
-		amp := float32(math.Exp2(float64(logBandAmp[band]+energyMeans[band])))
+		amp := float32(math.Exp2(float64(logBandAmp[band] + energyMeans[band])))
 		if amp <= 1e-15 {
 			continue
 		}

--- a/internal/celt/encode_bands.go
+++ b/internal/celt/encode_bands.go
@@ -83,7 +83,7 @@ func normaliseBandsForEncoding(
 	for band := info.startBand; band < info.endBand; band++ {
 		start := scale * int(bandEdges[band])
 		end := scale * int(bandEdges[band+1])
-		amp := float32(math.Pow(2, float64(logBandAmp[band]+energyMeans[band])))
+		amp := float32(math.Exp2(float64(logBandAmp[band]+energyMeans[band])))
 		if amp <= 1e-15 {
 			continue
 		}

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -827,7 +827,7 @@ func (e *Encoder) newBandState(
 	for ch := range info.channelCount {
 		for band := info.startBand; band < info.endBand; band++ {
 			state.bandEnergy[ch][band] = float32(math.Exp2(
-				float64(logBandAmp[ch][band]+energyMeans[band])))
+				float64(logBandAmp[ch][band] + energyMeans[band])))
 		}
 	}
 

--- a/internal/celt/encoder.go
+++ b/internal/celt/encoder.go
@@ -826,7 +826,7 @@ func (e *Encoder) newBandState(
 	}
 	for ch := range info.channelCount {
 		for band := info.startBand; band < info.endBand; band++ {
-			state.bandEnergy[ch][band] = float32(math.Pow(2,
+			state.bandEnergy[ch][band] = float32(math.Exp2(
 				float64(logBandAmp[ch][band]+energyMeans[band])))
 		}
 	}


### PR DESCRIPTION
#### Description
Replace `math.Pow(2, x)` with `math.Exp2(x)` at three CELT encoder call sites. The output is bit-identical to `main` for 30 seconds of deterministic PCM across mono/stereo, 24/96 kbps, and CBR/VBR configurations. Validated with: `go test ./...`  `GOARCH=386` `go test ./...` `golangci-lint run`

#### Reference issue
