### PR TITLE
Keep CELT DC blocker state local

### DIFF
--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -637,9 +637,11 @@ func spreadingDecision(
 func applyDCBlock(pcm []float32, sampleRate int, mem *float32) {
 	coef := 6.3 * dcBlockCutoffHz / float32(sampleRate)
 	coef2 := float32(1) - coef
+	m := *mem
 	for i := range pcm {
 		x := pcm[i]
-		pcm[i] = x - *mem
-		*mem = coef*x + coef2**mem
+		pcm[i] = x - m
+		m = coef*x + coef2*m
 	}
+	*mem = m
 }

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -361,6 +361,33 @@ func TestDCBlockMultiFrameState(t *testing.T) {
 	}
 }
 
+func TestDCBlockMatchesScalarReference(t *testing.T) {
+	pcm := make([]float32, 960)
+	for i := range pcm {
+		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / float64(sampleRate)))
+	}
+	want := append([]float32(nil), pcm...)
+	got := append([]float32(nil), pcm...)
+	memWant := float32(0.1)
+	memGot := memWant
+
+	applyDCBlockScalar(want, sampleRate, &memWant)
+	applyDCBlock(got, sampleRate, &memGot)
+
+	assert.Equal(t, want, got)
+	assert.Equal(t, memWant, memGot)
+}
+
+func applyDCBlockScalar(pcm []float32, sampleRate int, mem *float32) {
+	coef := 6.3 * dcBlockCutoffHz / float32(sampleRate)
+	coef2 := float32(1) - coef
+	for i := range pcm {
+		x := pcm[i]
+		pcm[i] = x - *mem
+		*mem = coef*x + coef2**mem
+	}
+}
+
 func TestAnalyzeFrameAppliesDCBlock(t *testing.T) {
 	// A sine with DC offset must produce a different bitstream than the clean sine.
 	enc1 := NewEncoder()


### PR DESCRIPTION
#### Description

Keep the DC blocker state in a local variable through each frame and write it back once after filtering.

Adds an exact scalar-reference test for the output and persistent state.

The output is bit-identical to `main` for deterministic PCM across mono/stereo, 24/96 kbps, and CBR/VBR configurations.

Validated with:
- `go test ./...`
- `GOARCH=386 go test ./...`
- `golangci-lint run`

#### Reference issue

N/A