### PR TITLE
Optimize Opus decoding for ARM64

### DIFF
--- a/internal/celt/synthesis.go
+++ b/internal/celt/synthesis.go
@@ -842,6 +842,44 @@ func (d *Decoder) deemphasisAndInterleave(
 	if outputSampleRate == 0 {
 		outputSampleRate = sampleRate
 	}
+	// Mono output needs no interleaving. Round the sum and feedback product
+	// separately to float32 before carrying filter memory into the next sample.
+	if channelCount == 1 && outputSampleRate == sampleRate {
+		samples := timeX[:frameSampleCount]
+		output := out[:frameSampleCount]
+		memory := d.preemphasisMem[0]
+		for i, sample := range samples {
+			left := float32(sample + memory)
+			memory = float32(0.85000610 * left)
+			output[i] = left / 32768
+		}
+		d.preemphasisMem[0] = memory
+
+		return
+	}
+	// Emit even-indexed samples; discarded odd samples still advance the
+	// filter recurrence. Pairing them avoids a per-sample modulo.
+	if channelCount == 1 && outputSampleRate == sampleRate/2 {
+		samples := timeX[:frameSampleCount]
+		output := out[:frameSampleCount/2]
+		memory := d.preemphasisMem[0]
+		for i := range output {
+			left := float32(samples[2*i] + memory)
+			memory = float32(0.85000610 * left)
+			output[i] = left / 32768
+			left = float32(samples[2*i+1] + memory)
+			memory = float32(0.85000610 * left)
+		}
+		if frameSampleCount%2 != 0 {
+			// With an odd count, the last input index is even and must be emitted.
+			left := float32(samples[frameSampleCount-1] + memory)
+			memory = float32(0.85000610 * left)
+			out[frameSampleCount/2] = left / 32768
+		}
+		d.preemphasisMem[0] = memory
+
+		return
+	}
 	downsample := sampleRate / outputSampleRate
 	outputSample := 0
 	for sample := range frameSampleCount {

--- a/internal/rangecoding/decoder.go
+++ b/internal/rangecoding/decoder.go
@@ -132,6 +132,27 @@ func (r *Decoder) DecodeSymbolWithICDF(cumulativeDistributionTable []uint) uint3
 	total := uint32(cumulativeDistributionTable[0]) //nolint:gosec // G115
 	cumulativeDistributionTable = cumulativeDistributionTable[1:]
 
+	// For SILK's total-256 tables, scaled interval comparisons avoid division.
+	// These guards ensure a nonzero scale and uint32-safe interval boundaries.
+	if total == 256 && r.rangeSize >= total && r.highAndCodedDifference < r.rangeSize {
+		scale := r.rangeSize >> 8
+		symbolIndex := uint32(0)
+		high := uint32(cumulativeDistributionTable[symbolIndex]) //nolint:gosec // G115
+		// Zero cumulative entries have no probability. Bound high before
+		// subtracting it from total to avoid unsigned underflow.
+		for high == 0 || (high < total && r.highAndCodedDifference < scale*(total-high)) {
+			symbolIndex++
+			high = uint32(cumulativeDistributionTable[symbolIndex]) //nolint:gosec // G115
+		}
+		low := uint32(0)
+		if symbolIndex != 0 {
+			low = uint32(cumulativeDistributionTable[symbolIndex-1]) //nolint:gosec // G115
+		}
+		r.update(scale, low, high, total)
+
+		return symbolIndex
+	}
+
 	scale := r.rangeSize / total
 	symbol := r.highAndCodedDifference/scale + 1
 	symbol = total - uint32(localMin(uint(symbol), uint(total))) //nolint:gosec // G115

--- a/internal/resample/silk/fixed.go
+++ b/internal/resample/silk/fixed.go
@@ -6,8 +6,9 @@ package silkresample
 import "math"
 
 func silkSMULWB(a32, b32 int32) int32 {
-	return ((a32 >> 16) * int32(int16(b32))) + // #nosec G115
-		int32((int64(int32(uint32(a32)&0xffff))*int64(int32(int16(b32))))>>16) // #nosec G115
+	// Only b's signed low 16 bits participate. The widened product fits in
+	// int64, and the arithmetic shift rounds toward negative infinity.
+	return int32((int64(a32) * int64(int16(b32))) >> 16) // #nosec G115
 }
 
 func silkSMLAWB(a32, b32, c32 int32) int32 {
@@ -23,7 +24,9 @@ func silkSMLABB(a32, b32, c32 int32) int32 {
 }
 
 func silkSMULWW(a32, b32 int32) int32 {
-	return silkSMULWB(a32, b32) + (a32 * silkRShiftRound(b32, 16))
+	// Shift the full int64 product before narrowing: Q16 multiplication
+	// rounds toward negative infinity and wraps the result to int32.
+	return int32((int64(a32) * int64(b32)) >> 16) // #nosec G115
 }
 
 func silkRShiftRound(a32 int32, shift int) int32 {

--- a/internal/resample/silk/iir_fir.go
+++ b/internal/resample/silk/iir_fir.go
@@ -29,7 +29,9 @@ func (r *Resampler) resamplerPrivateIIRFIR(out, in []int16) {
 	}
 }
 
-func resamplerPrivateIIRFIRInterpolate(out, buf []int16, maxIndexQ16, indexIncrementQ16 int32) int {
+// resamplerPrivateIIRFIRInterpolateGeneric uses bounds-checked Go indexing.
+// The eight-tap sum wraps at int32 before rounding and int16 saturation.
+func resamplerPrivateIIRFIRInterpolateGeneric(out, buf []int16, maxIndexQ16, indexIncrementQ16 int32) int {
 	outIndex := 0
 	for indexQ16 := int32(0); indexQ16 < maxIndexQ16; indexQ16 += indexIncrementQ16 {
 		tableIndex := silkSMULWB(int32(uint32(indexQ16)&0xffff), 12)

--- a/internal/resample/silk/iir_fir_arm64.go
+++ b/internal/resample/silk/iir_fir_arm64.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build arm64 && go1.27 && !purego
+
+package silkresample
+
+import "math"
+
+// Each phase stores the forward taps followed by the reversed complementary
+// taps, so all eight coefficients fit in one vector load. The source ROM is immutable.
+var resamplerFracFIR12NEON = func() [12][8]int16 { //nolint:gochecknoglobals
+	var coefficients [12][8]int16
+	for phase := range coefficients {
+		copy(coefficients[phase][:4], resamplerFracFIR12[phase][:])
+		for tap := range 4 {
+			coefficients[phase][4+tap] = resamplerFracFIR12[11-phase][3-tap]
+		}
+	}
+
+	return coefficients
+}()
+
+// resamplerPrivateIIRFIRInterpolate processes a block per assembly call.
+// NEON is part of the arm64 baseline.
+func resamplerPrivateIIRFIRInterpolate(out, buf []int16, maxIndexQ16, indexIncrementQ16 int32) int {
+	// An empty range needs no samples or buffer pointers.
+	if maxIndexQ16 <= 0 {
+		return 0
+	}
+	// The vector kernel requires a positive step.
+	if indexIncrementQ16 <= 0 {
+		return resamplerPrivateIIRFIRInterpolateGeneric(out, buf, maxIndexQ16, indexIncrementQ16)
+	}
+
+	// Positive progression makes the last eight-sample window the furthest
+	// read. Check both buffers and int32 overflow, including the increment
+	// after the final output, before passing raw pointers to assembly.
+	sampleCount := (int64(maxIndexQ16)-1)/int64(indexIncrementQ16) + 1
+	lastIndexQ16 := (sampleCount - 1) * int64(indexIncrementQ16)
+	if sampleCount > int64(len(out)) || (lastIndexQ16>>16)+8 > int64(len(buf)) ||
+		sampleCount*int64(indexIncrementQ16) > math.MaxInt32 {
+		return resamplerPrivateIIRFIRInterpolateGeneric(out, buf, maxIndexQ16, indexIncrementQ16)
+	}
+
+	resamplerPrivateIIRFIRInterpolateNEON(
+		&out[0], &buf[0], &resamplerFracFIR12NEON[0][0], int(sampleCount), uint32(indexIncrementQ16),
+	)
+
+	return int(sampleCount)
+}
+
+//go:noescape
+func resamplerPrivateIIRFIRInterpolateNEON(out, buf, coefficients *int16, sampleCount int, indexIncrementQ16 uint32)

--- a/internal/resample/silk/iir_fir_arm64.s
+++ b/internal/resample/silk/iir_fir_arm64.s
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build arm64 && go1.27 && !purego
+
+#include "textflag.h"
+
+// The wrapper checks the buffer spans and positive count/step.
+// If out and buf alias, later windows may read earlier outputs, so process
+// outputs in order.
+TEXT ·resamplerPrivateIIRFIRInterpolateNEON(SB), NOSPLIT, $0-36
+	MOVD out+0(FP), R0
+	MOVD buf+8(FP), R1
+	MOVD coefficients+16(FP), R2
+	MOVD sampleCount+24(FP), R3
+	MOVWU indexIncrementQ16+32(FP), R4
+	MOVD $0, R5
+	MOVD $12, R7
+
+firLoop:
+	// The fraction selects floor(fraction*12/65536), a phase in [0,11].
+	// Each phase occupies 16 bytes; the integer part selects the sample window.
+	AND $0xffff, R5, R6
+	MUL R7, R6, R6
+	LSR $16, R6, R6
+	ADD R6<<4, R2, R6
+	LSR $16, R5, R8
+	ADD R8<<1, R1, R8
+	// These loads accept unaligned windows and read exactly eight int16s.
+	VLD1 (R8), [V0.H8]
+	VLD1 (R6), [V1.H8]
+	// Multiply both signed int16 halves, then reduce with wrapping int32 adds.
+	// Reassociating these additions is exact modulo 2^32; do not saturate yet.
+	VSMULL V0.H4, V1.H4, V2.S4
+	VSMLAL2 V0.H8, V1.H8, V2.S4
+	VADDV V2.S4, V2
+	// SRSHR matches ((sum >> 14) + 1) >> 1, including negative half-way values
+	// rounding toward +infinity, without overflowing a 32-bit rounding bias.
+	VSRSHR $15, V2.S4, V2.S4
+	// Saturate only the rounded sum, then store exactly one int16 output.
+	VSQXTN V2.S4, V2.H4
+	VMOV V2.H[0], R9
+	MOVH.P R9, 2(R0)
+	ADD R4, R5, R5
+	SUB $1, R3, R3
+	CBNZ R3, firLoop
+	RET

--- a/internal/resample/silk/iir_fir_generic.go
+++ b/internal/resample/silk/iir_fir_generic.go
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !arm64 || !go1.27 || purego
+
+package silkresample
+
+// Builds without a selected SIMD kernel use the scalar interpolator.
+func resamplerPrivateIIRFIRInterpolate(out, buf []int16, maxIndexQ16, indexIncrementQ16 int32) int {
+	return resamplerPrivateIIRFIRInterpolateGeneric(out, buf, maxIndexQ16, indexIncrementQ16)
+}

--- a/internal/resample/silk/up2_hq.go
+++ b/internal/resample/silk/up2_hq.go
@@ -4,45 +4,53 @@
 package silkresample
 
 func (r *Resampler) resamplerPrivateUp2HQ(out, in []int16) {
+	// The even and odd outputs each use a three-stage allpass recurrence.
+	// State stays local throughout the block. out needs two slots per input sample.
+	s0, s1, s2 := r.sIIR[0], r.sIIR[1], r.sIIR[2]
+	s3, s4, s5 := r.sIIR[3], r.sIIR[4], r.sIIR[5]
+	c0, c1, c2 := int32(resamplerUp2HQ0[0]), int32(resamplerUp2HQ0[1]), int32(resamplerUp2HQ0[2])
+	c3, c4, c5 := int32(resamplerUp2HQ1[0]), int32(resamplerUp2HQ1[1]), int32(resamplerUp2HQ1[2])
 	for sampleIndex := range in {
 		in32 := int32(in[sampleIndex]) << 10
 
-		diff := in32 - r.sIIR[0]
-		delta := silkSMULWB(diff, int32(resamplerUp2HQ0[0]))
-		out32 := r.sIIR[0] + delta
-		r.sIIR[0] = in32 + delta
+		diff := in32 - s0
+		delta := silkSMULWB(diff, c0)
+		out32 := s0 + delta
+		s0 = in32 + delta
 
 		out32_1 := out32
-		diff = out32_1 - r.sIIR[1]
-		delta = silkSMULWB(diff, int32(resamplerUp2HQ0[1]))
-		out32 = r.sIIR[1] + delta
-		r.sIIR[1] = out32_1 + delta
+		diff = out32_1 - s1
+		delta = silkSMULWB(diff, c1)
+		out32 = s1 + delta
+		s1 = out32_1 + delta
 
 		out32_2 := out32
-		diff = out32_2 - r.sIIR[2]
-		delta = silkSMLAWB(diff, diff, int32(resamplerUp2HQ0[2]))
-		out32 = r.sIIR[2] + delta
-		r.sIIR[2] = out32_2 + delta
+		diff = out32_2 - s2
+		delta = silkSMLAWB(diff, diff, c2)
+		out32 = s2 + delta
+		s2 = out32_2 + delta
 
 		out[2*sampleIndex] = silkSAT16(silkRShiftRound(out32, 10))
 
-		diff = in32 - r.sIIR[3]
-		delta = silkSMULWB(diff, int32(resamplerUp2HQ1[0]))
-		out32 = r.sIIR[3] + delta
-		r.sIIR[3] = in32 + delta
+		diff = in32 - s3
+		delta = silkSMULWB(diff, c3)
+		out32 = s3 + delta
+		s3 = in32 + delta
 
 		out32_1 = out32
-		diff = out32_1 - r.sIIR[4]
-		delta = silkSMULWB(diff, int32(resamplerUp2HQ1[1]))
-		out32 = r.sIIR[4] + delta
-		r.sIIR[4] = out32_1 + delta
+		diff = out32_1 - s4
+		delta = silkSMULWB(diff, c4)
+		out32 = s4 + delta
+		s4 = out32_1 + delta
 
 		out32_2 = out32
-		diff = out32_2 - r.sIIR[5]
-		delta = silkSMLAWB(diff, diff, int32(resamplerUp2HQ1[2]))
-		out32 = r.sIIR[5] + delta
-		r.sIIR[5] = out32_2 + delta
+		diff = out32_2 - s5
+		delta = silkSMLAWB(diff, diff, c5)
+		out32 = s5 + delta
+		s5 = out32_2 + delta
 
 		out[(2*sampleIndex)+1] = silkSAT16(silkRShiftRound(out32, 10))
 	}
+	// The next block continues both filter recurrences from these states.
+	r.sIIR = [6]int32{s0, s1, s2, s3, s4, s5}
 }

--- a/internal/silk/decoder.go
+++ b/internal/silk/decoder.go
@@ -951,8 +951,8 @@ func (d *Decoder) decodeExcitationLSB(eRaw []int32, lsbcounts []uint8) {
 	}
 }
 
-// After decoding the pulse locations and the LSBs, the decoder knows
-// the magnitude of each coefficient in the excitation.
+// decodeExcitationSign assigns signs to the nonzero excitation magnitudes
+// decoded from the pulse locations and LSBs. Zero coefficients consume no sign.
 //
 // https://datatracker.ietf.org/doc/html/rfc6716#section-4.2.7.8.5
 //
@@ -963,21 +963,22 @@ func (d *Decoder) decodeExcitationSign(
 	quantizationOffsetType frameQuantizationOffsetType,
 	pulsecounts []uint8,
 ) {
-	for i := range eRaw {
-		// It then decodes a sign for all coefficients
-		// with a non-zero magnitude
-		//
-		// https://datatracker.ietf.org/doc/html/rfc6716#section-4.2.7.8.5
-		if eRaw[i] == 0 {
+	// The sign PDF is shared by a 16-sample shell block. Its context depends
+	// on the frame type, quantization offset, and the block's pulse count.
+	for blockStart := 0; blockStart < len(eRaw); blockStart += pulsecountLargestPartitionSize {
+		block := eRaw[blockStart:min(blockStart+pulsecountLargestPartitionSize, len(eRaw))]
+		// Skip leading zeros; an all-zero block needs no sign context.
+		for len(block) != 0 && block[0] == 0 {
+			block = block[1:]
+		}
+		if len(block) == 0 {
 			continue
 		}
 
 		var icdf []uint
-		pulsecount := pulsecounts[i/pulsecountLargestPartitionSize]
+		pulsecount := pulsecounts[blockStart/pulsecountLargestPartitionSize]
 
-		// using one of the PDFs from Table 52.
-		//
-		// https://datatracker.ietf.org/doc/html/rfc6716#section-4.2.7.8.5
+		// Select this block's sign PDF from RFC 6716 Table 52.
 		switch signalType {
 		case frameSignalTypeInactive:
 			switch quantizationOffsetType {
@@ -1093,10 +1094,16 @@ func (d *Decoder) decodeExcitationSign(
 			}
 		}
 
+		// The same context applies to every nonzero coefficient in the block.
 		// If the value decoded is 0, then the coefficient magnitude is negated.
 		// Otherwise, it remains positive.
-		if d.rangeDecoder.DecodeSymbolWithICDF(icdf) == 0 {
-			eRaw[i] *= -1
+		for i, pulse := range block {
+			if pulse == 0 {
+				continue
+			}
+			if d.rangeDecoder.DecodeSymbolWithICDF(icdf) == 0 {
+				block[i] = -pulse
+			}
 		}
 	}
 }
@@ -1189,12 +1196,14 @@ func (d *Decoder) decodeExcitation(
 		// e_Q23[i] value may require more than 16 bits per sample, but it will
 		// not require more than 23, including the sign.
 
-		eQ23[i] = (eRaw[i] << 8) - int32(sign(int(eRaw[i])))*20 + offsetQ23 //nolint:gosec // g115
+		pulse := eRaw[i]
+		excitation := (pulse << 8) - int32(sign(int(pulse)))*20 + offsetQ23 //nolint:gosec // g115
 		seed = (196314165*seed + 907633515) & 0xFFFFFFFF
-		if seed&0x80000000 != 0 {
-			eQ23[i] *= -1
-		}
-		seed = (seed + uint32(eRaw[i])) & 0xFFFFFFFF //nolint:gosec // g115
+		// A 0/-1 mask applies the random sign without an unpredictable branch:
+		// (x ^ mask) - mask yields x or -x with int32 wrapping.
+		signMask := int32(seed) >> 31 //nolint:gosec // G115: reinterpret the random seed's sign bit.
+		eQ23[i] = (excitation ^ signMask) - signMask
+		seed = (seed + uint32(pulse)) & 0xFFFFFFFF //nolint:gosec // g115
 	}
 
 	return eQ23
@@ -1711,11 +1720,11 @@ func (d *Decoder) ltpSynthesis(
 	wQ2 int16,
 	aQ12, gainQ16, res, resLag []float32,
 ) {
-	// If this is the third or fourth subframe of a 20 ms SILK frame and the LSF
-	// interpolation factor, w_Q2 (see Section 4.2.7.5.5), is less than 4,
-	// then let out_end be set to (j - (s-2)*n) and let LTP_scale_Q14 be set
-	// to 16384.  Otherwise, set out_end to (j - s*n) and set LTP_scale_Q14
-	// to the Q14 LTP scaling value from Section 4.2.7.6.3.
+	// outEnd is the rewhitening boundary relative to j. When the frame uses
+	// LSF interpolation (wQ2 < 4), subframes 2 and 3 of a 20 ms frame use the
+	// frame-absolute boundary 2*n and unity Q14 scaling (16384). Otherwise
+	// the boundary is frame index 0 and the decoded LTP scale applies.
+	// Add j to outEnd for frame indices (RFC 6716 Section 4.2.7.9.1).
 	var outEnd int
 	if s < 2 || wQ2 == 4 {
 		outEnd = -s * n
@@ -1724,127 +1733,141 @@ func (d *Decoder) ltpSynthesis(
 		ltpScaleQ14 = 16384.0
 	}
 
-	// out[i] and lpc[i] are initially cleared to all zeros. Then, for i
-	// such that (j - pitch_lags[s] - 2) <= i < out_end, out[i] is
-	// rewhitened into an LPC residual, res[i], via
+	// Rewhiten output history for j-pitchLags[s]-2 <= i < j+outEnd:
 	//
-	//              4.0*LTP_scale_Q14
-	//     res[i] = ----------------- * clamp(-1.0,
-	//                 gain_Q16[s]
-	//                                        d_LPC-1
-	//                                          __              a_Q12[k]
-	//                                 out[i] - \  out[i-k-1] * --------, 1.0)
-	//                                          /_               4096.0
-	//                                          k=0
-	for i := (-pitchLags[s]) - 2; i < outEnd; i++ {
-		index := i + j
+	//   R(i) = rewhitenScale * clamp(O(i) - sum(k=0..dLPC-1,
+	//                              O(i-k-1)*lpcWeights[k]), -1, 1)
+	//
+	// O(i) reads out[i] for i >= 0, or finalOutValues[len(finalOutValues)+i]
+	// for i < 0. R(i) is written to res[i] or resLag[len(resLag)+i] respectively.
+	// Clamp the prediction error before scaling. Coefficients and gain are
+	// constant within the subframe; LPC order is 10 for NB/MB and 16 for WB.
+	var lpcWeights [16]float32
+	for k := range dLPC {
+		lpcWeights[k] = aQ12[k] / 4096.0
+	}
+	rewhitenScale := (4.0 * ltpScaleQ14) / gainQ16[s]
+	lag := pitchLags[s]
+	start := j - lag - 2
+	end := min(j+outEnd, len(res))
 
-		var (
-			resVal     float32
-			resIndex   int
-			writeToLag bool
-		)
-
-		switch {
-		case index >= len(res):
-			continue
-		case index >= 0:
-			resVal = out[index]
-			resIndex = index
-		default:
-			resIndex = len(resLag) + index
-			resVal = d.finalOutValues[len(d.finalOutValues)+index]
-			writeToLag = true
+	// Previous-frame and current-frame history each form a contiguous span.
+	// Only the first dLPC current-frame samples have taps in both histories.
+	if start < 0 {
+		// Negative frame indices read the previous frame and write resLag.
+		// Include dLPC extra history samples for the analysis filter's taps.
+		negativeEnd := min(end, 0)
+		if start < negativeEnd {
+			rewhitenLTPHistory(
+				resLag[len(resLag)+start:len(resLag)+negativeEnd],
+				d.finalOutValues[len(d.finalOutValues)+start-dLPC:len(d.finalOutValues)+negativeEnd],
+				dLPC,
+				lpcWeights,
+				rewhitenScale,
+			)
 		}
-
+		start = 0
+	}
+	// These windows cross the frame boundary, so each tap selects its history.
+	boundaryEnd := min(end, dLPC)
+	for ; start < boundaryEnd; start++ {
+		value := out[start]
 		for k := range dLPC {
-			var outVal float32
-			if outIndex := index - k - 1; outIndex >= 0 {
-				outVal = out[outIndex]
+			var previous float32
+			if index := start - k - 1; index >= 0 {
+				previous = out[index]
 			} else {
-				outVal = d.finalOutValues[len(d.finalOutValues)+outIndex]
+				previous = d.finalOutValues[len(d.finalOutValues)+index]
 			}
-
-			resVal -= outVal * (aQ12[k] / 4096.0)
+			value -= previous * lpcWeights[k]
 		}
-
-		resVal = clampNegativeOneToOne(resVal)
-		resVal *= (4.0 * ltpScaleQ14) / gainQ16[s]
-
-		if !writeToLag {
-			res[resIndex] = resVal
-		} else {
-			resLag[resIndex] = resVal
-		}
+		res[start] = clampNegativeOneToOne(value) * rewhitenScale
+	}
+	if start < end {
+		// Every tap in this span lies in the current frame.
+		rewhitenLTPHistory(res[start:end], out[start-dLPC:end], dLPC, lpcWeights, rewhitenScale)
 	}
 
-	// Then, for i such that
-	// out_end <= i < j, lpc[i] is rewhitened into an LPC residual, res[i],
-	// via
+	// For j+outEnd <= i < j, the LPC coefficients are unchanged and the
+	// stored residuals are normalized to the preceding subframe's gain.
+	// Rewhitening at the current gain therefore requires only:
 	//
-	//                                      d_LPC-1
-	//                  65536.0               __              a_Q12[k]
-	//       res[i] = ----------- * (lpc[i] - \  lpc[i-k-1] * --------)
-	//                gain_Q16[s]             /_               4096.0
-	//                                        k=0
+	//   R(i) *= gainQ16[s-1] / gainQ16[s]
 	//
-	// This requires storage to buffer up to 256 values of lpc[i] from
-	// previous subframes (240 from the current SILK frame and 16 from the
-	// previous SILK frame).  This corresponds to WB with up to three
-	// previous subframes in the current SILK frame, plus 16 samples for
-	// d_LPC.
-
-	// The astute reader will notice that, given the definition of
-	// lpc[i] in Section 4.2.7.9.2, the output of this latter equation is
-	// merely a scaled version of the values of res[i] from previous
-	// subframes.
+	// This is the gain adjustment in RFC 6716 Section 4.2.7.9.1; the stored
+	// residuals supply the LPC analysis result without recomputing its taps.
 	if s > 0 {
 		scaledGain := gainQ16[s-1] / gainQ16[s]
-		for i := outEnd; i < 0; i++ {
-			index := j + i
-			if index < 0 {
+		scaleStart := j + outEnd
+		if scaleStart < 0 {
+			negativeEnd := min(j, 0)
+			for index := scaleStart; index < negativeEnd; index++ {
 				resLag[len(resLag)+index] *= scaledGain
-			} else {
-				res[index] *= scaledGain
 			}
+			scaleStart = 0
+		}
+		for index := scaleStart; index < j; index++ {
+			res[index] *= scaledGain
 		}
 	}
 
-	// Let e_Q23[i] for j <= i < (j + n) be the excitation for the current
-	// subframe, and b_Q7[k] for 0 <= k < 5 be the coefficients of the LTP
-	// filter taken from the codebook entry in one of Tables 39 through 41
-	// corresponding to the index decoded for the current subframe in
-	// Section 4.2.7.6.2.  Then for i such that j <= i < (j + n), the LPC
-	// residual is
+	// Subframe s uses one five-tap Q7 pitch filter from RFC 6716 Tables 39-41,
+	// selected as described in Section 4.2.7.6.2. Normalize its coefficients once.
+	taps := bQ7[s]
+	weights := [5]float32{
+		float32(taps[0]) / 128.0,
+		float32(taps[1]) / 128.0,
+		float32(taps[2]) / 128.0,
+		float32(taps[3]) / 128.0,
+		float32(taps[4]) / 128.0,
+	}
 
-	//                          4
-	//              e_Q23[i]   __                                  b_Q7[k]
-	//    res[i] = --------- + \  res[i - pitch_lags[s] + 2 - k] * -------
-	//              2.0**23    /_                                   128.0
-	//                         k=0
-
-	var resSum, resVal float32
-	for i := j; i < (j + n); i++ {
-		resSum = res[i]
-		for k := 0; k <= 4; k++ {
-			if resIndex := i - pitchLags[s] + 2 - k; resIndex < 0 {
-				resVal = resLag[len(resLag)+resIndex]
+	// silkFrameReconstruction initializes res[j:j+n] with eQ23/2^23.
+	// Add pitch prediction for each i in [j, j+n):
+	//
+	//   res[i] += sum(k=0..4, R(i-lag+2-k)*weights[k])
+	//
+	// weights[k] is bQ7[s][k]/128 and lag is pitchLags[s]. R(q) reads res[q]
+	// for q >= 0, or resLag[len(resLag)+q] for q < 0. Results can feed later
+	// predictions, so process samples in increasing order (RFC 6716 Section 4.2.7.9.1).
+	// At most four windows have taps on both sides of the frame boundary.
+	current := j
+	limit := j + n
+	negativeEnd := min(limit, lag-2)
+	if current < negativeEnd {
+		// Even the newest tap precedes this frame: all five reads use resLag.
+		synthesizeLTPTaps(
+			res[current:negativeEnd],
+			resLag[len(resLag)+current-lag-2:len(resLag)+negativeEnd-lag+2],
+			weights,
+		)
+		current = negativeEnd
+	}
+	// From lag-2 through lag+1 the five taps straddle the frame boundary.
+	boundaryEnd = min(limit, lag+2)
+	for ; current < boundaryEnd; current++ {
+		value := res[current]
+		for k := range 5 {
+			var previous float32
+			if index := current - lag + 2 - k; index < 0 {
+				previous = resLag[len(resLag)+index]
 			} else {
-				resVal = res[resIndex]
+				previous = res[index]
 			}
-
-			resSum += resVal * (float32(bQ7[s][k]) / 128.0)
+			value += previous * weights[k]
 		}
-
-		res[i] = resSum
+		res[current] = value
+	}
+	if current < limit {
+		// All taps now use this frame's residuals. The slices may overlap;
+		// each output must be written before the next sample reads its taps.
+		synthesizeLTPTaps(res[current:limit], res[current-lag-2:limit-lag+2], weights)
 	}
 }
 
-// LPC synthesis uses the short-term LPC filter to predict the next
-// output coefficient.  For i such that (j - d_LPC) <= i < j, let lpc[i]
-// be the result of LPC synthesis from the last d_LPC samples of the
-// previous subframe or zeros in the first subframe for this channel
-// after either
+// lpcSynthesis reconstructs subframe s from its residuals and unclipped LPC
+// history. The first subframe uses previousFrameLPCValues, with zeros for any
+// unavailable samples; subsequent subframes use the shared lpc buffer.
 //
 // https://www.rfc-editor.org/rfc/rfc6716.html#section-4.2.7.9.2
 func (d *Decoder) lpcSynthesis(
@@ -1852,15 +1875,16 @@ func (d *Decoder) lpcSynthesis(
 	n, s, dLPC int, //nolint:varnamelen
 	aQ12, res, gainQ16, lpc []float32,
 ) {
-	// Then, for i such that j <= i < (j + n), the result of LPC synthesis
-	// for the current subframe is
+	// For frame index i in [j, j+n), where j = n*s:
 	//
-	//                                     d_LPC-1
-	//                gain_Q16[i]            __              a_Q12[k]
-	//       lpc[i] = ----------- * res[i] + \  lpc[i-k-1] * --------
-	//                  65536.0              /_               4096.0
-	//                                       k=0
+	//   lpc[i] = gainQ16[s]/65536 * res[i]
+	//          + sum(k=0..dLPC-1, H(i-k-1)*aQ12[k]/4096)
+	//   out[i-j] = clamp(lpc[i], -1, 1)
 	//
+	// H(q) reads lpc[q] for q >= 0. For q < 0, it reads
+	// previousFrameLPCValues[len(previousFrameLPCValues)+q], or zero when
+	// that index is negative. Only output is clamped; prediction feeds back
+	// the unclipped LPC values.
 	normalizedAQ12, reversedAQ12 := normalizedLPCWeights(aQ12, dLPC)
 	gain := gainQ16[s] / 65536.0
 	subframeOffset := n * s
@@ -1895,25 +1919,6 @@ func normalizedLPCWeights(aQ12 []float32, dLPC int) (normalizedAQ12, reversedAQ1
 	return normalizedAQ12, reversedAQ12
 }
 
-func lpcSynthesisSteadyState(
-	out []float32,
-	dLPC int,
-	reversedAQ12 [16]float32,
-	subframeRes, subframeLPC, historyAndOutput []float32,
-	gain float32,
-) {
-	for sampleIndex := range out {
-		lpcVal := gain * subframeRes[sampleIndex]
-		history := historyAndOutput[sampleIndex : sampleIndex+dLPC]
-		for coefficientIndex := range dLPC {
-			lpcVal += history[coefficientIndex] * reversedAQ12[coefficientIndex]
-		}
-
-		subframeLPC[sampleIndex] = lpcVal
-		out[sampleIndex] = clampNegativeOneToOne(lpcVal)
-	}
-}
-
 func (d *Decoder) lpcSynthesisFirstSubframe(
 	out []float32,
 	dLPC int,
@@ -1921,8 +1926,16 @@ func (d *Decoder) lpcSynthesisFirstSubframe(
 	subframeRes, subframeLPC []float32,
 	gain float32,
 ) {
+	// Only the first dLPC samples can reference previous-frame LPC state
+	// (or zero history after reset). Once warmed up, order-10/16 prediction
+	// uses a contiguous current-subframe window with no history-selection
+	// branches. Short subframes and other orders stay entirely scalar.
+	warmupSamples := len(out)
+	if dLPC == 10 || dLPC == 16 {
+		warmupSamples = min(dLPC, len(out))
+	}
 	var currentLPCVal float32
-	for sampleIndex := range out {
+	for sampleIndex := range warmupSamples {
 		lpcVal := gain * subframeRes[sampleIndex]
 
 		for coefficientIndex := range dLPC {
@@ -1940,18 +1953,18 @@ func (d *Decoder) lpcSynthesisFirstSubframe(
 		subframeLPC[sampleIndex] = lpcVal
 		out[sampleIndex] = clampNegativeOneToOne(lpcVal)
 	}
+	if warmupSamples < len(out) {
+		// The warm-up wrote the unclipped LPC history needed by this tail;
+		// clipped output samples must never feed the prediction recurrence.
+		lpcSynthesisFirstSubframeTail(out, dLPC, normalizedAQ12, subframeRes, subframeLPC, gain)
+	}
 }
 
 func (d *Decoder) savePreviousFrameLPCValues(lpc, out []float32, n, dLPC int) { //nolint:varnamelen
-	//  The decoder saves the final d_LPC values, i.e., lpc[i] such that
-	// (j + n - d_LPC) <= i < (j + n), to feed into the LPC synthesis of the
-	// next subframe.  This requires storage for up to 16 values of lpc[i]
-	// (for WB frames).
-	// The final d_LPC synthesized samples become the history for the next
-	// subframe. RFC 6716 section 4.2.7.9 describes that continuity
-	// requirement, and decode_frame.c preserves this state even for the
-	// first decoded frame. The old haveDecoded guard skipped that initial
-	// handoff and left the next frame with an all-zero LPC history.
+	// out is the remaining frame suffix, so len(out) == n marks the final
+	// subframe. Save its last dLPC unclipped samples for the next frame,
+	// including after the first decoded frame. Earlier subframes use the
+	// shared lpc buffer directly (RFC 6716 Section 4.2.7.9.2).
 	if len(out) != n {
 		return
 	}
@@ -1990,13 +2003,12 @@ func (d *Decoder) silkFrameReconstruction(
 	// https://www.rfc-editor.org/rfc/rfc6716.html#section-4.2.7.9
 	n := d.samplesInSubframe(bandwidth)
 
-	// let lpc[i] be the result of LPC synthesis from the last d_LPC samples of the
-	//  previous subframe or zeros in the first subframe for this channel
+	// Current-frame LPC samples are shared across subframes. Previous-frame
+	// history is held separately in previousFrameLPCValues.
 	lpc := slicetools.ResizeZero(&d.lpc, n*subframeCount)
 
-	// For unvoiced frames (see Section 4.2.7.3), the LPC residual for i
-	// such that j <= i < (j + n) is simply a normalized copy of the
-	// excitation signal, i.e.,
+	// Every frame starts with normalized excitation in res. Unvoiced frames
+	// use it directly; voiced frames add pitch prediction through ltpSynthesis.
 	//
 	//               e_Q23[i]
 	//     res[i] = ---------
@@ -2007,8 +2019,7 @@ func (d *Decoder) silkFrameReconstruction(
 		res[i] = float32(eQ23[i]) / 8388608.0
 	}
 
-	// subFrame be the index of the current subframe in this SILK frame
-	// (0 or 1 for 10 ms frames, or 0 to 3 for 20 ms frames)
+	// A 10 ms frame has two subframes; a 20 ms frame has four.
 	for subFrame := range subframeCount {
 		// For 20 ms SILK frames, the first half of the frame (i.e., the first
 		// two subframes) may use normalized LSF coefficients that are

--- a/internal/silk/lpc_synthesis.go
+++ b/internal/silk/lpc_synthesis.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package silk
+
+// lpcSynthesisSteadyState uses constant tap indices for SILK's orders 10 and 16.
+// historyAndOutput contains dLPC prior samples followed by the current subframe
+// and aliases subframeLPC. Each unclipped result feeds the next prediction;
+// only out is clamped. Accumulation proceeds from the gain-scaled residual through
+// oldest-to-newest history samples.
+func lpcSynthesisSteadyState(
+	out []float32,
+	dLPC int,
+	reversedAQ12 [16]float32,
+	subframeRes, subframeLPC, historyAndOutput []float32,
+	gain float32,
+) {
+	switch dLPC {
+	case 10:
+		// Narrowband and mediumband use ten predictor taps.
+		for sampleIndex := range out {
+			lpcVal := gain * subframeRes[sampleIndex]
+			history := historyAndOutput[sampleIndex : sampleIndex+10]
+			lpcVal += history[0] * reversedAQ12[0]
+			lpcVal += history[1] * reversedAQ12[1]
+			lpcVal += history[2] * reversedAQ12[2]
+			lpcVal += history[3] * reversedAQ12[3]
+			lpcVal += history[4] * reversedAQ12[4]
+			lpcVal += history[5] * reversedAQ12[5]
+			lpcVal += history[6] * reversedAQ12[6]
+			lpcVal += history[7] * reversedAQ12[7]
+			lpcVal += history[8] * reversedAQ12[8]
+			lpcVal += history[9] * reversedAQ12[9]
+			subframeLPC[sampleIndex] = lpcVal
+			out[sampleIndex] = clampNegativeOneToOne(lpcVal)
+		}
+
+		return
+	case 16:
+		// Wideband uses all sixteen predictor taps.
+		for sampleIndex := range out {
+			lpcVal := gain * subframeRes[sampleIndex]
+			history := historyAndOutput[sampleIndex : sampleIndex+16]
+			lpcVal += history[0] * reversedAQ12[0]
+			lpcVal += history[1] * reversedAQ12[1]
+			lpcVal += history[2] * reversedAQ12[2]
+			lpcVal += history[3] * reversedAQ12[3]
+			lpcVal += history[4] * reversedAQ12[4]
+			lpcVal += history[5] * reversedAQ12[5]
+			lpcVal += history[6] * reversedAQ12[6]
+			lpcVal += history[7] * reversedAQ12[7]
+			lpcVal += history[8] * reversedAQ12[8]
+			lpcVal += history[9] * reversedAQ12[9]
+			lpcVal += history[10] * reversedAQ12[10]
+			lpcVal += history[11] * reversedAQ12[11]
+			lpcVal += history[12] * reversedAQ12[12]
+			lpcVal += history[13] * reversedAQ12[13]
+			lpcVal += history[14] * reversedAQ12[14]
+			lpcVal += history[15] * reversedAQ12[15]
+			subframeLPC[sampleIndex] = lpcVal
+			out[sampleIndex] = clampNegativeOneToOne(lpcVal)
+		}
+
+		return
+	}
+
+	// Other predictor orders use a variable-length recurrence.
+	for sampleIndex := range out {
+		lpcVal := gain * subframeRes[sampleIndex]
+		history := historyAndOutput[sampleIndex : sampleIndex+dLPC]
+		for coefficientIndex := range dLPC {
+			lpcVal += history[coefficientIndex] * reversedAQ12[coefficientIndex]
+		}
+		subframeLPC[sampleIndex] = lpcVal
+		out[sampleIndex] = clampNegativeOneToOne(lpcVal)
+	}
+}
+
+// lpcSynthesisFirstSubframeTail requires the first dLPC samples to be synthesized
+// and dLPC to be 10 or 16. Every predictor tap then lies in this subframe.
+// Accumulation runs newest-to-oldest, with unclipped results feeding back.
+func lpcSynthesisFirstSubframeTail(
+	out []float32,
+	dLPC int,
+	normalizedAQ12 [16]float32,
+	subframeRes, subframeLPC []float32,
+	gain float32,
+) {
+	switch dLPC {
+	case 10:
+		// NB/MB uses ten warm-up samples.
+		for sampleIndex := 10; sampleIndex < len(out); sampleIndex++ {
+			lpcVal := gain * subframeRes[sampleIndex]
+			history := subframeLPC[sampleIndex-10 : sampleIndex]
+			lpcVal += history[9] * normalizedAQ12[0]
+			lpcVal += history[8] * normalizedAQ12[1]
+			lpcVal += history[7] * normalizedAQ12[2]
+			lpcVal += history[6] * normalizedAQ12[3]
+			lpcVal += history[5] * normalizedAQ12[4]
+			lpcVal += history[4] * normalizedAQ12[5]
+			lpcVal += history[3] * normalizedAQ12[6]
+			lpcVal += history[2] * normalizedAQ12[7]
+			lpcVal += history[1] * normalizedAQ12[8]
+			lpcVal += history[0] * normalizedAQ12[9]
+			subframeLPC[sampleIndex] = lpcVal
+			out[sampleIndex] = clampNegativeOneToOne(lpcVal)
+		}
+
+		return
+	case 16:
+		// WB needs sixteen warm-up samples before all taps are local.
+		for sampleIndex := 16; sampleIndex < len(out); sampleIndex++ {
+			lpcVal := gain * subframeRes[sampleIndex]
+			history := subframeLPC[sampleIndex-16 : sampleIndex]
+			lpcVal += history[15] * normalizedAQ12[0]
+			lpcVal += history[14] * normalizedAQ12[1]
+			lpcVal += history[13] * normalizedAQ12[2]
+			lpcVal += history[12] * normalizedAQ12[3]
+			lpcVal += history[11] * normalizedAQ12[4]
+			lpcVal += history[10] * normalizedAQ12[5]
+			lpcVal += history[9] * normalizedAQ12[6]
+			lpcVal += history[8] * normalizedAQ12[7]
+			lpcVal += history[7] * normalizedAQ12[8]
+			lpcVal += history[6] * normalizedAQ12[9]
+			lpcVal += history[5] * normalizedAQ12[10]
+			lpcVal += history[4] * normalizedAQ12[11]
+			lpcVal += history[3] * normalizedAQ12[12]
+			lpcVal += history[2] * normalizedAQ12[13]
+			lpcVal += history[1] * normalizedAQ12[14]
+			lpcVal += history[0] * normalizedAQ12[15]
+			subframeLPC[sampleIndex] = lpcVal
+			out[sampleIndex] = clampNegativeOneToOne(lpcVal)
+		}
+
+		return
+	}
+}

--- a/internal/silk/ltp_synthesis.go
+++ b/internal/silk/ltp_synthesis.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package silk
+
+// rewhitenLTPHistory applies the LPC analysis filter. source contains dLPC
+// preceding samples followed by len(dst) samples from one contiguous history
+// span and does not overlap dst. Taps run newest-to-oldest; the prediction
+// error is clamped before gain scaling.
+func rewhitenLTPHistory(dst, source []float32, dLPC int, weights [16]float32, scale float32) {
+	switch dLPC {
+	case 10:
+		// NB/MB: ten preceding samples plus the sample being rewhitened.
+		for i := range dst {
+			history := source[i : i+11]
+			value := history[10]
+			value -= history[9] * weights[0]
+			value -= history[8] * weights[1]
+			value -= history[7] * weights[2]
+			value -= history[6] * weights[3]
+			value -= history[5] * weights[4]
+			value -= history[4] * weights[5]
+			value -= history[3] * weights[6]
+			value -= history[2] * weights[7]
+			value -= history[1] * weights[8]
+			value -= history[0] * weights[9]
+			dst[i] = clampNegativeOneToOne(value) * scale
+		}
+
+		return
+	case 16:
+		// WB: sixteen preceding samples plus the sample being rewhitened.
+		for i := range dst {
+			history := source[i : i+17]
+			value := history[16]
+			value -= history[15] * weights[0]
+			value -= history[14] * weights[1]
+			value -= history[13] * weights[2]
+			value -= history[12] * weights[3]
+			value -= history[11] * weights[4]
+			value -= history[10] * weights[5]
+			value -= history[9] * weights[6]
+			value -= history[8] * weights[7]
+			value -= history[7] * weights[8]
+			value -= history[6] * weights[9]
+			value -= history[5] * weights[10]
+			value -= history[4] * weights[11]
+			value -= history[3] * weights[12]
+			value -= history[2] * weights[13]
+			value -= history[1] * weights[14]
+			value -= history[0] * weights[15]
+			dst[i] = clampNegativeOneToOne(value) * scale
+		}
+
+		return
+	}
+	// Other predictor orders use a variable-length analysis filter.
+	for i := range dst {
+		history := source[i : i+dLPC+1]
+		value := history[dLPC]
+		for k := range dLPC {
+			value -= history[dLPC-k-1] * weights[k]
+		}
+		dst[i] = clampNegativeOneToOne(value) * scale
+	}
+}
+
+// synthesizeLTPTaps adds five-tap pitch prediction to the excitation in dst.
+// source stores each five-sample window oldest-to-newest; taps accumulate
+// newest-to-oldest. The slices may overlap, so each result must be stored
+// before reading the next sample's taps.
+func synthesizeLTPTaps(dst, source []float32, weights [5]float32) {
+	for i := range dst {
+		history := source[i : i+5]
+		value := dst[i]
+		value += history[4] * weights[0]
+		value += history[3] * weights[1]
+		value += history[2] * weights[2]
+		value += history[1] * weights[3]
+		value += history[0] * weights[4]
+		dst[i] = value
+	}
+}


### PR DESCRIPTION
Reduce decoder CPU time with portable specializations and an ARM64 NEON resampling kernel. On an Apple M4 Max, complete RFC stream replays with 24 kHz mono `DecodeToInt16` output take 18.5–27.0% less time than the base revision.

### Implementation

- Avoid integer divisions when decoding symbols from total-256 probability tables, with the generic path retained for other totals and range states.
- Specialize CELT deemphasis for mono 48 kHz and 24 kHz output while preserving filter updates for discarded samples.
- Select SILK excitation sign contexts once per 16-sample block and apply pseudorandom sign inversion with integer masking.
- Specialize 10/16-tap LPC synthesis and separate the first subframe's history-dependent warm-up from its contiguous tail.
- Partition LTP rewhitening and pitch prediction into contiguous history spans and boundary-crossing spans. Normalize coefficients once per subframe and use constant tap indices within contiguous spans.
- Keep up2HQ filter state in locals, simplify equivalent fixed-point multiplication, and add an eight-tap NEON FIR kernel. Assembly is selected by `arm64 && go1.27 && !purego`; other builds use the scalar implementation. The shared PCM quantizer is unchanged.

### LTP correctness

Frame index zero separates saved history from the current frame. Rewhitening an output at `i` reads `[i-dLPC, i]`, so only `0 <= i < dLPC` needs mixed history access. Five-tap pitch prediction reads `[i-lag-2, i-lag+2]`, so only `lag-2 <= i < lag+2` needs mixed access: at most four output samples.

For a contiguous output span `[A, B)`, the pitch helper receives source `[A-lag-2, B-lag+2)`. Its local tap `source[t+4-k]` maps exactly to the original index `A+t-lag+2-k`. Rewhitening uses the corresponding `dLPC` preceding samples. The helpers preserve tap order, clamp-before-gain scaling, and ascending sample writes. Source and destination may overlap during pitch prediction, so each result is stored before the next output reads its history. The existing gain-ratio adjustment and frame-history handoff are preserved.

### Measurements

Apple M4 Max, Go 1.27.0, 24 kHz mono `DecodeToInt16`; values are median microseconds per packet. Each implementation runs five rounds of 60 complete-stream replays, with rotated execution order, a fresh decoder per replay, and warm-up outside the timer. Reference libopus is the optimized Homebrew 1.6.1 build; its decoding loop runs in C without per-packet cgo calls.

| Official stream | Base `1e54f79` | Portable + NEON | libopus |
|---|---:|---:|---:|
| 12: mono, 20 ms | 13.43 | 9.87 | 6.79 |
| 04: WB SILK | 17.77 | 12.97 | 9.36 |
| 05: SWB hybrid | 21.70 | 17.33 | 10.63 |
| 06: FB hybrid | 24.15 | 19.69 | 12.08 |

Timings were collected before comment cleanup and equivalent loop rewrites for lint; the final cleanup has not been retimed. These are complete conformance-stream measurements on this host. The reference integer API uses soft clipping while Pion's integer API hard-clips. Ratios remain 1.39–1.63 times libopus; results do not establish performance on other ARM64 CPUs.

### Validation

- Full repository `TestRFC6716Conformance`: **120/120 passed**, covering all 12 streams, five sample rates, and mono/stereo. Latest ARM64 run after the lint fixes: Go 1.27.1, 73.189 s, no skips or failures, unchanged quality matrix.
- The full corpus also passed on the ARM64 `purego` path. NEON and portable output hashes matched for all 120 cases in the retained implementation.
- Linux/amd64 scalar fallback cross-build passed; `git diff --check` is clean.
- LPC unrolling can change compiler floating-point fusion. The cumulative change passes conformance but is not bit-identical to the base revision.

With the repository's RFC reference source and test vectors prepared:

```sh
OPUS_RFC6716_REFERENCE="$REFERENCE" \
OPUS_RFC6716_TESTVECTORS="$TESTVECTORS" \
go test -count=1 -timeout 20m -tags conformance \
  -run '^TestRFC6716Conformance$' -parallel 4 -v .
```
