### PR TITLE
Reuse CWRS recurrence row during encoding

### DIFF
--- a/internal/celt/cwrs.go
+++ b/internal/celt/cwrs.go
@@ -307,12 +307,10 @@ func encodePulses(y []int, n, k int, rangeEncoder *rangecoding.Encoder, scratch 
 	if k <= 0 {
 		return
 	}
-	index := cwrsEncode(y, n, k, scratch)
-	// cwrsEncode walks scratch backward via cwrsPreviousRow, so I have to
-	// reinitialise it before reading u[k]+u[k+1] for the uniform-coder total.
 	u := cwrsRowFromScratch(scratch, k)
 	cwrsUrowInto(u, n)
 	total := u[k] + u[k+1]
+	index := cwrsEncodeRow(y, n, k, u)
 	rangeEncoder.EncodeUniform(total, index)
 }
 
@@ -325,8 +323,19 @@ func cwrsEncode(y []int, n, k int, scratch []uint32) uint32 {
 
 	u := cwrsRowFromScratch(scratch, k)
 	cwrsUrowInto(u, n)
-	var index uint32
 
+	return cwrsEncodeRow(y, n, k, u)
+}
+
+// cwrsEncodeRow maps a PVQ pulse vector to its unique CWRS codeword index
+// using a pre-computed recurrence row. It is identical to cwrsEncode but
+// avoids the O(n*k) cwrsUrowInto call when the caller already has the row.
+func cwrsEncodeRow(y []int, n, k int, u []uint32) uint32 {
+	if n <= 0 || k <= 0 {
+		return 0
+	}
+
+	var index uint32
 	for j := range n {
 		magnitude := y[j]
 		sign := magnitude >> (bits.UintSize - 1)

--- a/internal/celt/cwrs.go
+++ b/internal/celt/cwrs.go
@@ -337,7 +337,8 @@ func cwrsEncodeRow(y []int, n, k int, u []uint32) uint32 {
 
 	var index uint32
 	for j := range n {
-		magnitude := y[j]
+		pulse := y[j : j+1]
+		magnitude := pulse[0]
 		sign := magnitude >> (bits.UintSize - 1)
 		magnitude = (magnitude ^ sign) - sign
 		if magnitude > k {
@@ -346,7 +347,7 @@ func cwrsEncodeRow(y []int, n, k int, u []uint32) uint32 {
 
 		remaining := k - magnitude
 		index += u[remaining]
-		if y[j] < 0 {
+		if pulse[0] < 0 {
 			index += u[k+1]
 		}
 

--- a/internal/celt/cwrs_test.go
+++ b/internal/celt/cwrs_test.go
@@ -156,6 +156,7 @@ func TestCwrsEncodeRowMatchesEncode(t *testing.T) {
 		y    []int
 	}{
 		{2, 3, []int{2, 1}},
+		{2, 3, []int{-2, 1}},
 		{3, 5, []int{3, 1, 1}},
 		{4, 8, []int{4, 2, 1, 1}},
 		{6, 12, []int{6, 3, 2, 1, 0, 0}},
@@ -171,4 +172,8 @@ func TestCwrsEncodeRowMatchesEncode(t *testing.T) {
 
 		assert.Equal(t, indexA, indexB)
 	}
+
+	assert.Zero(t, cwrsEncodeRow(nil, 0, 1, nil))
+	assert.Zero(t, cwrsEncodeRow(nil, 1, 0, nil))
+	assert.Zero(t, cwrsEncodeRow([]int{2, 0}, 2, 1, cwrsUrow(2, 1)))
 }

--- a/internal/celt/cwrs_test.go
+++ b/internal/celt/cwrs_test.go
@@ -149,3 +149,26 @@ func TestCWRSRowFromScratchLargeK(t *testing.T) {
 	row := cwrsRowFromScratch(scratch, cwrsMaxPulseCount+1)
 	assert.Len(t, row, cwrsMaxPulseCount+3)
 }
+
+func TestCwrsEncodeRowMatchesEncode(t *testing.T) {
+	for _, tc := range []struct {
+		n, k int
+		y    []int
+	}{
+		{2, 3, []int{2, 1}},
+		{3, 5, []int{3, 1, 1}},
+		{4, 8, []int{4, 2, 1, 1}},
+		{6, 12, []int{6, 3, 2, 1, 0, 0}},
+	} {
+		scratchA := make([]uint32, tc.k+2)
+		scratchB := make([]uint32, tc.k+2)
+
+		indexA := cwrsEncode(tc.y, tc.n, tc.k, scratchA)
+
+		u := cwrsRowFromScratch(scratchB, tc.k)
+		cwrsUrowInto(u, tc.n)
+		indexB := cwrsEncodeRow(tc.y, tc.n, tc.k, u)
+
+		assert.Equal(t, indexA, indexB)
+	}
+}


### PR DESCRIPTION
#### Description

Reuse the CWRS recurrence row already computed by `encodePulses` instead of rebuilding it before encoding the uniform range.

Adds coverage that encoding from a precomputed row produces the same codeword index as the scratch-backed path.

The output is bit-identical to `main` for deterministic PCM across mono/stereo, 24/96 kbps, and CBR/VBR configurations.

Validated with:
- `go test ./...`
- `GOARCH=386 go test ./...`
- `golangci-lint run`

#### Reference issue

N/A