### PR TITLE
Make EncodeSILK output failures transactional

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -490,19 +490,26 @@ func (e *Encoder) EncodeSILK(pcm []int16, bandwidth Bandwidth, out []byte) (int,
 	// 20/40/60 ms), so the duration offset is frameCount-1, not (frameCount-1)*2.
 	config += frameCount - 1
 
-	filtered := applySILKDCBlock(pcm, bandwidth.SampleRate(), &e.silkDCBlockMem)
+	// Encode against an independent candidate so a short output buffer cannot
+	// advance the DC blocker, VAD, prediction, or noise-shaping state. Commit
+	// the candidate only after the complete payload is known to fit.
+	nextDCBlockMem := e.silkDCBlockMem
+	filtered := applySILKDCBlock(pcm, bandwidth.SampleRate(), &nextDCBlockMem)
+	nextSILKEncoder := e.silkEncoder.Clone()
 	// The SILK encoder keeps its prediction state (NLSF interpolation, pitch
 	// lag, gain, LCG seed) across packets so consecutive 60 ms frames stay in
 	// sync with the decoder's stateful stream. Only the range coder is
 	// re-initialized per packet, so each packet is a self-contained bitstream
 	// that the decoder can start reading from scratch.
-	payload := e.silkEncoder.Encode(filtered, silk.Bandwidth(bandwidth), e.bitrate)
+	payload := nextSILKEncoder.Encode(filtered, silk.Bandwidth(bandwidth), e.bitrate)
 	if len(out) < len(payload)+1 {
 		return 0, errOutBufferTooSmall
 	}
 
 	out[0] = byte(config<<3) | byte(frameCodeOneFrame) // mono, one frame
 	n := copy(out[1:], payload)
+	e.silkDCBlockMem = nextDCBlockMem
+	e.silkEncoder = nextSILKEncoder
 
 	return n + 1, nil
 }

--- a/internal/silk/encoder.go
+++ b/internal/silk/encoder.go
@@ -68,6 +68,26 @@ func NewEncoder() Encoder {
 	return e
 }
 
+// Clone returns an independent copy of the persistent encoder state. The
+// range coder is deliberately reset instead of copied: Encode initializes it
+// at the start of every packet, and sharing its backing buffers would let a
+// speculative encode modify the original encoder.
+func (e *Encoder) Clone() Encoder {
+	clone := *e
+	clone.rangeEncoder = rangecoding.Encoder{}
+	clone.prevNLSFq = append([]int16(nil), e.prevNLSFq...)
+	clone.xBuf = append([]float32(nil), e.xBuf...)
+	if e.nsq != nil {
+		nsqClone := *e.nsq
+		nsqClone.xq = append([]int16(nil), e.nsq.xq...)
+		nsqClone.sLTPShpQ14 = append([]int32(nil), e.nsq.sLTPShpQ14...)
+		nsqClone.sLPCQ14 = append([]int32(nil), e.nsq.sLPCQ14...)
+		clone.nsq = &nsqClone
+	}
+
+	return clone
+}
+
 // SetUseInterpolatedNLSFs enables or disables the NLSF interpolation search
 // in findLPCNLSF, mirroring libopus's complexity-tier setting
 // (silk_setup_complexity: enabled for encoder complexity >= 4).

--- a/silk_encode_test.go
+++ b/silk_encode_test.go
@@ -4,6 +4,7 @@
 package opus
 
 import (
+	"bytes"
 	"math"
 	"testing"
 
@@ -266,13 +267,74 @@ func TestEncodeSILKInvalidBandwidth(t *testing.T) {
 	}
 }
 
-func TestEncodeSILKOutBufferTooSmall(t *testing.T) {
-	enc, err := NewEncoder()
-	require.NoError(t, err)
+// TestEncodeSILKOutBufferTooSmallDoesNotAdvanceState checks that a rejected
+// packet is transactional: retrying with enough output space must produce the
+// exact packet an encoder that never saw the rejected call would produce.
+// Cover both fresh and established prediction state at every supported SILK
+// packet duration.
+func TestEncodeSILKOutBufferTooSmallDoesNotAdvanceState(t *testing.T) {
+	durations := []struct {
+		name  string
+		units int
+	}{
+		{duration20Ms, 1},
+		{duration40Ms, 2},
+		{duration60Ms, 3},
+	}
 
-	pcm := make([]int16, BandwidthWideband.SampleRate()/50)
-	_, err = enc.EncodeSILK(pcm, BandwidthWideband, make([]byte, 1))
-	require.Error(t, err)
+	makePCM := func(samples, offset int) []int16 {
+		pcm := make([]int16, samples)
+		for i := range pcm {
+			phase := float64(i + offset)
+			pcm[i] = int16(5000*math.Sin(2*math.Pi*phase/48) + 1200*math.Sin(2*math.Pi*phase/11))
+		}
+
+		return pcm
+	}
+
+	unit := BandwidthWideband.SampleRate() / 50
+	for _, duration := range durations {
+		for _, warmed := range []bool{false, true} {
+			state := "fresh"
+			if warmed {
+				state = "warmed"
+			}
+
+			t.Run(duration.name+"/"+state, func(t *testing.T) {
+				retryEncoder, err := NewEncoder(WithComplexity(8))
+				require.NoError(t, err)
+				referenceEncoder, err := NewEncoder(WithComplexity(8))
+				require.NoError(t, err)
+
+				if warmed {
+					warmup := makePCM(unit, 0)
+					for _, encoder := range []*Encoder{retryEncoder, referenceEncoder} {
+						_, err = encoder.EncodeSILK(warmup, BandwidthWideband, make([]byte, maxOpusFrameSize))
+						require.NoError(t, err)
+					}
+				}
+
+				pcm := makePCM(duration.units*unit, 37)
+				shortOut := []byte{0xa5}
+				n, err := retryEncoder.EncodeSILK(pcm, BandwidthWideband, shortOut)
+				assert.Zero(t, n)
+				assert.ErrorIs(t, err, errOutBufferTooSmall)
+				assert.Equal(t, []byte{0xa5}, shortOut, "rejected call must not modify output")
+
+				retryPacket := make([]byte, maxOpusFrameSize)
+				retryN, err := retryEncoder.EncodeSILK(pcm, BandwidthWideband, retryPacket)
+				require.NoError(t, err)
+
+				referencePacket := make([]byte, maxOpusFrameSize)
+				referenceN, err := referenceEncoder.EncodeSILK(pcm, BandwidthWideband, referencePacket)
+				require.NoError(t, err)
+
+				require.Equal(t, referenceN, retryN)
+				assert.True(t, bytes.Equal(referencePacket[:referenceN], retryPacket[:retryN]),
+					"retry packet differs from untouched reference")
+			})
+		}
+	}
 }
 
 // TestSILKDCBlockRemovesConstantOffset mirrors celt's TestDCBlockRemovesConstantOffset:


### PR DESCRIPTION
## Problem

`EncodeSILK` could return `ErrOutputTooSmall` after the encoder had already advanced internal SILK/DC state. Retrying the same PCM with a larger output buffer therefore encoded from a different state and could produce a different packet than a clean encoder.

## What changes

The encoder now stages all mutable encode state in a copy and commits it only after the complete payload fits the caller-provided buffer.

- Success keeps the existing state transition.
- `ErrOutputTooSmall` becomes an exact encoder-state no-op.
- No API change and no hidden retry or allocation contract is introduced.

## Why this is better

Before this change, callers could not safely recover from an undersized output buffer: the rejected attempt silently consumed codec history. After this change, resizing the buffer and retrying is deterministic and matches an untouched reference encoder.

## Executable evidence

The regression was reconstructed from base commit `6393603fc13127a64f602822fedbbe71ac1a5e1d` by applying only `TestEncodeSILKOutBufferTooSmallDoesNotAdvanceState`. All six fresh/warmed frame-duration cases failed because the retry packet length differed from the untouched reference:

| Case | Reference bytes | Retry after rejected encode |
| --- | ---: | ---: |
| 20 ms / fresh | 256 | 226 |
| 20 ms / warmed | 339 | 347 |
| 40 ms / fresh | 454 | 414 |
| 40 ms / warmed | 684 | 693 |
| 60 ms / fresh | 644 | 683 |
| 60 ms / warmed | 1030 | 1040 |

The test then checks byte-for-byte packet equality, not only length. It passes at commit `1b0f7e1` (`Make SILK output failures transactional`), including 100 repeated runs of the targeted matrix.

## Validation

- `go test ./...`
- `go vet ./...`
- targeted rollback matrix repeated 100 times
- 386 compile/test coverage used by the repository checks
- GitHub CI green
