### PR TITLE
Skip identity twiddle in CELT FFT

### DIFF
--- a/internal/celt/fft.go
+++ b/internal/celt/fft.go
@@ -157,7 +157,18 @@ func fftRadix2(in []complex32, plan *fftPlan) {
 		}
 	}
 
-	for stage, length := 0, 2; length <= n; stage, length = stage+1, length<<1 {
+	// Stage 0 always multiplies by the identity twiddle {1, 0}.
+	for i := 0; i < n; i += 2 {
+		pair := in[i : i+2]
+		ar := pair[0].r
+		ai := pair[0].i
+		br := pair[1].r
+		bi := pair[1].i
+		pair[0] = complex32{r: ar + br, i: ai + bi}
+		pair[1] = complex32{r: ar - br, i: ai - bi}
+	}
+
+	for stage, length := 1, 4; length <= n; stage, length = stage+1, length<<1 {
 		halfLen := length >> 1
 		twiddles := plan.stageTwiddles[stage]
 		for i := 0; i < n; i += length {

--- a/internal/celt/fft_test.go
+++ b/internal/celt/fft_test.go
@@ -8,6 +8,8 @@ import (
 	"math/rand"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFFTRoundTrip(t *testing.T) {
@@ -79,6 +81,20 @@ func TestFFTPureRadix2Sizes(t *testing.T) {
 			assertComplexSliceClose(t, expected, actual, tolerance)
 		})
 	}
+}
+
+func TestFFTRadix2StageZero(t *testing.T) {
+	input := []complex32{
+		{r: 1.5, i: -2},
+		{r: -3.5, i: 4},
+	}
+
+	fftRadix2(input, fftPlanForLength(2))
+
+	assert.Equal(t, []complex32{
+		{r: -2, i: 2},
+		{r: 5, i: -6},
+	}, input)
 }
 
 func TestInverseFFTMatchesNaive(t *testing.T) {


### PR DESCRIPTION
#### Description

Handle the first radix-2 FFT stage directly, avoiding multiplication by its identity twiddle `{1, 0}`.

Adds a direct stage-zero butterfly test.

The output is bit-identical to `main` for deterministic PCM across mono/stereo, 24/96 kbps, and CBR/VBR configurations.

Validated with:
- `go test ./...`
- `GOARCH=386 go test ./...`
- `golangci-lint run`

#### Reference issue

N/A