### PR TITLE
Process CELT analysis filters in blocks of four

### DIFF
--- a/internal/celt/allocation.go
+++ b/internal/celt/allocation.go
@@ -1071,7 +1071,7 @@ func dynallocAnalysis(
 		if combined[band] > 4.0 {
 			combined[band] = 4.0
 		}
-		width := channelCount * (int(bandEdges[band+1] - bandEdges[band])) << lm
+		width := channelCount * int(bandEdges[band+1]-bandEdges[band]) << lm
 
 		var boost int
 		var boostBits int

--- a/internal/celt/analysis.go
+++ b/internal/celt/analysis.go
@@ -414,13 +414,36 @@ func transientMaskMetric(signal, scratch []float32) int {
 	tmp := scratch[:n]
 
 	var mem0, mem1 float32
-	for i, x := range signal {
+	i := 0
+	for ; i+4 <= n; i += 4 {
+		x0 := signal[i]
+		x1 := signal[i+1]
+		x2 := signal[i+2]
+		x3 := signal[i+3]
+
+		u0 := mem0
+		v0 := mem1
+		u1 := u0 - x0 + 0.5*v0
+		u2 := 0.5*u0 + 0.5*v0 - 0.5*x0 - x1
+		u3 := 0.25*v0 - 0.5*x1 - x2
+
+		tmp[i] = u0 + x0
+		tmp[i+1] = u1 + x1
+		tmp[i+2] = u2 + x2
+		tmp[i+3] = u3 + x3
+
+		mem0 = -0.25*u0 + 0.25*x0 - 0.5*x2 - x3
+		mem1 = x3 - 0.25*v0 + 0.5*x1 + x2
+	}
+	for ; i < n; i++ {
+		x := signal[i]
 		y := mem0 + x
 		prevMem0 := mem0
 		mem0 = mem0 - x + 0.5*mem1
 		mem1 = x - prevMem0
 		tmp[i] = y
 	}
+
 	// The first few samples are unreliable since the filter memory hasn't
 	// propagated yet.
 	clear(tmp[:min(12, n)])
@@ -484,7 +507,7 @@ func computeBandLogAmp(freq []float32, lm int, startBand int, endBand int) [maxB
 		bandStart := scale * int(bandEdges[band])
 		bandEnd := scale * int(bandEdges[band+1])
 
-		energy := float64(1e-27)
+		energy := 1e-27
 		for i := bandStart; i < bandEnd; i++ {
 			value := float64(freq[i])
 			energy += value * value
@@ -636,12 +659,34 @@ func spreadingDecision(
 // pre-processing (libopus dc_reject, src/opus_encoder.c:479-507).
 func applyDCBlock(pcm []float32, sampleRate int, mem *float32) {
 	coef := 6.3 * dcBlockCutoffHz / float32(sampleRate)
-	coef2 := float32(1) - coef
-	m := *mem
-	for i := range pcm {
-		x := pcm[i]
-		pcm[i] = x - m
-		m = coef*x + coef2*m
+	decay := float32(1) - coef
+	decay2 := decay * decay
+	decay3 := decay2 * decay
+	decay4 := decay2 * decay2
+
+	memory := *mem
+	i := 0
+	for ; i+4 <= len(pcm); i += 4 {
+		x0 := pcm[i]
+		x1 := pcm[i+1]
+		x2 := pcm[i+2]
+		x3 := pcm[i+3]
+
+		m1 := coef*x0 + decay*memory
+		m2 := coef*(decay*x0+x1) + decay2*memory
+		m3 := coef*(decay2*x0+decay*x1+x2) + decay3*memory
+		m4 := coef*(decay3*x0+decay2*x1+decay*x2+x3) + decay4*memory
+
+		pcm[i] = x0 - memory
+		pcm[i+1] = x1 - m1
+		pcm[i+2] = x2 - m2
+		pcm[i+3] = x3 - m3
+		memory = m4
 	}
-	*mem = m
+	for ; i < len(pcm); i++ {
+		x := pcm[i]
+		pcm[i] = x - memory
+		memory = coef*x + decay*memory
+	}
+	*mem = memory
 }

--- a/internal/celt/analysis_test.go
+++ b/internal/celt/analysis_test.go
@@ -5,6 +5,7 @@ package celt
 
 import (
 	"math"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -361,7 +362,7 @@ func TestDCBlockMultiFrameState(t *testing.T) {
 	}
 }
 
-func TestDCBlockMatchesScalarReference(t *testing.T) {
+func TestDCBlockStaysCloseToScalarReference(t *testing.T) {
 	pcm := make([]float32, 960)
 	for i := range pcm {
 		pcm[i] = float32(math.Sin(2 * math.Pi * 440 * float64(i) / float64(sampleRate)))
@@ -374,8 +375,69 @@ func TestDCBlockMatchesScalarReference(t *testing.T) {
 	applyDCBlockScalar(want, sampleRate, &memWant)
 	applyDCBlock(got, sampleRate, &memGot)
 
-	assert.Equal(t, want, got)
-	assert.Equal(t, memWant, memGot)
+	for i := range want {
+		assert.InDelta(t, want[i], got[i], 1e-6)
+	}
+	assert.InDelta(t, memWant, memGot, 1e-6)
+}
+
+func TestDCBlockBlockOfFourLongRun(t *testing.T) {
+	const (
+		frames     = 3000
+		frameSize  = 960
+		sampleRate = 48000
+	)
+
+	var scalarMem, blockMem float32
+	var maxDiff float32
+
+	for frame := range frames {
+		input := make([]float32, frameSize)
+		for i := range input {
+			sample := frame*frameSize + i
+			input[i] = float32(
+				0.6*math.Sin(2*math.Pi*440*float64(sample)/sampleRate) +
+					0.2*math.Sin(2*math.Pi*73*float64(sample)/sampleRate),
+			)
+		}
+
+		want := append([]float32(nil), input...)
+		got := append([]float32(nil), input...)
+		applyDCBlockScalar(want, sampleRate, &scalarMem)
+		applyDCBlock(got, sampleRate, &blockMem)
+
+		for i := range want {
+			diff := float32(math.Abs(float64(want[i] - got[i])))
+			maxDiff = max(maxDiff, diff)
+		}
+	}
+
+	assert.LessOrEqual(t, maxDiff, float32(1e-6))
+	assert.InDelta(t, scalarMem, blockMem, 1e-6)
+}
+
+func TestTransientMaskMetricBlockOfFour(t *testing.T) {
+	for _, n := range []int{0, 1, 3, 4, 15, 18, 31, 32, 35, 36, 959, 960, 961} {
+		t.Run("n="+strconv.Itoa(n), func(t *testing.T) {
+			signal := make([]float32, n)
+			for i := range signal {
+				signal[i] = float32(
+					0.7*math.Sin(2*math.Pi*440*float64(i)/sampleRate) +
+						0.2*math.Cos(2*math.Pi*73*float64(i)/sampleRate),
+				)
+			}
+
+			wantScratch := make([]float32, n)
+			gotScratch := make([]float32, n)
+			want := transientMaskMetricScalar(signal, wantScratch)
+			got := transientMaskMetric(signal, gotScratch)
+
+			assert.Equal(t, want, got)
+			for i := range wantScratch {
+				assert.InDelta(t, wantScratch[i], gotScratch[i], 1e-6)
+			}
+		})
+	}
 }
 
 func applyDCBlockScalar(pcm []float32, sampleRate int, mem *float32) {
@@ -386,6 +448,55 @@ func applyDCBlockScalar(pcm []float32, sampleRate int, mem *float32) {
 		pcm[i] = x - *mem
 		*mem = coef*x + coef2**mem
 	}
+}
+
+func transientMaskMetricScalar(signal, scratch []float32) int {
+	n := len(signal)
+	tmp := scratch[:n]
+
+	var mem0, mem1 float32
+	for i, x := range signal {
+		y := mem0 + x
+		prevMem0 := mem0
+		mem0 = mem0 - x + 0.5*mem1
+		mem1 = x - prevMem0
+		tmp[i] = y
+	}
+	clear(tmp[:min(12, n)])
+
+	len2 := n / 2
+	if len2 < 18 {
+		return 0
+	}
+
+	var mean float32
+	mem0 = 0
+	for i := range len2 {
+		x2 := tmp[2*i]*tmp[2*i] + tmp[2*i+1]*tmp[2*i+1]
+		mean += x2
+		mem0 = x2 + (1-transientForwardDecay)*mem0
+		tmp[i] = transientForwardDecay * mem0
+	}
+
+	mem0 = 0
+	var maxE float32
+	for i := len2 - 1; i >= 0; i-- {
+		mem0 = tmp[i] + transientBackwardDecay*mem0
+		tmp[i] = (1 - transientBackwardDecay) * mem0
+		maxE = max(maxE, tmp[i])
+	}
+
+	frameEnergy := float32(math.Sqrt(float64(mean * maxE * 0.5 * float32(len2))))
+	norm := float32(len2) / (1e-15 + frameEnergy)
+
+	unmask := 0
+	for i := 12; i < len2-5; i += 4 {
+		id := int(math.Floor(float64(64 * norm * (tmp[i] + 1e-15))))
+		id = min(max(id, 0), 127)
+		unmask += transientInverseTable[id]
+	}
+
+	return 64 * unmask * 4 / (6 * (len2 - 17))
 }
 
 func TestAnalyzeFrameAppliesDCBlock(t *testing.T) {


### PR DESCRIPTION
#### Description

This processes the CELT DC blocker and the first filter in `transientMaskMetric` four samples at a time.

Both filters still use the scalar path for a trailing partial block. The closed-form calculations change some float32 rounding, so this is not guaranteed to keep the same packet bytes on every configuration.

The new tests compare both paths against the previous scalar calculation. The DC blocker stays within 1e-6 after 3,000 frames, and the transient metric keeps the same final integer result across short, full-frame, and odd-length inputs.

The encoder remains deterministic. The real-audio corpus passed all 12 clips without a quality regression or additional bad windows. Encoder conformance against libopus also passed.

On the local benchmark, the median changed from 255.7 us/op on `main` to 244.0 us/op, around 4.6%.

#### Reference issue
N/A
