### PR TITLE
Support atomic 40 and 60 ms SILK PLC

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -1214,7 +1214,7 @@ func (d *Decoder) decodePLCToFloat32(out []float32) error {
 	if d.previousRedundancy {
 		mode = configurationModeCELTOnly
 	}
-	samplesPerChannel := d.sampleRate / 50
+	samplesPerChannel := len(out) / d.channels
 	var err error
 	switch mode {
 	case configurationModeSilkOnly:
@@ -1240,11 +1240,18 @@ func (d *Decoder) validatePLCOutput(sampleCount int) error {
 		return errInvalidSampleRate
 	case d.channels == 0:
 		return errInvalidChannelCount
-	case sampleCount != d.sampleRate/50*d.channels:
-		return errInvalidPLCFrameSize
-	default:
+	}
+
+	twentyMilliseconds := d.sampleRate / 50 * d.channels
+	if sampleCount == twentyMilliseconds {
 		return nil
 	}
+	if d.previousMode == configurationModeSilkOnly && !d.previousRedundancy &&
+		(sampleCount == 2*twentyMilliseconds || sampleCount == 3*twentyMilliseconds) {
+		return nil
+	}
+
+	return errInvalidPLCFrameSize
 }
 
 func (d *Decoder) decodeCeltPLCFrame(out []float32, samplesPerChannel int, hybrid bool) error {
@@ -1580,7 +1587,9 @@ func (d *Decoder) DecodeToInt16(in []byte, out []int16) (int, error) {
 	return sampleCount, nil
 }
 
-// DecodePLC recovers one missing 20 ms packet into signed 16-bit PCM.
+// DecodePLC recovers one missing packet into signed 16-bit PCM. SILK-only
+// packets may be concealed atomically for 20, 40, or 60 ms according to the
+// output length. CELT and Hybrid concealment currently support 20 ms.
 func (d *Decoder) DecodePLC(out []int16) error {
 	d.floatBuffer = resizeFloat32Buffer(&d.floatBuffer, len(out))
 	if err := d.decodePLCToFloat32(d.floatBuffer); err != nil {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -269,6 +269,63 @@ func TestDecodePLCFrameSizeValidation(t *testing.T) {
 	assert.ErrorIs(t, err, errInvalidPLCFrameSize)
 }
 
+func TestDecodePLCConcealsOneAtomicLongSILKPacket(t *testing.T) {
+	const sampleRate = 16000
+
+	for _, duration := range []int{2, 3} {
+		t.Run(fmt.Sprintf("%dms", duration*20), func(t *testing.T) {
+			encoder, err := NewEncoder()
+			require.NoError(t, err)
+
+			input := make([]int16, duration*sampleRate/50)
+			for i := range input {
+				input[i] = int16((i%80)*400 - 16000)
+			}
+			packet := make([]byte, maxOpusFrameSize)
+			written, err := encoder.EncodeSILK(input, BandwidthWideband, packet)
+			require.NoError(t, err)
+
+			decoder, err := NewDecoderWithOutput(sampleRate, 1)
+			require.NoError(t, err)
+			decoded := make([]int16, len(input))
+			samples, err := decoder.DecodeToInt16(packet[:written], decoded)
+			require.NoError(t, err)
+			require.Equal(t, len(input), samples)
+
+			plc := make([]int16, len(input))
+			require.NoError(t, decoder.DecodePLC(plc))
+			assert.NotEqual(t, make([]int16, len(plc)), plc)
+
+			decoded = make([]int16, len(input))
+			samples, err = decoder.DecodeToInt16(packet[:written], decoded)
+			require.NoError(t, err)
+			require.Equal(t, len(input), samples)
+		})
+	}
+}
+
+func TestDecodePLCRejectsLongOutputForNonSILKModes(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		mode       configurationMode
+		redundancy bool
+	}{
+		{name: "Hybrid", mode: configurationModeHybrid},
+		{name: "CELT", mode: configurationModeCELTOnly},
+		{name: "SILK redundancy", mode: configurationModeSilkOnly, redundancy: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			decoder, err := NewDecoderWithOutput(16000, 1)
+			require.NoError(t, err)
+			decoder.previousMode = test.mode
+			decoder.previousRedundancy = test.redundancy
+
+			err = decoder.DecodePLC(make([]int16, 960))
+			assert.ErrorIs(t, err, errInvalidPLCFrameSize)
+		})
+	}
+}
+
 func TestDecodePLCStateValidation(t *testing.T) {
 	var uninitialized Decoder
 	assert.ErrorIs(t, uninitialized.DecodePLC(nil), errInvalidSampleRate)

--- a/errors.go
+++ b/errors.go
@@ -30,7 +30,7 @@ var (
 
 	errInvalidFrameByteBudget = errors.New("invalid frame byte budget")
 
-	errInvalidPLCFrameSize = errors.New("PLC output must contain exactly 20 ms of interleaved samples")
+	errInvalidPLCFrameSize = errors.New("PLC output has an unsupported duration for the previous packet mode")
 
 	errInvalidApplication = errors.New("invalid application")
 


### PR DESCRIPTION
#### Description

Allow Decoder.DecodePLC to conceal one missing 40 or 60 ms SILK-only packet in a single call, using the output length as the requested packet duration.

Long PLC remains rejected for CELT, Hybrid, and SILK redundancy. The existing 20 ms behavior remains valid for every mode.

This also passes the requested per-channel sample count into the SILK PLC path instead of hard-coding 20 ms, and updates the frame-size error to describe the mode-dependent constraint.

Added tests covering atomic 40/60 ms SILK concealment, decoder continuity after concealment, and rejection of long output for unsupported modes.

Validated with:
- go test ./...
- GOARCH=386 go test ./...

#### Reference issue

N/A