### PR TITLE
Pack SILK PredCoef_Q12 at the prediction order

### DIFF
--- a/internal/silk/enc_frame.go
+++ b/internal/silk/enc_frame.go
@@ -215,9 +215,14 @@ func (e *Encoder) encodeSILKFrame(
 		interpolateNLSF(nlsf0, e.prevNLSFq, quantNLSF, nlsfInterpQ2, order)
 		predCoefQ12Half0 = nlsfToLPCQ12(nlsf0, bandwidth) // interpolated first half
 	}
-	predCoef2 := make([]int16, 2*maxLPCOrder)
+	// Pack the two halves at the prediction order, the stride the noise
+	// shaping quantizer indexes them with. This matches libopus, where the
+	// state is PredCoef_Q12[2][MAX_LPC_ORDER] (structs.h) with MAX_LPC_ORDER
+	// 16 (define.h); maxLPCOrder (24) is the analysis order and is not the
+	// layout of this array.
+	predCoef2 := make([]int16, 2*maxPredictLPCOrder)
 	copy(predCoef2, predCoefQ12Half0)
-	copy(predCoef2[maxLPCOrder:], predCoefQ12)
+	copy(predCoef2[maxPredictLPCOrder:], predCoefQ12)
 	copy(e.prevNLSFq, quantNLSF)
 
 	// Residual energy per subframe from the quantized LPC (gain soft-limit).

--- a/silk_encode_test.go
+++ b/silk_encode_test.go
@@ -15,6 +15,17 @@ const (
 	duration20Ms = "20ms"
 	duration40Ms = "40ms"
 	duration60Ms = "60ms"
+
+	// Guards for TestEncodeSILKTracksTargetRate. The ratio and the SNR floor
+	// are deliberately loose: they are there to catch a quantizer that has
+	// stopped predicting, not to pin encoder quality, which
+	// TestEncoderQuality tracks against a baseline.
+	silkRateTestBitrate     = 24000
+	silkRateTestComplexity  = 5
+	silkRateTestSeconds     = 1
+	silkRateTestMaxOverrun  = 2.0  // emitted rate, as a multiple of the target
+	silkRateTestPeakCeiling = 0.99 // decoded peak, 1.0 being full scale
+	silkRateTestMinSNRDB    = 6.0
 )
 
 // TestEncodeSILKRoundTrip encodes a SILK frame with the public encoder and
@@ -335,4 +346,100 @@ func TestSILKDCBlockMultiFrameState(t *testing.T) {
 	splitOut := append(append([]int16(nil), out1...), out2...)
 
 	assert.Equal(t, fullOut, splitOut)
+}
+
+// silkRateMeasurement is what runSILKRateProbe reports for one bandwidth.
+type silkRateMeasurement struct {
+	bitrate float64 // emitted bits per second
+	peak    float64 // largest absolute decoded sample, 1.0 being full scale
+	snrDB   float64 // round-trip signal to noise ratio
+}
+
+// silkSpeechLike generates count samples of voiced-speech-like audio at the
+// given rate: a 180 Hz five-harmonic series under a slow amplitude envelope,
+// so the LPC analysis, the pitch predictor and the gain control all have
+// something to work with.
+func silkSpeechLike(count, sampleRate int) []int16 {
+	pcm := make([]int16, count)
+	for i := range pcm {
+		sec := float64(i) / float64(sampleRate)
+		var sum float64
+		for harmonic := 1; harmonic <= 5; harmonic++ {
+			sum += math.Sin(2*math.Pi*180*float64(harmonic)*sec) / float64(harmonic)
+		}
+		env := 0.6 + 0.4*math.Sin(2*math.Pi*3*sec)
+		pcm[i] = int16(env * 9000 * sum / harmonicsPeakAmplitude)
+	}
+
+	return pcm
+}
+
+// runSILKRateProbe encodes silkRateTestSeconds of speech-like audio one 20 ms
+// coding unit at a time and decodes it with a single stateful decoder,
+// reporting the emitted bitrate, the decoded peak, and the round-trip SNR.
+func runSILKRateProbe(t *testing.T, bandwidth Bandwidth, bitrate int) silkRateMeasurement {
+	t.Helper()
+
+	encoder, err := NewEncoder(WithBitrate(bitrate), WithComplexity(silkRateTestComplexity))
+	require.NoErrorf(t, err, "bandwidth %d", bandwidth)
+
+	decoder, err := NewDecoderWithOutput(bandwidth.SampleRate(), 1)
+	require.NoErrorf(t, err, "bandwidth %d", bandwidth)
+
+	sampleRate := bandwidth.SampleRate()
+	unit := sampleRate / 50 // one 20 ms coding unit
+	pcm := silkSpeechLike(sampleRate*silkRateTestSeconds, sampleRate)
+
+	packet := make([]byte, maxOpusFrameSize)
+	decoded := make([]float32, 0, len(pcm))
+	payloadBytes := 0
+	for offset := 0; offset+unit <= len(pcm); offset += unit {
+		size, encErr := encoder.EncodeSILK(pcm[offset:offset+unit], bandwidth, packet)
+		require.NoErrorf(t, encErr, "bandwidth %d, sample %d", bandwidth, offset)
+		payloadBytes += size
+
+		out := make([]float32, unit)
+		got, decErr := decoder.DecodeToFloat32(packet[:size], out)
+		require.NoErrorf(t, decErr, "bandwidth %d, sample %d", bandwidth, offset)
+		decoded = append(decoded, out[:got]...)
+	}
+
+	original := make([]float32, len(pcm))
+	for i, sample := range pcm {
+		original[i] = float32(sample) / 32768
+	}
+
+	peak := 0.0
+	for _, sample := range decoded {
+		peak = max(peak, math.Abs(float64(sample)))
+	}
+
+	return silkRateMeasurement{
+		bitrate: float64(payloadBytes*8) / silkRateTestSeconds,
+		peak:    peak,
+		snrDB:   computeSNR(original, decoded),
+	}
+}
+
+// TestEncodeSILKTracksTargetRate encodes speech-like audio at a 24 kb/s target
+// for every SILK bandwidth and checks three things the round-trip tests above
+// cannot: the emitted rate stays near the requested target, the decode stays
+// below full scale, and the round-trip error stays well under the signal.
+// A noise shaping quantizer predicting through a broken filter still produces
+// non-silent output, so it passes every energy check while spending several
+// times the target and clipping the decode.
+func TestEncodeSILKTracksTargetRate(t *testing.T) {
+	for _, bandwidth := range []Bandwidth{BandwidthNarrowband, BandwidthMediumband, BandwidthWideband} {
+		got := runSILKRateProbe(t, bandwidth, silkRateTestBitrate)
+		t.Logf("bandwidth %d: %.2f kb/s for a %d kb/s target, peak %.3f of full scale, SNR %.1f dB",
+			bandwidth, got.bitrate/1000, silkRateTestBitrate/1000, got.peak, got.snrDB)
+
+		assert.LessOrEqualf(t, got.bitrate, silkRateTestMaxOverrun*silkRateTestBitrate,
+			"bandwidth %d: emitted %.2f kb/s for a %d kb/s target",
+			bandwidth, got.bitrate/1000, silkRateTestBitrate/1000)
+		assert.Lessf(t, got.peak, silkRateTestPeakCeiling,
+			"bandwidth %d: decoded peak %.3f is at full scale", bandwidth, got.peak)
+		assert.GreaterOrEqualf(t, got.snrDB, silkRateTestMinSNRDB,
+			"bandwidth %d: round-trip SNR %.1f dB", bandwidth, got.snrDB)
+	}
 }


### PR DESCRIPTION
Fixes #221.

`internal/silk/enc_frame.go` packed the two frame-half LPC sets into `predCoef2` at a stride of `maxLPCOrder` (24, the analysis order), while `nsq.go` indexes them at `maxPredictLPCOrder` (16). The second half was written at offset 24 and read at offset 16, which lands in the padding between the halves, so the noise shaping quantizer predicted through a zeroed filter. With `lsfInterpFlag == 0` the index `(k>>1)|1` is 1 for every subframe, so all four read offset 16 and the half at 24 was never read at all.

libopus stores the state as `PredCoef_Q12[2][MAX_LPC_ORDER]` (`structs.h:351`) with `MAX_LPC_ORDER` 16 (`define.h:142`). `SILK_MAX_ORDER_LPC` (24) is the LPC analysis order and is not this array's layout, which is what `nsq.go`'s own comment on `maxPredictLPCOrder` already says.

### Effect

One second of speech-like audio (180 Hz five-harmonic series under a slow envelope) at a 24 kb/s target, complexity 5:

| bandwidth | | bitrate | decoded peak | SNR |
|---|---|---:|---:|---:|
| narrowband | before | 72.08 kb/s | 32768/32768 | -21.9 dB |
| | after | 16.43 kb/s | 6291/32768 | +19.1 dB |
| mediumband | before | 105.61 kb/s | 32768/32768 | -21.3 dB |
| | after | 16.87 kb/s | 6651/32768 | +18.7 dB |
| wideband | before | 117.26 kb/s | 32768/32768 | -20.9 dB |
| | after | 18.23 kb/s | 6455/32768 | +20.4 dB |

The rate now tracks the target instead of saturating, and the clipping is gone.

### Test

`TestEncodeSILKTracksTargetRate` encodes that signal one 20 ms unit at a time through a single stateful encoder and decoder, per SILK bandwidth, and asserts three things:

- the emitted rate stays under 2x the requested target,
- the decoded peak stays below full scale,
- the round-trip SNR clears a 6 dB floor.

All three fail on `main` and pass with the change. The thresholds are deliberately loose: they are there to catch a quantizer that has stopped predicting, not to pin encoder quality, which `TestEncoderQuality` already tracks against a baseline. The existing SILK round-trip tests only assert non-silent output, which a clipped signal satisfies, so nothing caught this.

SNR reuses the existing `computeSNR` / `estimateCodecDelayFloat32` helpers from `encoder_quality_test.go`.

`go test ./...` and `golangci-lint run ./...` are clean.
