### PR TITLE
Align SILK VAD-gated pitch state with libopus

### DIFF
--- a/internal/silk/enc_frame.go
+++ b/internal/silk/enc_frame.go
@@ -13,6 +13,10 @@ package silk
 // SILK_FIX_CONST does in libopus 1.6.1.
 const silkVADThreshold = 13
 
+func silkVADActive(speechActivityQ8 int) bool {
+	return speechActivityQ8 >= silkVADThreshold
+}
+
 // silkInternalRate returns the SILK internal sample rate in kHz.
 func silkInternalRate(bandwidth Bandwidth) int {
 	switch bandwidth {
@@ -115,7 +119,7 @@ func (e *Encoder) encodeSILKFrame(
 	// Voice activity initializes signalType before pitch analysis, matching
 	// silk_encode_do_VAD_FLP. Inactive frames never enter the pitch search.
 	saQ8, tiltQ15, quality := e.vad.getSpeechActivityQ8(input, frameLength, fsKHz)
-	active := saQ8 > silkVADThreshold
+	active := silkVADActive(saQ8)
 
 	// Pitch analysis on the whitening residual (with LTP-memory history).
 	if len(e.xBuf) != ltpMemLength {

--- a/internal/silk/enc_frame.go
+++ b/internal/silk/enc_frame.go
@@ -9,10 +9,9 @@ package silk
 // interpolation. The delayed-decision NSQ, stereo, and the rate-control loop
 // are follow-up refinements.
 
-// silkVADThreshold is the current Pion speech_activity_Q8 cutoff. Its value
-// 100 is a legacy encoder heuristic, not libopus's Q8 threshold 13. Pitch
-// analysis may still promote a periodic unit to active below it.
-const silkVADThreshold = 100
+// silkVADThreshold is SPEECH_ACTIVITY_DTX_THRES (0.05) in Q8, rounded as
+// SILK_FIX_CONST does in libopus 1.6.1.
+const silkVADThreshold = 13
 
 // silkInternalRate returns the SILK internal sample rate in kHz.
 func silkInternalRate(bandwidth Bandwidth) int {
@@ -113,9 +112,8 @@ func (e *Encoder) encodeSILKFrame(
 	frameLength := subfrCount * subfrLength
 	ltpMemLength := 20 * fsKHz
 
-	// Voice activity. Pitch analysis below may promote a periodic frame to
-	// active, so the packet-header flag is recorded only after signal type is
-	// finalized.
+	// Voice activity initializes signalType before pitch analysis, matching
+	// silk_encode_do_VAD_FLP. Inactive frames never enter the pitch search.
 	saQ8, tiltQ15, quality := e.vad.getSpeechActivityQ8(input, frameLength, fsKHz)
 	active := saQ8 > silkVADThreshold
 
@@ -129,7 +127,9 @@ func (e *Encoder) encodeSILKFrame(
 		analysis[ltpMemLength+i] = float32(input[i])
 	}
 	voiced, pitchL, lagIndex, contourIndex, res, predGain := e.findPitchLags(
-		analysis[:ltpMemLength+frameLength], fsKHz, subfrCount, saQ8, tiltQ15)
+		analysis[:ltpMemLength+frameLength], fsKHz, subfrCount, saQ8, tiltQ15,
+		active && !e.firstFrameAfterReset,
+	)
 	// Keep a few zero samples of headroom after the residual for find_LTP.
 	res = append(res, make([]float32, ltpOrder)...)
 
@@ -137,7 +137,6 @@ func (e *Encoder) encodeSILKFrame(
 	switch {
 	case voiced:
 		signalType = frameSignalTypeVoiced
-		active = true
 	case active:
 		signalType = frameSignalTypeUnvoiced
 	}

--- a/internal/silk/enc_frame_test.go
+++ b/internal/silk/enc_frame_test.go
@@ -165,37 +165,70 @@ func TestEncodeSILKFrameVoicedHighOffset(t *testing.T) {
 	require.Equal(t, dataRange, dec.rangeDecoder.FinalRange(), "second frame range coder desync")
 }
 
-// TestEncodeSILKFrameLowVADVoicedHeader verifies that a periodic frame which
-// pitch analysis promotes to voiced remains decodable even when the earlier
-// VAD threshold classified it as inactive. The packet header and frame-type
-// entropy table must use the same final activity decision.
-func TestEncodeSILKFrameLowVADVoicedHeader(t *testing.T) {
+// TestEncodeSILKFrameFirstAfterResetSkipsPitch is pinned to libopus 1.6.1
+// (22244de5a79bd1d6d623c32e72bf1954b56235be): an active first frame is
+// unvoiced, with pitch/LTP state cleared, until first_frame_after_reset is
+// consumed. Encoder and decoder must still finish at the same range state.
+func TestEncodeSILKFrameFirstAfterResetSkipsPitch(t *testing.T) {
 	bandwidth := BandwidthWideband
 	fsKHz := silkInternalRate(bandwidth)
 	frameLength := 20 * fsKHz
-	first := make([]int16, frameLength)
-	for i := range first {
-		first[i] = int16(6000 * math.Sin(2*math.Pi*float64(i)/50))
+	input := make([]int16, frameLength)
+	for i := range input {
+		input[i] = int16(6000 * math.Sin(2*math.Pi*float64(i)/50))
 	}
-	quiet := make([]int16, frameLength)
-	for i := range quiet {
-		quiet[i] = int16(1024 * math.Sin(2*math.Pi*float64(i)/32))
+
+	enc := NewEncoder()
+	packet := enc.Encode(input, bandwidth, 24000)
+	require.NotEmpty(t, packet)
+	assert.True(t, enc.vadFlags[0], "libopus vector is VAD-active")
+	assert.False(t, enc.isPreviousFrameVoiced, "first frame after reset must not run pitch search")
+	assert.Zero(t, enc.ltpCorr, "skipped pitch search must clear LTP correlation")
+	assert.Zero(t, enc.nsq.lagPrev, "inactive pitch path must give NSQ zero lags")
+
+	dec := NewDecoder()
+	out := make([]float32, frameLength)
+	require.NoError(t, dec.Decode(packet, out, false, nanoseconds20Ms, bandwidth))
+	assert.Equal(t, enc.rangeEncoder.FinalRange(), dec.rangeDecoder.FinalRange())
+}
+
+// TestEncodeSILKFrameInactivePeriodicInputClearsPitch follows the libopus
+// 1.6.1 low-activity lead: after a loud periodic frame and a long quiet
+// periodic tail, VAD eventually becomes inactive. Pitch must not promote an
+// inactive frame back to voiced; lag/LTP state is cleared and the range stream
+// remains synchronized for every packet.
+func TestEncodeSILKFrameInactivePeriodicInputClearsPitch(t *testing.T) {
+	bandwidth := BandwidthWideband
+	fsKHz := silkInternalRate(bandwidth)
+	frameLength := 20 * fsKHz
+	makePeriodic := func(amplitude, period float64) []int16 {
+		input := make([]int16, frameLength)
+		for i := range input {
+			input[i] = int16(amplitude * math.Sin(2*math.Pi*float64(i)/period))
+		}
+
+		return input
 	}
 
 	enc := NewEncoder()
 	dec := NewDecoder()
 	out := make([]float32, frameLength)
-	firstPacket := enc.Encode(first, bandwidth, 0)
-	firstRange := enc.rangeEncoder.FinalRange()
-	require.NoError(t, dec.Decode(firstPacket, out, false, nanoseconds20Ms, bandwidth))
-	require.Equal(t, firstRange, dec.rangeDecoder.FinalRange(), "first frame range coder desync")
-	for repeat := 1; repeat <= 10; repeat++ {
-		packet := enc.Encode(quiet, bandwidth, 0)
-		require.NoErrorf(t, dec.Decode(packet, out, false, nanoseconds20Ms, bandwidth),
-			"low-VAD voiced packet failed to decode at repeat %d", repeat)
-		require.Equalf(t, enc.rangeEncoder.FinalRange(), dec.rangeDecoder.FinalRange(),
-			"low-VAD voiced packet desynchronized the range coder at repeat %d", repeat)
+
+	inputs := [][]int16{makePeriodic(6000, 50)}
+	for range 20 {
+		inputs = append(inputs, makePeriodic(16, 32))
 	}
+	for frame, input := range inputs {
+		packet := enc.Encode(input, bandwidth, 24000)
+		require.NotEmptyf(t, packet, "frame %d", frame)
+		require.NoErrorf(t, dec.Decode(packet, out, false, nanoseconds20Ms, bandwidth), "frame %d", frame)
+		require.Equalf(t, enc.rangeEncoder.FinalRange(), dec.rangeDecoder.FinalRange(), "frame %d", frame)
+	}
+
+	assert.False(t, enc.vadFlags[0], "quiet tail must converge to VAD-inactive")
+	assert.False(t, enc.isPreviousFrameVoiced, "inactive frame must not be promoted by pitch")
+	assert.Zero(t, enc.ltpCorr, "inactive frame must clear LTP correlation")
+	assert.Zero(t, enc.nsq.lagPrev, "inactive frame must clear NSQ pitch lag")
 }
 
 // TestEncode checks the public Encode wrapper: it must Init the range coder,

--- a/internal/silk/enc_frame_test.go
+++ b/internal/silk/enc_frame_test.go
@@ -185,6 +185,7 @@ func TestEncodeSILKFrameFirstAfterResetSkipsPitch(t *testing.T) {
 	assert.True(t, enc.vadFlags[0], "libopus vector is VAD-active")
 	assert.False(t, enc.isPreviousFrameVoiced, "first frame after reset must not run pitch search")
 	assert.Zero(t, enc.ltpCorr, "skipped pitch search must clear LTP correlation")
+	assert.Zero(t, enc.previousLag, "skipped pitch search must clear the stored previous lag")
 	assert.Zero(t, enc.nsq.lagPrev, "inactive pitch path must give NSQ zero lags")
 
 	dec := NewDecoder()
@@ -229,7 +230,16 @@ func TestEncodeSILKFrameInactivePeriodicInputClearsPitch(t *testing.T) {
 	assert.False(t, enc.vadFlags[0], "quiet tail must converge to VAD-inactive")
 	assert.False(t, enc.isPreviousFrameVoiced, "inactive frame must not be promoted by pitch")
 	assert.Zero(t, enc.ltpCorr, "inactive frame must clear LTP correlation")
+	assert.Zero(t, enc.previousLag, "inactive frame must clear the stored previous lag")
 	assert.Zero(t, enc.nsq.lagPrev, "inactive frame must clear NSQ pitch lag")
+}
+
+// TestSILKVADThresholdBoundaryIsActive pins silk_encode_do_VAD_FLP's strict
+// inactive comparison: speech activity is inactive only below the threshold,
+// so SILK_FIX_CONST(0.05, 8) == 13 remains active.
+func TestSILKVADThresholdBoundaryIsActive(t *testing.T) {
+	assert.False(t, silkVADActive(silkVADThreshold-1))
+	assert.True(t, silkVADActive(silkVADThreshold))
 }
 
 // TestEncode checks the public Encode wrapper: it must Init the range coder,

--- a/internal/silk/enc_frame_test.go
+++ b/internal/silk/enc_frame_test.go
@@ -4,6 +4,7 @@
 package silk
 
 import (
+	"encoding/hex"
 	"math"
 	"testing"
 
@@ -288,6 +289,45 @@ func TestEncodeSILKPacketHeaderReservesInactiveVAD(t *testing.T) {
 		assert.Equalf(t, make([]bool, frameCount), vadFlags, "frame count %d", frameCount)
 		assert.Falsef(t, lbrr, "frame count %d", frameCount)
 		assert.Equalf(t, encRange, dec.rangeDecoder.FinalRange(), "frame count %d", frameCount)
+	}
+}
+
+// TestLibopus161VADPolicyVectors pins the VAD header decisions produced by
+// libopus 1.6.1 at exact source commit 22244de5a79bd1d6d623c32e72bf1954b56235be.
+// Both packets are 20 ms, 16 kHz, mono, restricted SILK:
+// the first is a loud periodic first frame, while the second follows one loud
+// frame and twenty quiet periodic frames (amplitude 16, period 32).
+func TestLibopus161VADPolicyVectors(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		hex    string
+		active bool
+	}{
+		{
+			name: "first frame remains active while pitch is reset-gated",
+			hex: "4881A7B7022A8729FA0637420C88CB4371F6B65F9E802E8FD52CF5FAD21127A8103DC8044DD3CF02C9" +
+				"B24EBD74E782311962A0696744E9332E2BE8EE390D92F050558E46807036514940E156E1AA74A7E5DF83EC349870EC" +
+				"9D87638B19D111841A02973DC0",
+			active: true,
+		},
+		{
+			name:   "quiet periodic tail is inactive",
+			hex:    "4808AFB2CC0E9461B3D062D308E498AC2604A212E71EB821DF6A4CDEAE902D1CC6621841C87E23E8A378",
+			active: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			packet, err := hex.DecodeString(test.hex)
+			require.NoError(t, err)
+			require.Equal(t, byte(0x48), packet[0], "20 ms mono wideband SILK TOC")
+
+			dec := NewDecoder()
+			dec.rangeDecoder.Init(packet[1:])
+			vadFlags, lbrr := dec.decodeHeaderBitsInto(nil, 1)
+
+			require.Equal(t, []bool{test.active}, vadFlags)
+			assert.False(t, lbrr)
+		})
 	}
 }
 

--- a/internal/silk/find_pitch_lags.go
+++ b/internal/silk/find_pitch_lags.go
@@ -19,7 +19,7 @@ const (
 // whether the frame is voiced, the per-subframe pitch lags, the lag/contour
 // indices, and the whitening residual (reused by the LTP analysis).
 func (e *Encoder) findPitchLags(
-	analysisBuf []float32, fsKHz, nbSubfr, speechActivityQ8 int, inputTiltQ15 int32,
+	analysisBuf []float32, fsKHz, nbSubfr, speechActivityQ8 int, inputTiltQ15 int32, searchPitch bool,
 ) (voiced bool, pitchL []int, lagIndex int16, contourIndex int8, res []float32, predGain float32) {
 	bufLen := len(analysisBuf)
 	laPitch := laPitchMS * fsKHz
@@ -47,6 +47,13 @@ func (e *Encoder) findPitchLags(
 	res = make([]float32, bufLen)
 	lpcAnalysisFilterFLP(res, a, analysisBuf, bufLen, pitchEstLPCOrder)
 
+	pitchL = make([]int, nbSubfr)
+	if !searchPitch {
+		e.ltpCorr = 0
+
+		return false, pitchL, 0, 0, res, predGain
+	}
+
 	// Voicing threshold (search_thres2).
 	prevVoiced := float32(0)
 	if e.isPreviousFrameVoiced {
@@ -58,7 +65,6 @@ func (e *Encoder) findPitchLags(
 		0.15*prevVoiced -
 		0.1*float32(inputTiltQ15)*(1.0/32768.0)
 
-	pitchL = make([]int, nbSubfr)
 	prevLag := 0
 	if e.isPreviousFrameVoiced {
 		prevLag = e.previousLag

--- a/internal/silk/find_pitch_lags.go
+++ b/internal/silk/find_pitch_lags.go
@@ -50,6 +50,7 @@ func (e *Encoder) findPitchLags(
 	pitchL = make([]int, nbSubfr)
 	if !searchPitch {
 		e.ltpCorr = 0
+		e.previousLag = 0
 
 		return false, pitchL, 0, 0, res, predGain
 	}

--- a/internal/silk/find_pitch_lags_test.go
+++ b/internal/silk/find_pitch_lags_test.go
@@ -30,7 +30,7 @@ func TestFindPitchLagsVoiced(t *testing.T) {
 	}
 
 	enc := NewEncoder()
-	voiced, pitchL, lagIndex, contourIndex, res, predGain := enc.findPitchLags(buf, fsKHz, nbSubfr, 200, 0)
+	voiced, pitchL, lagIndex, contourIndex, res, predGain := enc.findPitchLags(buf, fsKHz, nbSubfr, 200, 0, true)
 
 	require.True(t, voiced, "periodic signal should be voiced")
 	require.Len(t, res, ltpMemLength+frameLength)
@@ -67,6 +67,6 @@ func TestFindPitchLagsUnvoiced(t *testing.T) {
 
 	enc := NewEncoder()
 	// Not asserting hard (noise can occasionally correlate) — just that it runs.
-	_, _, _, _, res, _ := enc.findPitchLags(buf, fsKHz, 4, 50, 0) //nolint:dogsled // only the residual is under test
+	_, _, _, _, res, _ := enc.findPitchLags(buf, fsKHz, 4, 50, 0, true) //nolint:dogsled // only the residual is under test
 	require.Len(t, res, ltpMemLength+frameLength)
 }

--- a/internal/silk/noise_shape_analysis_test.go
+++ b/internal/silk/noise_shape_analysis_test.go
@@ -34,7 +34,7 @@ func TestNoiseShapeAnalysisAndProcessGainsVoiced(t *testing.T) {
 
 	enc := NewEncoder()
 	enc.ltpCorr = 0.6
-	voiced, pitchL, _, _, res, predGain := enc.findPitchLags(analysisBuf, fsKHz, nbSubfr, 200, 0)
+	voiced, pitchL, _, _, res, predGain := enc.findPitchLags(analysisBuf, fsKHz, nbSubfr, 200, 0, true)
 	require.True(t, voiced, "periodic signal should be voiced")
 
 	shapeBuf := make([]float32, frameLength+2*laShape)

--- a/silk_encode_test.go
+++ b/silk_encode_test.go
@@ -5,6 +5,7 @@ package opus
 
 import (
 	"bytes"
+	"encoding/hex"
 	"math"
 	"testing"
 
@@ -28,6 +29,28 @@ const (
 	silkRateTestPeakCeiling = 0.99 // decoded peak, 1.0 being full scale
 	silkRateTestMinSNRDB    = 6.0
 )
+
+// TestDecodeLibopus161FirstFrameVector pins the public packet boundary against
+// libopus 1.6.1 at exact source commit
+// 22244de5a79bd1d6d623c32e72bf1954b56235be. The input is one 20 ms, 16 kHz,
+// mono periodic frame encoded in SILK-only wideband mode.
+func TestDecodeLibopus161FirstFrameVector(t *testing.T) {
+	packet, err := hex.DecodeString(
+		"4881A7B7022A8729FA0637420C88CB4371F6B65F9E802E8FD52CF5FAD21127A8103DC8044DD3CF02C9" +
+			"B24EBD74E782311962A0696744E9332E2BE8EE390D92F050558E46807036514940E156E1AA74A7E5DF83EC349870EC" +
+			"9D87638B19D111841A02973DC0",
+	)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x48), packet[0], "20 ms mono wideband SILK TOC")
+
+	dec, err := NewDecoderWithOutput(16000, 1)
+	require.NoError(t, err)
+	out := make([]float32, 320)
+	got, err := dec.DecodeToFloat32(packet, out)
+	require.NoError(t, err)
+	require.Equal(t, 320, got)
+	assert.Equal(t, uint32(0x49cf8000), dec.rangeFinal)
+}
 
 // TestEncodeSILKRoundTrip encodes a SILK frame with the public encoder and
 // decodes the resulting Opus packet with the public decoder, for every


### PR DESCRIPTION
## Problem

The Go SILK encoder could promote pitch/LTP state on the first frame after reset and on a low-amplitude transition where the pinned libopus policy clears pitch state. That makes quiet or reset-adjacent input look voiced and leaves stale correlation/lag state available to later encoding decisions.

## What changes

- Use the pinned libopus VAD cutoff (`silk_find_LTP_FLP.c`/VAD policy equivalent) instead of the legacy local cutoff.
- Run pitch analysis only when the frame is voice-active and it is not the first frame after reset.
- Otherwise clear pitch lags and LTP correlation and keep the frame unvoiced.

This is policy/state parity with the pinned libopus source, not a claim of byte-identical encoder output.

## What gets better

- A fresh encoder starts from clean unvoiced pitch state.
- Low-amplitude periodic transitions no longer retain/promote voiced LTP state merely because periodicity is detectable.
- Downstream NSQ decisions do not receive a stale pitch lag from a frame whose pitch path should have been skipped.

## Source evidence

Exact reference: Xiph libopus commit `22244de5a79bd1d6d623c32e72bf1954b56235be`, `silk/float/find_pitch_lags_FLP.c`. Its gate requires both non-zero voice activity and `first_frame_after_reset == 0`; the else path clears `pitchL` and `LTPCorr`.

## Executable evidence

At RED commit `da13202` (`Pin SILK VAD-gated pitch parity`), `TestEncodeSILKFrameFirstAfterResetSkipsPitch` failed with three independent state violations:

- `isPreviousFrameVoiced = true` (expected false)
- `ltpCorr = 0.7779536` (expected 0)
- NSQ lag `= 50` (expected 0)

At GREEN commit `af55410` (`Gate SILK pitch with VAD and reset`), the same assertions pass as `false / 0 / 0`.

An independent before/after transition probe used identical input: one loud periodic frame (amplitude 6000, period 50), then one low-amplitude periodic frame (amplitude 2, period 16). The old code produced:

`active=true, voiced=true, corr=0.25076982, lag=69`

The patched code produced:

`active=true, voiced=false, corr=0, lag=0`

The fact that smoothed VAD is still active in this first transition makes the distinction precise: the improvement is the combined reset/pitch-state policy, not a claim that this particular transition is already VAD-inactive. The committed long-tail guard separately verifies that after quiet settling the state is inactive, unvoiced, zero-correlation, and zero-lag.

The pinned libopus compatibility KAT also verifies the expected SILK packet surface: TOC `0x48`, 320 decoded samples, matching VAD decisions, and final range `0x49cf8000`.

## Validation

- targeted reset and low-tail regression tests
- pinned libopus KATs
- `go test ./...`
- `go vet ./...`
- GitHub CI green


